### PR TITLE
Create MOJFrontend.initAll()

### DIFF
--- a/app/views/components/add-another/index.html
+++ b/app/views/components/add-another/index.html
@@ -11,7 +11,7 @@
         href: "../"
       }) }}
 
-      <div class="moj-add-another">
+      <div data-module="moj-add-another">
 
         <h1 class="govuk-heading-xl">
           <span class="govuk-caption-xl">Components</span> Add another
@@ -120,13 +120,5 @@
     </div>
 
   </div>
-
-{% endblock %}
-
-{% block pageScripts %}
-
-  <script>
-    new MOJFrontend.AddAnother($('.moj-add-another'));
-  </script>
 
 {% endblock %}

--- a/app/views/components/multi-select/index.html
+++ b/app/views/components/multi-select/index.html
@@ -15,10 +15,10 @@
         <span class="govuk-caption-xl">Components</span> Multi-select
       </h1>
 
-      <table class="govuk-table">
+      <table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header moj-multi-select__select-all-container" scope="col"></th>
+            <th class="govuk-table__header" scope="col" id="select-all"></th>
             <th class="govuk-table__header" scope="col">Name</th>
             <th class="govuk-table__header" scope="col">Elevation</th>
             <th class="govuk-table__header" scope="col">Continent</th>
@@ -130,15 +130,4 @@
 
     </div>
   </div>
-{% endblock %}
-
-{% block pageScripts %}
-
-  <script>
-    new MOJFrontend.MultiSelect({
-      container: $('.moj-multi-select__select-all-container'),
-      checkboxes: $('.govuk-checkboxes__input')
-    });
-  </script>
-
 {% endblock %}

--- a/app/views/components/password-reveal/index.html
+++ b/app/views/components/password-reveal/index.html
@@ -48,11 +48,3 @@
   </div>
 
 {% endblock %}
-
-{% block pageScripts %}
-
-  <script>
-    new MOJFrontend.PasswordReveal(document.getElementById('password'));
-  </script>
-
-{% endblock %}

--- a/app/views/components/password-reveal/index.html
+++ b/app/views/components/password-reveal/index.html
@@ -33,7 +33,10 @@
           text: "Password",
           classes: 'govuk-label--m'
         },
