### PR TITLE
Replace email with contact URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -10,7 +10,7 @@ Have you read the Code of Conduct? By filing an Issue, you are expected to compl
 
 https://github.com/ministryofjustice/moj-frontend/blob/master/CODE_OF_CONDUCT.md
 
-Do you want to ask a question? Are you looking for support? You can email [design-system@digital.justice.gov.uk](design-system@digital.justice.gov.uk) putting the repository name in the subject line.
+Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
 
 <!--
@@ -10,7 +9,7 @@ Have you read the Code of Conduct? By filing an Issue, you are expected to compl
 
 https://github.com/ministryofjustice/moj-frontend/blob/master/CODE_OF_CONDUCT.md
 
-Do you want to ask a question? Are you looking for support? You can email [design-system@digital.justice.gov.uk](design-system@digital.justice.gov.uk) putting the repository name in the subject line.
+Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing or otherwise unacceptable behaviour may be reported by contacting the project team at design-system@digital.justice.gov.uk. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality concerning the reporter of an incident.
+Instances of abusive, harassing or otherwise unacceptable behaviour may be reported by [contacting the Design System team](https://moj-design-system.herokuapp.com/get-in-touch). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality concerning the reporter of an incident.
 
 Further details of specific enforcement policies may be posted separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Please note we have a [code of conduct](https://github.com/ministryofjustice/moj
 
 If you’ve got an idea or suggestion you can:
 
-* Email [design-system@digital.justice.gov.uk](design-system@digital.justice.gov.uk) putting the repository name in the subject line.
-* [Create a GitHub issue](https://github.com/ministryofjustice/mojdt-frontend/issues).
+- [Contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch)
+- [Create a GitHub issue](https://github.com/ministryofjustice/mojdt-frontend/issues)
 
 ## Raising bugs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![moj-frontend](https://circleci.com/gh/ministryofjustice/moj-frontend.svg?style=shield)](https://circleci.com/gh/ministryofjustice/moj-frontend)
 
-
 # Ministry of Justice Frontend
 
 MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.
@@ -15,7 +14,7 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 
 ## Contact the team
 
-MOJ Frontend is maintained by the MOJ Design System team. If you need support email the [Design System team](mailto:design-system@digital.justice.gov.uk).
+MOJ Frontend is maintained by the MOJ Design System team. If you need support [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 
 ## Quick start
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/ministryofjustice/moj-frontend.git"
   },
-  "author": "Simon Whatley, Adam Silver, Gavin Wye, Matthew Solle",
+  "author": "MOJ Digital & Technology",
   "license": "MIT",
   "publishConfig": {
     "access": "public",

--- a/package/README.md
+++ b/package/README.md
@@ -2,7 +2,6 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![moj-frontend](https://circleci.com/gh/ministryofjustice/moj-frontend.svg?style=shield)](https://circleci.com/gh/ministryofjustice/moj-frontend)
 
-
 # Ministry of Justice Frontend
 
 MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.
@@ -15,7 +14,7 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 
 ## Contact the team
 
-MOJ Frontend is maintained by the MOJ Design System team. If you need support email the [Design System team](mailto:design-system@digital.justice.gov.uk).
+MOJ Frontend is maintained by the MOJ Design System team. If you need support [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
 
 ## Quick start
 

--- a/package/package.json
+++ b/package/package.json
@@ -7,10 +7,7 @@
   "engines": {
     "node": ">= 4.2.0"
   },
-  "author": {
-    "name": "MOJ Design System Team",
-    "email": "design-system@digital.justice.gov.uk"
-  },
+  "author": "MOJ Digital & Technology",
   "repository": {
     "type": "git",
     "url": "https://github.com/ministryofjustice/moj-frontend.git"


### PR DESCRIPTION
The linked email address isn't operated as a support channel and shouldn't be advertised to users.

Instead, direct them to https://moj-design-system.herokuapp.com/get-in-touch where up-to-date contact details can be found.

Fixes #148