### PR TITLE
docs: remove duplicate tag guidance

### DIFF
--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -3,9 +3,11 @@ layout: layouts/component.njk
 title: Tag
 ---
 
-Use the [GOV.UK tag component](https://design-system.service.gov.uk/components/tag/) to indicate the status of something, such as an item on a [task list page](https://design-system.service.gov.uk/patterns/task-list-pages).
+{% banner "This component is on the GOV.UK Design System" %}
+[Tag](https://design-system.service.gov.uk/components/tag/) is published in the GOV.UK Design System.
+{% endbanner %}
 
-There are a number of additional colour styles that can be used:
+Additional colours are below, which are not in the GOV.UK Design System.
 
 <table class="govuk-table">
     <thead class="govuk-table__head">
@@ -106,14 +108,6 @@ There are a number of additional colour styles that can be used:
     </tbody>
 </table>
 
-## When to use these styles
+## Contribute to this component
 
-Use tag styles when the user needs to be alerted to the status of something like the status of a prisoner.
-
-## Research on these styles
-
-We need more research. If you have used alternative tag styles, get in touch to share your research findings.
-
-## Contribute to these styles
-
-You can contribute to these styles via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/26)
+You can contribute to this component on the [GOV.UK Design System](https://design-system.service.gov.uk/components/tag/#help-improve-this-page)


### PR DESCRIPTION
### Description of the change

- Add notification banner to communicate this component us on the GOV.UK Design System
- Remove duplicate guidance which is already on the GOV.UK Design System, leaving just the additional colours.
- Change where people are directed to contribute from the MOJ GitHub repo to the GOV.UK Design System

|Before |After  |
--- | ---
|![Screenshot 2021-06-23 at 09 16 06](https://user-images.githubusercontent.com/6122118/123063337-38ee5300-d405-11eb-8928-62ea80f4c2b4.png)|![Screenshot 2021-06-23 at 09 16 12](https://user-images.githubusercontent.com/6122118/123064218-fe38ea80-d405-11eb-8c8a-c637e6d8cf78.png)|

### Release notes

Users can access the MOJ additional colours of the Tag component which is not on the GOV.UK Design System, and navigate to the GOV.UK Design System for guidance on usage and to contribute. 
