### PR TITLE
ci: test docs can build in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "scripts": {
     "build:docs": "webpack && eleventy --input=./docs --output=public",
     "build:package": "node bin/check-nvmrc.js && gulp build:package",
-    "ci:testsass": "node-sass -q test.scss >/dev/null && echo 'ok'",
     "ci:release": "HUSKY_SKIP_HOOKS=1 CI=true semantic-release --debug",
     "ci:dryrun": "HUSKY_SKIP_HOOKS=1 CI=true semantic-release --dry-run",
     "start": "npm-run-all --parallel watch:*",
-    "test": "npm run ci:testsass",
+    "test": "npm-run-all --parallel test:*",
+    "test:sass": "node-sass -q test.scss >/dev/null && echo 'ok'",
+    "test:docs": "npm run build:docs",
     "watch:11ty": "eleventy --input=./docs --output=public --serve --watch",
     "watch:webpack": "webpack --watch"
   },


### PR DESCRIPTION
When running CI tests, build the docs to ensure it can happen without error