### PR TITLE
Output JavaScript as UMD

### DIFF
--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -1,5 +1,6 @@
 const gulp = require('gulp');
 var concat = require('gulp-concat');
+var umd = require('gulp-umd');
 
 gulp.task('build:javascript', () => {
   return gulp.src([
@@ -8,5 +9,13 @@ gulp.task('build:javascript', () => {
       'src/moj/components/**/*.js'
     ])
     .pipe(concat('all.js'))
+    .pipe(umd({
+      exports: function() {
+        return 'MOJFrontend';
+      },
+      namespace: function() {
+        return 'MOJFrontend';
+      }
+    }))
     .pipe(gulp.dest('package/moj/'));
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4190,6 +4190,35 @@
         }
       }
     },
+    "gulp-umd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-umd/-/gulp-umd-2.0.0.tgz",
+      "integrity": "sha512-zA0RDIITdOwpVUBQ6vy2R+iCsTXwDImPnWreNBmVJQAg3nDGefowV7KYwWoIeEVoxyHZT2CR50nEF6ovUh5/2A==",
+      "requires": {
+        "concat-stream": "^1.6.2",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "lodash.template": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+          "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.templatesettings": "^4.0.0"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+          "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+          "requires": {
+            "lodash._reinterpolate": "^3.0.0"
+          }
+        }
+      }
+    },
     "gulp-util": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-imagemin": "^5.0.3",
     "gulp-nodemon": "^2.4.2",
     "gulp-sass": "^4.0.2",
+    "gulp-umd": "^2.0.0",
     "moment": "^2.22.2",
     "multer": "^1.4.2",
     "nunjucks": "^3.2.0",


### PR DESCRIPTION
### Issue or RFC endorsed by the maintainers

N/A but [discussed on Slack](https://mojdt.slack.com/archives/CH5RUSB27/p1570200776007000)

<!--

Link to the issue or RFC to which your change relates. This link must be one of the following:

* An open issue with the `help-wanted` label
* An open issue with the `triaged` label
* An RFC with "accepted" status

To contribute an enhancement that isn't covered by one of the items above, please follow our guide for suggesting an enhancement:

https://github.com/ministryofjustice/moj-frontend/blob/master/CONTRIBUTING.md#suggesting-enhancements

To contribute other changes, you must use a different template. You can see all templates at:

https://github.com/ministryofjustice/moj-frontend/tree/master/.github/PULL_REQUEST_TEMPLATE.

-->

### Description of the change

Currently the JavaScript module is exposed as a global variable, and may be used by including the `all.js` file and accessing `window.MOJFrontend`. This doesn't support use cases with bundlers, where the package needs to export something.

Fortunately, there is a JavaScript design pattern called "[Universal Module Definition](https://riptutorial.com/javascript/example/16339/universal-module-definition--umd-)" (UMD) which allows the module to support various different export styles depending on the context it's used in. It only adds a few extra lines to the file and is backwards compatible. It is also [currently used](https://github.com/alphagov/govuk-frontend/blob/master/tasks/gulp/compile-assets.js#L166) in the GOV.UK Design System, so would align the two design systems.

I've added a Gulp plugin called `gulp-umd` which simply wraps the `all.js` file in the UMD template.

### Alternative designs

I considered using Rollup, as the GOV.UK Design System does, but this would require significant unecessary changes to the JavaScript code base (it would need to be fully modularised).

I also considered manually adding the UMD template to existing files, adding the prefix to `namespace.js` and the suffix to a new `suffix.js` file. However, this would make the two files independently invalid, because brackets opened in `namespace.js` would be closed in `suffix.js`.

### Possible drawbacks

Other than `all.js` being a few lines larger, I can't think of any.

I considered that this might cause variable scope problems, but because `GOVUKFrontend` is locally scoped with `var` I don't believe that this could be possible.

### Verification process

I verified that the `all.js` file can be used in the following ways:

- Included in a `<script>` tag and referred to with global `GOVUKFrontend` (what is currently supported)
- Imported via `var MOJFrontend = require('.../all.js');` in Webpack
- Imported via `import MOJFrontend from '.../all.js';` in Webpack
- Imported via `import { ButtonMenu } from '.../all.js';` in Webpack

I specifically tested all of these with the [Button menu](https://moj-design-system.herokuapp.com/components/button-menu) component, but there's no reason to believe other components would work differently since they're all included in the `all.js` file.

### Release notes

- JavaScript module exported with Universal Module Definition