### PR TITLE
build: remove path prefix

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install and Build
         run: |
           npm install
-          npm run build:docs -- --pathprefix=moj-frontend
+          npm run build:docs
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@4.1.3

--- a/docs/_includes/layouts/partials/navigation.njk
+++ b/docs/_includes/layouts/partials/navigation.njk
@@ -1,24 +1,21 @@
 {%- from "node_modules/@ministryofjustice/frontend/moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation %}
 
-{% macro appPrimaryNavigation(config) %}
-  {% set config = config|addActiveAttribute(page.filePathStem | url) %}
-
-  {{ mojPrimaryNavigation(config) }}
-{% endmacro %}
-
-{{ appPrimaryNavigation({
+{{ mojPrimaryNavigation({
   items: [
     {
       text: 'Get started',
-      href: ('/' | url)
+      href: ('/' | url),
+      active: (page.filePathStem === '/index' or page.filePathStem.indexOf('/get-started') === 0)
     },
     {
       text: 'Components',
-      href: ('/components' | url)
+      href: ('/components' | url),
+      active: page.filePathStem.indexOf('/components') === 0
     },
     {
       text: 'Patterns',
-      href: ('/patterns' | url)
+      href: ('/patterns' | url),
+      active: page.filePathStem.indexOf('/patterns') === 0
     }
   ]
 }) }}


### PR DESCRIPTION
We're now hosted on a root domain, not in a subdirectory, so don't want links to include a path prefix

This also fixes #176 by changing how the primary navigation pages are highlighted