### PR TITLE
Fix syntax error

### DIFF
--- a/docs/examples/page-header-actions/index.njk
+++ b/docs/examples/page-header-actions/index.njk
@@ -7,7 +7,7 @@ title: Page header actions (example)
 
 {{ mojPageHeaderActions({
   heading: {
-    text: 'Documents
+    text: 'Documents',
   },
   items: [{
     text: 'Upload new',


### PR DESCRIPTION
I accidentally missed a quote mark and a comma, meaning the docs cannot render
