### PR TITLE
Add component categories

### DIFF
--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -13,101 +13,130 @@
     <div class="govuk-grid-column-one-third">
       {{ appSideNavigation({
         classes: 'govuk-!-padding-top-6',
-        items: [
+        sections: [
           {
-            text: 'Add another',
-            href: ('/components/add-another' | url)
+            heading: {
+              text: "Structure"
+            },
+            items: [
+            {
+              text: 'Header',
+              href: ('/components/header' | url)
+            },
+            {
+              text: 'Search',
+              href: ('/components/search' | url)
+            },
+            {
+              text: 'Identity bar',
+              href: ('/components/identity-bar' | url)
+            },
+            {
+              text: 'Organisation switcher',
+              href: ('/components/organisation-switcher' | url)
+            }
+            ]
           },
           {
-            text: 'Badge',
-            href: ('/components/badge' | url)
+            heading: {
+              text: "Navigation"
+            },
+            items: [
+            {
+              text: 'Primary navigation',
+              href: ('/components/primary-navigation' | url)
+            },
+            {
+              text: 'Sub navigation',
+              href: ('/components/sub-navigation' | url)
+            },
+            {
+              text: 'Side navigation',
+              href: ('/components/side-navigation' | url)
+            },
+            {
+              text: 'Notification badge',
+              href: ('/components/notification-badge' | url)
+            },
+            {
+              text: 'Page header actions',
+              href: ('/components/page-header-actions' | url)
+            },
+            {
+              text: 'Button menu',
+              href: ('/components/button-menu' | url)
+            },
+            {
+              text: 'Filter',
+              href: ('/components/filter' | url)
+            },
+            {
+              text: 'Pagination',
+              href: ('/components/pagination' | url)
+            }
+            ]
           },
           {
-            text: 'Banner',
-            href: ('/components/banner' | url)
+            heading: {
+              text: "Forms"
+            },
+            items: [
+            {
+              text: 'Add another',
+              href: ('/components/add-another' | url)
+            },
+            {
+              text: 'Form validator',
+              href: ('/components/form-validator' | url)
+            },
+            {
+              text: 'Multi file upload',
+              href: ('/components/multi-file-upload' | url)
+            },
+            {
+              text: 'Password reveal',
+              href: ('/components/password-reveal' | url)
+            },
+            {
+              text: 'Rich text editor',
+              href: ('/components/rich-text-editor' | url)
+            }
+            ]
           },
           {
-            text: 'Button menu',
-            href: ('/components/button-menu' | url)
-          },
-          {
-            text: 'Filter',
-            href: ('/components/filter' | url)
-          },
-          {
-            text: 'Form validator',
-            href: ('/components/form-validator' | url)
-          },
-          {
-            text: 'Header',
-            href: ('/components/header' | url)
-          },
-          {
-            text: 'Identity bar',
-            href: ('/components/identity-bar' | url)
-          },
-          {
-            text: 'Messages',
-            href: ('/components/messages' | url)
-          },
-          {
-            text: 'Multi file upload',
-            href: ('/components/multi-file-upload' | url)
-          },
-          {
-            text: 'Multi select',
-            href: ('/components/multi-select' | url)
-          },
-          {
-            text: 'Notification badge',
-            href: ('/components/notification-badge' | url)
-          },
-          {
-            text: 'Organisation switcher',
-            href: ('/components/organisation-switcher' | url)
-          },
-          {
-            text: 'Page header actions',
-            href: ('/components/page-header-actions' | url)
-          },
-          {
-            text: 'Pagination',
-            href: ('/components/pagination' | url)
-          },
-          {
-            text: 'Password reveal',
-            href: ('/components/password-reveal' | url)
-          },
-          {
-            text: 'Primary navigation',
-            href: ('/components/primary-navigation' | url)
-          },
-          {
-            text: 'Rich text editor',
-            href: ('/components/rich-text-editor' | url)
-          },
-          {
-            text: 'Search',
-            href: ('/components/search' | url)
-          },
-          {
-            text: 'Side navigation',
-            href: ('/components/side-navigation' | url)
-          },
-          {
-            text: 'Sortable table',
-            href: ('/components/sortable-table' | url)
-          },
-          {
-            text: 'Sub navigation',
-            href: ('/components/sub-navigation' | url)
-          },
-          {
-            text: 'Timeline',
-            href: ('/components/timeline' | url)
+            heading: {
+              text: "Content"
+            },
+            items: [
+            {
+              text: 'Banner',
+              href: ('/components/banner' | url)
+            },
+            {
+              text: 'Badge',
+              href: ('/components/badge' | url)
+            },
+            {
+              text: 'Messages',
+              href: ('/components/messages' | url)
+            },
+            {
+              text: 'Timeline',
+              href: ('/components/timeline' | url)
+            },
+            {
+              text: 'Multi select',
+              href: ('/components/multi-select' | url)
+            },
+            {
+              text: 'Sortable table',
+              href: ('/components/sortable-table' | url)
+            }
+            ]
           }
         ]
-      }) }}
+
+        }) }}
 
       <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -3,6 +3,12 @@ layout: layouts/component.njk
 title: Badge
 ---
 
+{% banner "The GOV.UK Design System has a similar component" %}
+The [Tag component](https://design-system.service.gov.uk/components/tag/) in the GOV.UK Design System has a similar function and visual design to this component.
+
+You should consider using the GOV.UK version if it fits your needs.
+{% endbanner %}
+
 Use the badge component to highlight small details like an urgent case.
 
 {% example "/examples/badge", 125 %}


### PR DESCRIPTION
### Description of the change

- Group components in the navigation into four categories: Structure, Navigation, Forms, Content 
- Order components within categories based on how they may be ordered on the page where possible, instead of alphabetically

**Also in this PR**
- Add notification banner to the Badge component to communicate there is a similar component (Tag) in the GOV.UK Design System which should be considered. 

|Before |After  |
--- | ---
|![ministryofjustice github io_moj-frontend_components_(iPad Pro) (1)](https://user-images.githubusercontent.com/6122118/123254330-71199280-d4e6-11eb-8b78-ce1823629d7c.png) |![localhost_8080_components_(iPad Pro) (1)](https://user-images.githubusercontent.com/6122118/123254367-7a0a6400-d4e6-11eb-8788-21c33135ca77.png) |
|![ministryofjustice github io_moj-frontend_components_badge_](https://user-images.githubusercontent.com/6122118/123253999-0405fd00-d4e6-11eb-9d91-effeb563abc6.png) |![localhost_8080_components_badge_](https://user-images.githubusercontent.com/6122118/123254026-0b2d0b00-d4e6-11eb-92ae-647c609b571f.png) |

### Release notes

Users will be able to find components easier by browsing the categories, and seeing them listed as they would be ordered on the page. 