### PR TITLE
fix(add-another): find labels of affixed text inputs

### DIFF
--- a/docs/examples/add-another/script.js
+++ b/docs/examples/add-another/script.js
@@ -1,7 +1,0 @@
-if (typeof MOJFrontend.MultiFileUpload !== "undefined") {
-  new MOJFrontend.MultiFileUpload({
-    container: $(".moj-multi-file-upload"),
-    uploadUrl: "/ajax-upload",
-    deleteUrl: "/ajax-delete",
-  });
-}

--- a/package/moj/all.js
+++ b/package/moj/all.js
@@ -174,9 +174,13 @@ MOJFrontend.AddAnother.prototype.getNewItem = function() {
 
 MOJFrontend.AddAnother.prototype.updateAttributes = function(index, item) {
 	item.find('[data-name]').each(function(i, el) {
+    var originalId = el.id
+
 		el.name = $(el).attr('data-name').replace(/%index%/, index);
 		el.id = $(el).attr('data-id').replace(/%index%/, index);
-		($(el).siblings('label')[0] || $(el).parents('label')[0]).htmlFor = el.id;
+
+    var label = $(el).siblings('label')[0] || $(el).parents('label')[0] || item.find('[for="' + originalId + '"]')[0];
+		label.htmlFor = el.id;
 	});
 };
 

--- a/package/moj/components/add-another/add-another.js
+++ b/package/moj/components/add-another/add-another.js
@@ -42,9 +42,13 @@ MOJFrontend.AddAnother.prototype.getNewItem = function() {
 
 MOJFrontend.AddAnother.prototype.updateAttributes = function(index, item) {
 	item.find('[data-name]').each(function(i, el) {
+    var originalId = el.id
+
 		el.name = $(el).attr('data-name').replace(/%index%/, index);
 		el.id = $(el).attr('data-id').replace(/%index%/, index);
-		($(el).siblings('label')[0] || $(el).parents('label')[0]).htmlFor = el.id;
+
+    var label = $(el).siblings('label')[0] || $(el).parents('label')[0] || item.find('[for="' + originalId + '"]')[0];
+		label.htmlFor = el.id;
 	});
 };
 

--- a/src/moj/components/add-another/README.md
+++ b/src/moj/components/add-another/README.md
@@ -1,0 +1,6 @@
+# Add another
+
+- [Guidance](https://moj-design-system.herokuapp.com/components/add-another)
+- [Preview](https://moj-frontend.herokuapp.com/components/add-another)
+
+## Arguments

--- a/src/moj/components/add-another/add-another.js
+++ b/src/moj/components/add-another/add-another.js
@@ -42,9 +42,13 @@ MOJFrontend.AddAnother.prototype.getNewItem = function() {
 
 MOJFrontend.AddAnother.prototype.updateAttributes = function(index, item) {
 	item.find('[data-name]').each(function(i, el) {
+    var originalId = el.id
+
 		el.name = $(el).attr('data-name').replace(/%index%/, index);
 		el.id = $(el).attr('data-id').replace(/%index%/, index);
-		($(el).siblings('label')[0] || $(el).parents('label')[0]).htmlFor = el.id;
+
+    var label = $(el).siblings('label')[0] || $(el).parents('label')[0] || item.find('[for="' + originalId + '"]')[0];
+		label.htmlFor = el.id;
 	});
 };
 


### PR DESCRIPTION
### Identify the bug

This was identified by @owen-bennett123 in #185

When a text input has affixes, it is wrapped in a `.govuk-input__wrapper` div, meaning its label is
no longer adjacent. This caused the Add anotehr component to fail, because it couldn't find the
input's label and update its for/id link.

### Description of the change

I've added a new strategy for finding the label: if it's not the parent or adjacent, then JavaScript
identifies it by searching for a label whose `for` attribute is the ID of the original input.

This should not introduce any regressions because the previous strategies are still in place and
prioritised: the new strategy will only be used if nothing was found, which would have previously
resulted in the application crashing.

I also did some cleanup:
 - Removed an unnecessary `script.js` from the Add another example
 - Restored the README for the Add another component (accidentally removed in a previous commit)

### Alternative designs

- I considered looking at the parent `.govuk-form-group` and finding the label inside it, but would cause issues with components that have multiple labels (like checkboxes or date inputs)
- I considered _only_ using my new strategy, rather than bothering to look for parent or adjacent labels, but that would have been a breaking change

### Verification process

I manually edited the [Add another example](https://design-patterns.service.justice.gov.uk/examples/add-another/), adding a prefix to the text inputs. I also copied the original example from the DWP repo in #185.

### Release notes

- fix(add-another): find labels of affixed text inputs

fixes #185
