### PR TITLE
Add font specification to pagination results

### DIFF
--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -35,7 +35,7 @@
 
 .moj-pagination__results {
   @include govuk-font(19);
-  mmargin-top: 0;
+  margin-top: 0;
   @include govuk-media-query($from: desktop) {
     display: inline-block;
     margin-bottom: 0;

--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -35,6 +35,7 @@
 
 .moj-pagination__results {
   @include govuk-font(19);
+  mmargin-top: 0;
   @include govuk-media-query($from: desktop) {
     display: inline-block;
     margin-bottom: 0;

--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -34,6 +34,7 @@
 }
 
 .moj-pagination__results {
+  @include govuk-font(19);
   @include govuk-media-query($from: desktop) {
     display: inline-block;
     margin-bottom: 0;


### PR DESCRIPTION
### Identify the bug

This fixes bug #88

### Description of the change

This ensures that the `moj-pagination__result` child element of the `moj-pagination` class have an explicit font-size so will be shown to the user.

I've applied the same rule already used for `moj-pagination__item` to ensure consistency between the child elements.

### Alternative designs

I didn't identify any suitable alternatives.

### Possible drawbacks

If a user was overwriting the font size of pagination elements with utility classes, they'd now also have to add a utility class to `moj-pagination__result` (rather than falling back on the GOV.UK Design System classes)

### Verification process

I can't identify any regressions that mmight be caused by this and could be tested. 

### Release notes

- Fixed an issue where the pagination results text was hidden in wide browsers
