### PR TITLE
Make default ticket panel have no border

### DIFF
--- a/src/moj/components/ticket-panel/_ticket-panel.scss
+++ b/src/moj/components/ticket-panel/_ticket-panel.scss
@@ -29,8 +29,7 @@
     padding: govuk-spacing(4);
     margin-bottom: govuk-spacing(3);
     flex-grow: 1;
-    border-left-width: 4px;
-    border-left-style: solid;
+    border-left: 4px solid transparent;
 
     &--grey {
       border-left-color: $govuk-border-colour;


### PR DESCRIPTION
The default ticket panel currently has a black border because `border-left-color` is not specified. This change instead makes it transparent, so that the border only appears if you add one of the variant classes (e.g. `.moj-ticket-panel__content--red`).

This means that default ticket panels have an extra 4px padding on the left, but this doesn't stand out visually and ensures that the text aligns between plain and colourful ticket panels.

<img width="264" alt="image" src="https://user-images.githubusercontent.com/100852/118789063-4fe0d900-b88c-11eb-8bf4-0a82fe2d719b.png">
