### PR TITLE
Added cookie banner component

### DIFF
--- a/app/views/components/cookie-banner/index.html
+++ b/app/views/components/cookie-banner/index.html
@@ -21,14 +21,18 @@
           title: 'Tell us whether you accept cookies',
           html: 'GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised.'
         },
-        acceptCookies: {
-          type: 'submit',
-          text: 'Accept all cookies'
-        },
-        setCookies: {
-          href: '/cookies',
-          text: 'Set application cookies'
-        }
+        items: [
+          {
+            type: 'submit',
+            text: 'Accept all cookies',
+            element: 'button'
+          },
+          {
+            href: '/cookies',
+            text: 'Set application cookies',
+            element: 'a',
+            class: 'govuk-button--secondary'
+          }]
       }) }}
 
   </div>

--- a/app/views/components/cookie-banner/index.html
+++ b/app/views/components/cookie-banner/index.html
@@ -16,6 +16,7 @@
       </h1>
 
       {{ mojCookieBanner({
+        show: true,
         heading: {
           title: 'Tell us whether you accept cookies',
           html: 'GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised.'

--- a/app/views/components/cookie-banner/index.html
+++ b/app/views/components/cookie-banner/index.html
@@ -1,0 +1,37 @@
+{% extends "layouts/base.html" %}
+
+{% block body %}
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-full">
+
+      {{ govukBackLink({
+        text: "Back",
+        href: "../"
+      }) }}
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Components</span> Cookie banner
+      </h1>
+
+      {{ mojCookieBanner({
+        heading: {
+          title: 'Tell us whether you accept cookies',
+          html: 'GOV.UK uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve government digital services. Any data collected is anonymised.'
+        },
+        acceptCookies: {
+          type: 'submit',
+          text: 'Accept all cookies'
+        },
+        setCookies: {
+          href: '/cookies',
+          text: 'Set application cookies'
+        }
+      }) }}
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -7,6 +7,7 @@
     <li><a href="/components/badge">Badge</a></li>
     <li><a href="/components/banner">Banner</a></li>
     <li><a href="/components/button-menu">Button menu</a></li>
+    <li><a href="/components/cookie-banner">Cookie banner</a></li>
     <li><a href="/components/currency-input">Currency input</a></li>
     <li><a href="/components/filter">Filter</a></li>
     <li><a href="/components/filter-layout">Filter layout</a></li>

--- a/app/views/layouts/base.html
+++ b/app/views/layouts/base.html
@@ -24,6 +24,7 @@
 {%- from "moj/components/badge/macro.njk" import mojBadge %}
 {%- from "moj/components/banner/macro.njk" import mojBanner %}
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu %}
+{%- from "moj/components/cookie-banner/macro.njk" import mojCookieBanner %}
 {%- from "moj/components/currency-input/macro.njk" import mojCurrencyInput %}
 {%- from "moj/components/filter/macro.njk" import mojFilter %}
 {%- from "moj/components/header/macro.njk" import mojHeader %}
@@ -73,7 +74,9 @@
   <body class="app-body">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    {%- block body %}{% endblock %}
+    <main>
+      {%- block body %}{% endblock %}
+    </main>
 
     {%- block scripts %}
       {%- include "includes/scripts.html" %}

--- a/src/moj/components/_all.scss
+++ b/src/moj/components/_all.scss
@@ -3,6 +3,7 @@
 @import "badge/badge";
 @import "banner/banner";
 @import "button-menu/button-menu";
+@import "cookie-banner/cookie-banner";
 @import "currency-input/currency-input";
 @import "filter/filter";
 @import "header/header";

--- a/src/moj/components/cookie-banner/README.md
+++ b/src/moj/components/cookie-banner/README.md
@@ -1,0 +1,6 @@
+# Cookie banner
+
+- [Guidance](https://moj-design-system.herokuapp.com/components/cookie-banner)
+- [Preview](https://moj-frontend.herokuapp.com/components/cookie-banner)
+
+## Arguments

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -8,7 +8,7 @@
   padding-bottom: govuk-spacing(3);
   left: govuk-spacing(3);
   padding-right: govuk-spacing(3);
-  background-color: govuk-colour("light-grey");
+  background-color: govuk-colour("white");
 
   &--show {
     display: block !important;
@@ -19,7 +19,13 @@
     @include govuk-width-container;
   }
 
-  &__button .govuk-button {
+  &__buttons {
+    .govuk-grid-column-full {
+      padding-left: 0;
+    }
+  }
+
+  .govuk-button {
     @include govuk-media-query($from: tablet) {
       width: 90%;
     }

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -8,10 +8,7 @@
   padding-bottom: govuk-spacing(3);
   left: govuk-spacing(3);
   padding-right: govuk-spacing(3);
-  background-color: lighten(
-    desaturate(govuk-colour("light-blue"), 8.46),
-    42.55
-  );
+  background-color: govuk-colour("light-grey");
 
   &--show {
     display: block !important;

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -1,0 +1,36 @@
+.moj-cookie-banner {
+  display: none;
+  @include govuk-font(16);
+
+  box-sizing: border-box;
+
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+  left: govuk-spacing(3);
+  padding-right: govuk-spacing(3);
+  background-color: lighten(
+    desaturate(govuk-colour("light-blue"), 8.46),
+    42.55
+  );
+
+  &--show {
+    display: block !important;
+  }
+
+  &__message {
+    margin: 0;
+    @include govuk-width-container;
+  }
+
+  &__button .govuk-button {
+    @include govuk-media-query($from: tablet) {
+      width: 90%;
+    }
+  }
+}
+
+@include govuk-media-query($media-type: print) {
+  .moj-cookie-banner {
+    display: none !important;
+  }
+}

--- a/src/moj/components/cookie-banner/macro.njk
+++ b/src/moj/components/cookie-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro mojCookieBanner(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/moj/components/cookie-banner/template.njk
+++ b/src/moj/components/cookie-banner/template.njk
@@ -1,10 +1,10 @@
 {%- from "govuk/components/button/macro.njk" import govukButton %}
 
-<div class="cookie-banner govuk-width-container cookie-banner--visible" role="region" aria-label="cookie banner">
+<div class="cookie-banner govuk-width-container cookie-banner--visible" role="region" aria-labelledby="moj-cookie-banner-title">
     <div class="govuk-grid-row">
         <div class=" govuk-grid-column-two-thirds">
             <div class="cookie-banner__message">
-                <h2 class="govuk-heading-m">{{ params.heading.title }}</h2>
+                <h2 id="moj-cookie-banner-title" class="govuk-heading-m">{{ params.heading.title }}</h2>
                 <p class="govuk-body">{{ params.heading.html }}</p>
             </div>
             <div class="cookie-banner__buttons">

--- a/src/moj/components/cookie-banner/template.njk
+++ b/src/moj/components/cookie-banner/template.njk
@@ -1,0 +1,24 @@
+{%- from "govuk/components/button/macro.njk" import govukButton %}
+
+<div class="cookie-banner govuk-width-container cookie-banner--visible" role="region" aria-label="cookie banner">
+    <div class="govuk-grid-row">
+        <div class=" govuk-grid-column-two-thirds">
+            <div class="cookie-banner__message">
+                <h2 class="govuk-heading-m">{{ params.heading.title }}</h2>
+                <p class="govuk-body">{{ params.heading.html }}</p>
+            </div>
+            <div class="cookie-banner__buttons">
+                <div class="cookie-banner__button cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+                    {{ govukButton({
+                      text: params.acceptCookies.text,
+                      classes: 'govuk-button button--inline',
+                      type: params.acceptCookies.type
+                    }) }}
+                </div>
+                <div class="cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+                    <a href="{{ params.setCookies.href }}" class="govuk-button govuk-button--secondary button--inline" role="button">{{ params.setCookies.text }}</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/moj/components/cookie-banner/template.njk
+++ b/src/moj/components/cookie-banner/template.njk
@@ -8,16 +8,16 @@
                 <p class="govuk-body">{{ params.heading.html | safe if params.heading.html else params.heading.text }}</p>
             </div>
             <div class="moj-cookie-banner__buttons">
-                <div class="moj-cookie-banner__button moj-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
-                    {{ govukButton({
-                      text: params.acceptCookies.text,
-                      classes: 'govuk-button button--inline',
-                      type: params.acceptCookies.type
-                    }) }}
-                </div>
-                <div class="moj-cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
-                    <a href="{{ params.setCookies.href }}" class="govuk-button govuk-button--secondary button--inline" role="button">{{ params.setCookies.text }}</a>
-                </div>
+                {%- for item in params.items %}
+                    <div class="govuk-grid-column-full govuk-grid-column-one-half-from-desktop">
+                        {{ govukButton({
+                            text: item.text,
+                            classes: 'govuk-button button--inline ' + item.class,
+                            type: item.type,
+                            element: item.element
+                        }) }}
+                    </div>
+                {% endfor -%}
             </div>
         </div>
     </div>

--- a/src/moj/components/cookie-banner/template.njk
+++ b/src/moj/components/cookie-banner/template.njk
@@ -1,21 +1,21 @@
 {%- from "govuk/components/button/macro.njk" import govukButton %}
 
-<div class="cookie-banner govuk-width-container cookie-banner--visible" role="region" aria-labelledby="moj-cookie-banner-title">
+<div class="moj-cookie-banner govuk-width-container{% if (params.show) %} moj-cookie-banner--show{% endif %}" role="region" aria-labelledby="moj-cookie-banner-title">
     <div class="govuk-grid-row">
         <div class=" govuk-grid-column-two-thirds">
-            <div class="cookie-banner__message">
+            <div class="moj-cookie-banner__message">
                 <h2 id="moj-cookie-banner-title" class="govuk-heading-m">{{ params.heading.title }}</h2>
-                <p class="govuk-body">{{ params.heading.html }}</p>
+                <p class="govuk-body">{{ params.heading.html | safe if params.heading.html else params.heading.text }}</p>
             </div>
-            <div class="cookie-banner__buttons">
-                <div class="cookie-banner__button cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+            <div class="moj-cookie-banner__buttons">
+                <div class="moj-cookie-banner__button moj-cookie-banner__button-accept govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
                     {{ govukButton({
                       text: params.acceptCookies.text,
                       classes: 'govuk-button button--inline',
                       type: params.acceptCookies.type
                     }) }}
                 </div>
-                <div class="cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
+                <div class="moj-cookie-banner__button govuk-grid-column-full govuk-grid-column-one-half-from-desktop govuk-!-padding-left-0">
                     <a href="{{ params.setCookies.href }}" class="govuk-button govuk-button--secondary button--inline" role="button">{{ params.setCookies.text }}</a>
                 </div>
             </div>

--- a/src/moj/components/cookie-banner/template.njk
+++ b/src/moj/components/cookie-banner/template.njk
@@ -14,7 +14,8 @@
                             text: item.text,
                             classes: 'govuk-button button--inline ' + item.class,
                             type: item.type,
-                            element: item.element
+                            element: item.element,
+                            href: item.href
                         }) }}
                     </div>
                 {% endfor -%}


### PR DESCRIPTION
### Issue or RFC endorsed by the maintainers

Relates to issue #92 

### Description of the change

This change adds a new Cookie Banner component. 

It does not contain any javascript currently. This component is purely for design purposes so that different projects can align on look and feel.

A separate pull request can be done post this to add a dynamic javascript implementation.

### Alternative designs

Previous designs have had 2 primary buttons in the header. This uses 1 primary and 1 secondary as per the GDS rules so it doesn't cause confusion to the user.

Some existing designs have a darker background, this has been removed to help increase colour contrast in the design.

### Possible drawbacks

None I can think of

### Verification process

To test we have implemented the design on the new Use a LPA service. It also exists in the CICA website. The design was taken from there and classes amended to fit the MoJ namespace.

I have used navigation via keyboard and also ran Axe and Wave across the component. All pass.

### Release notes

Added new Cookie Consent Banner component