### PR TITLE
docs: update term retired to archived components

### DIFF
--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -143,8 +143,8 @@
       {{ appSideNavigation({
         items: [
           {
-            text: 'Retired components',
-            href: ('/components/retired-components' | url)
+            text: 'Archived components',
+            href: ('/components/archived-components' | url)
           }
         ]
       }) }}

--- a/docs/components/archived-components.md
+++ b/docs/components/archived-components.md
@@ -1,9 +1,9 @@
 ---
 layout: layouts/component.njk
-title: Retired components
+title: Archived components
 ---
 
-These components are now published in the GOV.UK Design System. You should use the GOV.UK Design System component instead.
+MOJ components are archived when similar components are published in the GOV.UK Design System. You should use the GOV.UK Design System component instead.
 
 ### Contents
 
@@ -12,13 +12,13 @@ These components are now published in the GOV.UK Design System. You should use t
   
 ## Currency input
 
-[Currency input](../currency-input) is retired. 
+[Currency input](../currency-input) was archived on 23 June 2021. 
 
 You should use [prefixes and suffixes](https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes) in the GOV.UK Design System to help users enter things like currencies.
 
 ## Tag
 
-Additional colours of [Tag](../tag) are retired.
+Additional colours of [Tag](../tag) was archived on 23 June 2021.
 
 The GOV.UK Design System working group [made a decision to use tints for additional colours](https://github.com/alphagov/govuk-design-system-backlog/issues/62#issuecomment-590800378).
 

--- a/docs/components/currency-input.md
+++ b/docs/components/currency-input.md
@@ -3,7 +3,7 @@ layout: layouts/component.njk
 title: Currency input
 ---
 
-{% banner "This component is retired" %}
+{% banner "This component is archived" %}
 
 You should use [prefixes and suffixes](https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes) in the GOV.UK Design System to help users enter things like currencies.
 {% endbanner %}

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -8,4 +8,4 @@ Components in this section have been created by designers and developers at MOJ.
 
 To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
 
-If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MOJ version will become a [retired component](retired-components).
+If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MOJ component will be [archived](archived-components).

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -3,7 +3,7 @@ layout: layouts/component.njk
 title: Tag
 ---
 
-{% banner "This component is retired" %}
+{% banner "This component is archived" %}
 The GOV.UK Design System working group [made a decision to use tints for additional colours](https://github.com/alphagov/govuk-design-system-backlog/issues/62#issuecomment-590800378).
 
 You should use [additional colours](https://design-system.service.gov.uk/components/tag/#additional-colours) in the GOV.UK Design System.


### PR DESCRIPTION
### Description of the change

- Update the term 'Retired components' to 'Archived components'

### Further information

The term 'archived components' has been referenced from HMRC Design Patterns as a better term for components which should no longer be used.

|Before |After  |
--- | ---
|![ministryofjustice github io_moj-frontend_components_retired-components_(iPad Pro)](https://user-images.githubusercontent.com/6122118/123411546-7c34f700-d5a8-11eb-9acd-61a538281844.png) |![localhost_8080_components_archived-components_(iPad Pro)](https://user-images.githubusercontent.com/6122118/123411598-87882280-d5a8-11eb-9f1a-ec6a6a002ea0.png) |

### Release notes

Users will be able to see archived components, when they were archived and what they should use instead.