### PR TITLE
Fixes issue #79 with colour value not wrapped in quotes

### DIFF
--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -71,7 +71,7 @@
 
   &:focus {
     border-color: transparent;
-    color: govuk-colour(black);
+    color: govuk-colour("black");
   }
 
   &--organisation-name {


### PR DESCRIPTION

# Identify the bug
This bug was identified in issue #79 when being used in a Rails app. I have also ran into this issue but when importing via webpack using `sass-loader`.

In `_header.scss` the colour value black was not in quotes which seemed to be causing parsing errors.

Webpack and rails preprocessors appear to be stricter than gulps and so it causes an error while parsing

# Description of the change
I have amended the value black to be in quotes as all other colours are in the SCSS files.

# Alternative designs
Move all colours to a colour palette variable file to be referenced instead

# Possible drawbacks
None I can think of

# Verification process
* I cloned the repo and ran npm link to connect it to my webpack project.
* I still got the same error
* I changed the value to be in quotes
* Retried with webpack and the error disappeared and the SCSS files were processed out to CSS correctly

# Release notes
Fixes a parsing error with some sass processors where they could not parse a non string colour value