-        value: "1234ABC!"
+        value: "1234ABC!",
+        attributes: {
+          'data-module': 'moj-password-reveal'
+        }
       }) }}
 
       {{ govukButton({

--- a/app/views/components/primary-navigation/index.html
+++ b/app/views/components/primary-navigation/index.html
@@ -70,7 +70,7 @@
       <h2 class="govuk-heading-m govuk-!-margin-top-9">Toggle search</h2>
 
       {%- set toggleSearchHtml %}
-      <div class="moj-search-toggle">
+      <div class="moj-search-toggle" data-module="moj-search-toggle" data-moj-search-toggle-text="Find case">
         <div class="moj-search-toggle__toggle"></div>
         <div class="moj-search-toggle__search">
           {{ mojSearch({
@@ -114,18 +114,4 @@
 
   </div>
 
-{% endblock %}
-
-{% block pageScripts %}
-  <script>
-    new MOJFrontend.SearchToggle({
-      toggleButton: {
-        container: $('.moj-search-toggle__toggle'),
-        text: 'Find case'
-      },
-      search: {
-        container: $('.moj-search:eq(1)')
-      }
-    });
-  </script>
 {% endblock %}

--- a/app/views/components/rich-text-editor/index.html
+++ b/app/views/components/rich-text-editor/index.html
@@ -28,10 +28,13 @@
           {{ govukTextarea({
             id: 'body',
             name: 'body',
-            classes: 'js-editor',
             label: {
               text: 'Message',
               classes: 'govuk-!-font-weight-bold'
+            },
+            attributes: {
+              'data-module': 'moj-rich-text-editor',
+              'data-rich-text-editor-toolbar': 'bold,numbers'
             }
           }) }}
 
@@ -43,16 +46,5 @@
     </div>
 
   </div>
-
-{% endblock %}
-
-{% block pageScripts %}
-
-  <script>
-    new MOJFrontend.RichTextEditor({
-      textarea: $('.js-editor'),
-      toolbar: {'bold': true, 'italic': true, 'underline': true, 'bullets': true, 'numbers': true}
-    });
-  </script>
 
 {% endblock %}

--- a/app/views/components/sortable-table/index.html
+++ b/app/views/components/sortable-table/index.html
@@ -16,6 +16,9 @@
       </h1>
 
       {{ govukTable({
+        attributes: {
+          'data-module': 'moj-sortable-table'
+        },
         head: [
           {
             text: "Name",
@@ -197,12 +200,4 @@
     </div>
 
   </div>
-{% endblock %}
-
-{% block pageScripts %}
-  <script>
-    new MOJFrontend.SortableTable({
-      table: $('table')[0]
-    });
-  </script>
 {% endblock %}

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -11,3 +11,4 @@
 <script src="/public/javascripts/components/rich-text-editor/rich-text-editor.js"></script>
 <script src="/public/javascripts/components/search-toggle/search-toggle.js"></script>
 <script src="/public/javascripts/components/sortable-table/sortable-table.js"></script>
+<script src="/public/javascripts/all.js"></script>

--- a/app/views/layouts/base.html
+++ b/app/views/layouts/base.html
@@ -77,6 +77,9 @@
 
     {%- block scripts %}
       {%- include "includes/scripts.html" %}
+      <script type="text/javascript">
+        MOJFrontend.initAll();
+      </script>
       {%- block pageScripts %}{% endblock %}
     {%- endblock %}
   </body>

--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -5,6 +5,7 @@ gulp.task('build:javascript', () => {
   return gulp.src([
       'src/moj/namespace.js',
       'src/moj/helpers.js',
+      'src/moj/all.js',
       'src/moj/components/**/*.js'
     ])
     .pipe(concat('all.js'))

--- a/gulp/copy-helpers.js
+++ b/gulp/copy-helpers.js
@@ -2,7 +2,8 @@ const gulp = require('gulp');
 
 gulp.task('copy-helpers', () => {
   return gulp.src([
-      'src/moj/helpers.js'
+      'src/moj/helpers.js',
+      'src/moj/all.js'
     ])
     .pipe(gulp.dest('public/javascripts/'));
 });

--- a/gulp/watch.js
+++ b/gulp/watch.js
@@ -11,6 +11,7 @@ gulp.task('watch-sass', (done) => {
     'src/moj/components/**/*.js',
     'src/moj/namespace.js',
     'src/moj/helpers.js',
+    'src/moj/all.js',
     'app/assets/sass/*.scss'
   ], gulp.series('sass', 'copy-component-javascript', 'copy-namespace', 'copy-helpers'));
   done();

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -6,6 +6,11 @@ MOJFrontend.initAll = function (options) {
   // Defaults to the entire document if nothing is set.
   var scope = typeof options.scope !== 'undefined' ? options.scope : document;
 
+  var $addAnothers = scope.querySelectorAll('[data-module="moj-add-another"]');
+  MOJFrontend.nodeListForEach($addAnothers, function ($addAnother) {
+    new MOJFrontend.AddAnother($addAnother);
+  });
+
   var $passwordReveals = scope.querySelectorAll('[data-module="moj-password-reveal"]');
   MOJFrontend.nodeListForEach($passwordReveals, function ($passwordReveal) {
     new MOJFrontend.PasswordReveal($passwordReveal);

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -23,4 +23,20 @@ MOJFrontend.initAll = function (options) {
   MOJFrontend.nodeListForEach($passwordReveals, function ($passwordReveal) {
     new MOJFrontend.PasswordReveal($passwordReveal);
   });
+
+  var $richTextEditors = scope.querySelectorAll('[data-module="moj-rich-text-editor"]');
+  MOJFrontend.nodeListForEach($richTextEditors, function ($richTextEditor) {
+    var options = {
+      textarea: $($richTextEditor)
+    };
+
+    var toolbarAttr = $richTextEditor.getAttribute('data-rich-text-editor-toolbar');
+    if (toolbarAttr) {
+      var toolbar = toolbarAttr.split(',');
+      options.toolbar = {};
+      for (var item in toolbar) options.toolbar[toolbar[item]] = true;
+    }
+
+    new MOJFrontend.RichTextEditor(options);
+  });
 }

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -40,6 +40,26 @@ MOJFrontend.initAll = function (options) {
     new MOJFrontend.RichTextEditor(options);
   });
 
+  var $searchToggles = scope.querySelectorAll('[data-module="moj-search-toggle"]');
+  MOJFrontend.nodeListForEach($searchToggles, function ($searchToggle) {
+    new MOJFrontend.SearchToggle({
+      toggleButton: {
+        container: $($searchToggle.querySelector('.moj-search-toggle__toggle')),
+        text: $searchToggle.getAttribute('data-moj-search-toggle-text')
+      },
+      search: {
+        container: $($searchToggle.querySelector('.moj-search'))
+      }
+    });
+  });
+
+  var $sortableTables = scope.querySelectorAll('[data-module="moj-sortable-table"]');
+  MOJFrontend.nodeListForEach($sortableTables, function ($table) {
+    new MOJFrontend.SortableTable({
+      table: $table
+    });
+  });
+
   var $sortableTables = scope.querySelectorAll('[data-module="moj-sortable-table"]');
   MOJFrontend.nodeListForEach($sortableTables, function ($table) {
     new MOJFrontend.SortableTable({

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -11,6 +11,14 @@ MOJFrontend.initAll = function (options) {
     new MOJFrontend.AddAnother($addAnother);
   });
 
+  var $multiSelects = scope.querySelectorAll('[data-module="moj-multi-select"]');
+  MOJFrontend.nodeListForEach($multiSelects, function ($multiSelect) {
+    new MOJFrontend.MultiSelect({
+      container: $multiSelect.querySelector($multiSelect.getAttribute('data-multi-select-checkbox')),
+      checkboxes: $multiSelect.querySelectorAll('tbody .govuk-checkboxes__input')
+    });
+  });
+
   var $passwordReveals = scope.querySelectorAll('[data-module="moj-password-reveal"]');
   MOJFrontend.nodeListForEach($passwordReveals, function ($passwordReveal) {
     new MOJFrontend.PasswordReveal($passwordReveal);

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -39,4 +39,11 @@ MOJFrontend.initAll = function (options) {
 
     new MOJFrontend.RichTextEditor(options);
   });
+
+  var $sortableTables = scope.querySelectorAll('[data-module="moj-sortable-table"]');
+  MOJFrontend.nodeListForEach($sortableTables, function ($table) {
+    new MOJFrontend.SortableTable({
+      table: $table
+    });
+  });
 }

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -1,0 +1,13 @@
+MOJFrontend.initAll = function (options) {
+  // Set the options to an empty object by default if no options are passed.
+  options = typeof options !== 'undefined' ? options : {};
+
+  // Allow the user to initialise MOJ Frontend in only certain sections of the page
+  // Defaults to the entire document if nothing is set.
+  var scope = typeof options.scope !== 'undefined' ? options.scope : document;
+
+  var $passwordReveals = scope.querySelectorAll('[data-module="moj-password-reveal"]');
+  MOJFrontend.nodeListForEach($passwordReveals, function ($passwordReveal) {
+    new MOJFrontend.PasswordReveal($passwordReveal);
+  });
+}

--- a/src/moj/components/add-another/add-another.js
+++ b/src/moj/components/add-another/add-another.js
@@ -1,5 +1,12 @@
 MOJFrontend.AddAnother = function(container) {
 	this.container = $(container);
+
+	if (this.container.data('moj-add-another-initialised')) {
+		return
+	}
+
+	this.container.data('moj-add-another-initialised', true);
+
 	this.container.on('click', '.moj-add-another__remove-button', $.proxy(this, 'onRemoveButtonClick'));
 	this.container.on('click', '.moj-add-another__add-button', $.proxy(this, 'onAddButtonClick'));
 	this.container.find('.moj-add-another__add-button, moj-add-another__remove-button').prop('type', 'button');

--- a/src/moj/components/multi-select/multi-select.js
+++ b/src/moj/components/multi-select/multi-select.js
@@ -1,5 +1,12 @@
 MOJFrontend.MultiSelect = function(options) {
   this.container = $(options.container);
+
+  if (this.container.data('moj-multi-select-initialised')) {
+    return
+  }
+
+  this.container.data('moj-multi-select-initialised', true);
+
   this.toggle = $(this.getToggleHtml());
   this.toggleButton = this.toggle.find('input');
   this.toggleButton.on('click', $.proxy(this, 'onButtonClick'));

--- a/src/moj/components/multi-select/multi-select.js
+++ b/src/moj/components/multi-select/multi-select.js
@@ -1,10 +1,10 @@
 MOJFrontend.MultiSelect = function(options) {
-  this.container = options.container;
+  this.container = $(options.container);
   this.toggle = $(this.getToggleHtml());
   this.toggleButton = this.toggle.find('input');
   this.toggleButton.on('click', $.proxy(this, 'onButtonClick'));
   this.container.append(this.toggle);
-  this.checkboxes = options.checkboxes;
+  this.checkboxes = $(options.checkboxes);
   this.checkboxes.on('click', $.proxy(this, 'onCheckboxClick'));
   this.checked = options.checked || false;
 };

--- a/src/moj/components/password-reveal/password-reveal.js
+++ b/src/moj/components/password-reveal/password-reveal.js
@@ -1,6 +1,14 @@
 MOJFrontend.PasswordReveal = function(element) {
   this.el = element;
-  $(this.el).wrap('<div class="moj-password-reveal"></div>');
+  $el = $(this.el)
+
+  if ($el.data('moj-password-reveal-initialised')) {
+    return
+  }
+
+  $el.data('moj-password-reveal-initialised', true);
+
+  $el.wrap('<div class="moj-password-reveal"></div>');
   this.container = $(this.el).parent();
   this.createButton();
 };

--- a/src/moj/components/rich-text-editor/rich-text-editor.js
+++ b/src/moj/components/rich-text-editor/rich-text-editor.js
@@ -10,6 +10,13 @@ if('contentEditable' in document.documentElement) {
     };
     this.textarea = this.options.textarea;
     this.container = $(this.textarea).parent();
+
+    if (this.container.data('moj-rich-text-editor-initialised')) {
+      return
+    }
+
+    this.container.data('moj-rich-text-editor-initialised', true);
+
     this.createToolbar();
     this.hideDefault();
     this.configureToolbar();

--- a/src/moj/components/search-toggle/search-toggle.js
+++ b/src/moj/components/search-toggle/search-toggle.js
@@ -1,5 +1,12 @@
 MOJFrontend.SearchToggle = function(options) {
   this.options = options;
+
+  if (this.options.search.container.data('moj-search-toggle-initialised')) {
+    return
+  }
+
+  this.options.search.container.data('moj-search-toggle-initialised', true);
+
   this.toggleButton = $('<button class="moj-search-toggle__button" type="button" aria-haspopup="true" aria-expanded="false">'+this.options.toggleButton.text+'</button>');
 	this.toggleButton.on('click', $.proxy(this, 'onToggleButtonClick'));
   this.options.toggleButton.container.append(this.toggleButton);

--- a/src/moj/components/sortable-table/sortable-table.js
+++ b/src/moj/components/sortable-table/sortable-table.js
@@ -1,5 +1,12 @@
 MOJFrontend.SortableTable = function(params) {
 	this.table = $(params.table);
+
+	if (this.table.data('moj-search-toggle-initialised')) {
+		return
+	}
+
+	this.table.data('moj-search-toggle-initialised', true);
+
 	this.setupOptions(params);
 	this.body = this.table.find('tbody');
 	this.createHeadingButtons();

--- a/src/moj/helpers.js
+++ b/src/moj/helpers.js
@@ -40,3 +40,12 @@ MOJFrontend.fileApiSupported = function() {
   input.type = 'file';
   return typeof input.files != 'undefined';
 };
+
+MOJFrontend.nodeListForEach = function(nodes, callback) {
+  if (window.NodeList.prototype.forEach) {
+    return nodes.forEach(callback)
+  }
+  for (var i = 0; i < nodes.length; i++) {
+    callback.call(window, nodes[i], i, nodes)
+  }
+};


### PR DESCRIPTION
### Issue or RFC endorsed by the maintainers

N/A. I thought this hard to discuss without having code to review, so intended this PR to be the discussion space.

### Description of the change

#### Background

Several components require additional JavaScript to function properly (this isn't documented, something which I intend to remedy after this). For example, the [example password reveal component](https://moj-design-system.herokuapp.com/components/password-reveal) should contain some JavaScript too:
```html
<input class="govuk-input moj-password-reveal__input govuk-input--width-20" id="password" name="password" type="password" value="1234ABC!">

<script>
new MOJFrontend.PasswordReveal(document.getElementById('password'));
</script>
```

This isn't the case in the GOV.UK Design System. For example, take the similar [character count component](https://design-system.service.gov.uk/components/character-count/). Instead of manual JavaScript, this requires the attributes `data-module="govuk-character-count" data-maxlength="200"` and is automatically initialised alongside _all other_ components with the one-line call `GOVUKFrontend.initAll()`.

This approach is much easier to write, particularly for those unfamiliar with JavaScript. It's particularly helpful when using the Nunjucks templates (e.g. with the prototype kit) where `data-module` attributes can be added automatically and the author doesn't even need to consider JavaScript.

#### This change

This PR starts to add the same functionality to the MOJ Design System:  a global `initAll` function which initialises _some_ (see below) components automatically based on `data-module` attributes.

Six components are initially targeted:
- Add another
- Multi select
- Password reveal
- Rich text editor
- Search toggle
- Sortable table

I chose those six because they were easy to convert to an attribute-based pattern, both because of their limited configuration options and the structure of the underlying code.

Note that I also haven't made any notable changes to the underlying JavaScript code for any component, so existing manual-initialisation techniques will continue to work.

#### What wasn't included

I didn't touch any components which have no related JavaScript code. I also didn't include the following components because their JavaScript code is not trivial to convert. We would likely have to rewrite the components to support this initialisation approach (or at least add a likely-breaking-change to their signature):

- Button menu (has three optional configuration options)
- Filter toggle button (has a large number of configuration options)
- Form validator (defines bespoke validation rules, would likely benefit from a redesign based on HTML5 validation)
- Multi-file upload (has two required and three optional configuration options, two of which are URLs)

### Alternative designs

A much more light-touch approach would just be documenting the JavaScript each component needs, but that would still require authors to manually pen JavaScript and have at least basic knowledge of JS and—currently—jQuery.

There's also the option to commit more heavily and add this pattern for every component, but I believe that's beyond the scope of one PR.

### Possible drawbacks

If authors have code to manually initialise components (e.g. `new MOJFrontend.PasswordReveal(...);`) and then _also_ start using `MOJFrontend.initAll()`, some components will be initialised twice which may cause problems.

There's also the drawback noted above that some components still require JavaScript initialisation, which may be confusing. But clearer documentation can help with this.

### Verification process

- I ensured the code worked by adding `MOJFrontend.initAll()` to all the example pages in this repo. I also removed the bespoke JavaScript from the examples of components I've adapted.
- I ensured old functionality continued to work by adding this as a new layer rather than changing the underlying code. The only change to existing JavaScript is using `$($container)` to accept both jQuery and DOM objects as an argument to multi-selects.

### Release notes

- Added `MOJFrontend.initAll()` to automatically initialise several components if they have suitable data-* attributes
