### PR TITLE
Fix rich-text-editor attribute prefix

### DIFF
--- a/app/views/components/rich-text-editor/index.html
+++ b/app/views/components/rich-text-editor/index.html
@@ -34,7 +34,7 @@
             },
             attributes: {
               'data-module': 'moj-rich-text-editor',
-              'data-rich-text-editor-toolbar': 'bold,numbers'
+              'data-moj-rich-text-editor-toolbar': 'bold,numbers'
             }
           }) }}
 

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -30,7 +30,7 @@ MOJFrontend.initAll = function (options) {
       textarea: $($richTextEditor)
     };
 
-    var toolbarAttr = $richTextEditor.getAttribute('data-rich-text-editor-toolbar');
+    var toolbarAttr = $richTextEditor.getAttribute('data-moj-rich-text-editor-toolbar');
     if (toolbarAttr) {
       var toolbar = toolbarAttr.split(',');
       options.toolbar = {};


### PR DESCRIPTION
Include "moj" in prefix to avoid collisions with other libraries.