### PR TITLE
fix(add-another): clear floating legend

### DIFF
--- a/src/moj/components/add-another/_add-another.scss
+++ b/src/moj/components/add-another/_add-another.scss
@@ -18,6 +18,10 @@
     float: left;
     padding: 4px 0;
     width: 100%;
+
+    & + .govuk-form-group {
+      clear: left;
+    }
   }
 
   &__remove-button {


### PR DESCRIPTION
### Requirements for contributing a bug fix

* Fill out the template below. Maintainers are free to close any pull requests that do not include enough information, at their discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at https://github.com/ministryofjustice/moj-frontend/tree/master/.github/PULL_REQUEST_TEMPLATE.
* The pull request must update the test suite to demonstrate the changed functionality.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see https://github.com/ministryofjustice/moj-frontend/tree/master/CONTRIBUTING.md#pull-requests.

### Identify the bug

#152 

### Description of the change

Add an extra CSS rule in the `.moj-add-another__title` class that clears floats on a sibling `.govuk-form-group`.

### Alternative designs

The clear might be needed in all cases, not just the form group siblings, however I restrained the changes in those discussed in #152.

### Possible drawbacks

The only drawback might be that this fix does not cover the non form group sibling cases.

### Verification process

I have already tested this change in our project.

### Release notes

Fixed an issue with govuk error classes applying to add another fieldset's legend as well.
<!--

Please describe the changes in a single line that explains this improvement in terms that a user can understand. This text forms part of the release notes.

If this change is not user-facing or notable enough to for release notes, you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->