### PR TITLE
Update notification badge documentation

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -6,6 +6,11 @@ title: Components
 
 Components in this section have been created by designers and developers at MOJ.
 
+To use these components you can either:
+
+- copy the HTML code
+- copy the Nunjucks code (if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)) 
+
 To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
 
 If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MOJ component will be [archived](archived-components).

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -10,12 +10,12 @@ This component is in the GOV.UK Design System [community backlog](https://design
 {% endbanner %}
 
 {% example "/examples/notification-badge", 125 %}
-### When to use
+## When to use
 
 The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
 
 Only use it if the number changes when the user performs an action.
-### When not to use
+## When not to use
 
 Do not use the notification badge when:
 
@@ -24,12 +24,12 @@ Do not use the notification badge when:
 
 Unless there is a strong user need, only use it as a part of the navigation.
 
-### How to use
+## How to use
 
 Display the notification badge to the right-hand side of the information it refers to.
 
 If the number is more than 99, display ‘99+’.
-### Research
+## Research
 
 Research shows that notification badges are common across online services, smartphones and apps. Usability testing showed:
 

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -3,28 +3,12 @@ layout: layouts/component.njk
 title: Notification badge
 ---
 
-Use the notification badge component to notify users of something like an unread message.
+{% banner "HMRC Design Patterns has a similar component" %}
+[Notification badge](https://design.tax.service.gov.uk/hmrc-design-patterns/notification-badge/) in HMRC Design Patterns has a similar function and visual design to this component, and includes some guidance on usage.
+{% endbanner %}
+
+### 11 June 2019
+
+The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
 
 {% example "/examples/notification-badge", 125 %}
-
-## When to use this component
-
-Use this component when the user needs to be alerted that they have, for example, unread messages and how many of them there are. Only use it if the number changes when the user performs an action.
-
-## When not to use this component
-
-Do not use this component when the number of things is zero, or there is no action to take.
-
-Unless there is a strong user need, only use this component as a part of the navigation.
-
-## How it works
-
-There are 2 ways to use the notification badge component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
-
-## Research on this component
-
-We need more research. If you have used the notification badge component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/41)

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -11,5 +11,4 @@ The notification badge lets the user know that there is new information to view,
 
 ### 11 June 2019
 
-
 {% example "/examples/notification-badge", 125 %}

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -3,14 +3,35 @@ layout: layouts/component.njk
 title: Notification badge
 ---
 
-The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
-
 {% banner "HMRC Design Patterns has a similar component" %}
 [Notification badge](https://design.tax.service.gov.uk/hmrc-design-patterns/notification-badge/) in HMRC Design Patterns has a similar function and visual design to this component, and includes some guidance on when to use it.
 
 This component is in the GOV.UK Design System [community backlog](https://design-system.service.gov.uk/community/backlog/) for review. 
 {% endbanner %}
 
-### 11 June 2019
-
 {% example "/examples/notification-badge", 125 %}
+### When to use
+
+The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
+
+Only use it if the number changes when the user performs an action.
+### When not to use
+
+Do not use the notification badge when:
+
+- the number of things is 0
+- there is no action
+
+Unless there is a strong user need, only use it as a part of the navigation.
+
+### How to use
+
+Display the notification badge to the right-hand side of the information it refers to.
+
+If the number is more than 99, display ‘99+’.
+### Research
+
+Research shows that notification badges are common across online services, smartphones and apps. Usability testing showed:
+
+- users understand what it is for
+- it does not distract users from their task

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -7,6 +7,8 @@ The notification badge lets the user know that there is new information to view,
 
 {% banner "HMRC Design Patterns has a similar component" %}
 [Notification badge](https://design.tax.service.gov.uk/hmrc-design-patterns/notification-badge/) in HMRC Design Patterns has a similar function and visual design to this component, and includes some guidance on when to use it.
+
+This component is in the GOV.UK Design System [community backlog](https://design-system.service.gov.uk/community/backlog/) for review. 
 {% endbanner %}
 
 ### 11 June 2019

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -3,12 +3,13 @@ layout: layouts/component.njk
 title: Notification badge
 ---
 
+The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
+
 {% banner "HMRC Design Patterns has a similar component" %}
-[Notification badge](https://design.tax.service.gov.uk/hmrc-design-patterns/notification-badge/) in HMRC Design Patterns has a similar function and visual design to this component, and includes some guidance on usage.
+[Notification badge](https://design.tax.service.gov.uk/hmrc-design-patterns/notification-badge/) in HMRC Design Patterns has a similar function and visual design to this component, and includes some guidance on when to use it.
 {% endbanner %}
 
 ### 11 June 2019
 
-The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
 
 {% example "/examples/notification-badge", 125 %}

--- a/docs/patterns/task-list.md
+++ b/docs/patterns/task-list.md
@@ -3,7 +3,7 @@ layout: layouts/patterns.njk
 title: Task list pages
 ---
 
-{% banner "This pattern is on the GOV.UK Design System" %}
+{% banner "This pattern is in the GOV.UK Design System" %}
 [Task list pages](https://design-system.service.gov.uk/patterns/task-list-pages/) is published in the GOV.UK Design System.
 {% endbanner %}
 


### PR DESCRIPTION
### Description of the change

- Remove duplicate guidance on Notification banner component which exists on HMRC Design Patterns
- Add banner with link to HMRC Design Patterns and the GOV.UK Design System backlog

### Further information

It was felt that the previous iteration using the structured headings taken from the GOV.UK Design System made the component look more 'finished' than it is, and didn't clearly reflect that there is only a small amount of guidance on the component to date. 

To better reflect the component as a work in progress in order to encourage contribution, and to reduce the overhead of maintaining guidance that exists elsewhere, it was agreed to remove duplicate guidance and reduce the page to the minimal information. 

The method of contribution will be added in the future.

|Before |After  |
--- | ---
|![ministryofjustice github io_moj-frontend_components_notification-badge_(iPad Pro) (2)](https://user-images.githubusercontent.com/6122118/123408534-04b19880-d5a5-11eb-96c8-17996aadd77e.png) |![localhost_8080_components_notification-badge_(iPad Pro) (2)](https://user-images.githubusercontent.com/6122118/123408590-1004c400-d5a5-11eb-8506-327be7399652.png) |

### Release notes

Users will be able to see the how developed the Notification badge component and guidance is, and read further information on HMRC Design Patterns and GOV.UK.