### PR TITLE
Issue 109 Fix entry path for npm module

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -2,7 +2,7 @@
   "name": "@ministryofjustice/frontend",
   "description": "The MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.",
   "version": "0.0.19-alpha",
-  "main": "mpj/all.js",
+  "main": "moj/all.js",
   "sass": "moj/all.scss",
   "engines": {
     "node": ">= 4.2.0"


### PR DESCRIPTION
### Identify the bug

https://github.com/ministryofjustice/moj-frontend/issues/109

### Description of the change

Updated value of `main` property in `package/package.json` to correct value (`moj/all.js`)

### Alternative designs

n/a

### Possible drawbacks

None

### Verification process

Confirmed import now works manually

### Release notes

- `require('@ministryofjustice/frontend')` now works as expected 