### PR TITLE
Remove duplicated installation guidance

### DIFF
--- a/docs/components/add-another.md
+++ b/docs/components/add-another.md
@@ -3,33 +3,24 @@ layout: layouts/component.njk
 title: Add another
 ---
 
-Use the add another component to let users add multiple items of the same thing.
-
 {% lastUpdated "add-another" %}
 
 {% example "/examples/add-another", 664 %}
-
-## When to use this component
+## When to use
 
 Use the add another component when you need to let users enter variations of information multiple times, such as several names for a single application.
 
-## When not to use this component
+## When not to use
 
 Don’t use the add another component if you need to let users enter information which varies differently or is not similar. Or if one field is dependent on the answer to the previous.
 
-## How it works
-
-There are 2 ways to use the add another component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 The add another component uses JavaScript. When JavaScript is not available, the page will reload with the additional form elements added to the page.
 
-## Research on this component
+## Research
 
 This component has been tested in prototypes of several citizen and internal products, including:
 
 - Claim fees for Crown court defence (Legal Aid Agency)
 - Moving People Safely (Her Majesty’s Prison and Probation Service)
-
-## Contribute to this component
-
-You can contribute to this component via the design system backlog

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -9,19 +9,16 @@ The [Tag component](https://design-system.service.gov.uk/components/tag/) in the
 You should consider using the GOV.UK version if it fits your needs.
 {% endbanner %}
 
-Use the badge component to highlight small details like an urgent case.
-
 {% lastUpdated "badge" %}
 
 {% example "/examples/badge", 125 %}
+## When to use
 
-## When to use this component
+Use the badge component to highlight small details like an urgent case.
 
 The badge is useful for drawing users attention to particular information. It should be used sparingly because when used a lot it loses its value.
 
-## How it works
-
-There are 2 ways to use the badge component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 The default, neutral badge is blue. Alternative styles are also available, for example, green and red.
 
@@ -169,14 +166,10 @@ There are a number of additional colour styles that can be used:
 </tbody>
 </table>
 
-## Research on this component
+## Research
 
 This component has been used successfully in the following services:
 
 - Claim fees for Crown court defence (Legal Aid Agency)
 - Prisoner Escort Request (Her Majesty’s Prison and Probation Service)
 - Professional case manager (Her Majesty’s Courts and Tribunals Service)
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/26)

--- a/docs/components/banner.md
+++ b/docs/components/banner.md
@@ -9,23 +9,21 @@ The [Notification banner component](https://design-system.service.gov.uk/compone
 You should consider using the GOV.UK version if it fits your needs.
 {% endbanner %}
 
-Use the banner component to display a prominent message and related actions to take.
-
 {% lastUpdated "banner" %}
 
 {% example "/examples/banner", 225 %}
 
-## When to use this component
+## When to use
+
+Use the banner component to display a prominent message and related actions to take.
 
 Use this component when users might be performing an action repeatedly. For example, when a judge creates a batch of questions for sending to the citizen.
 
-## When not to use this component
+## When not to use
 
-For rarely performed or important actions, you should use the [Confirmation Page](https://design-system.service.gov.uk/patterns/confirmation-pages/) pattern.
+For rarely performed or important actions, you should use the [Confirmation Page](https://design-system.service.gov.uk/patterns/confirmation-pages/) pattern in the GOV.UK Design System.
 
-## How it works
-
-There are 2 ways to use the banner component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 The banner should be displayed at the top of the page above the main heading and below the back link if there is one.
 
@@ -48,13 +46,3 @@ Use this variant when you want to warn the user that something went wrong.
 Use this variant when you want to tell users some information.
 
 {% example "/examples/banner-information", 175 %}
-
-## Research on this component
-
-This component is marked as experimental because it needs more research.
-
-If you have used the banner component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/36)

--- a/docs/components/button-menu.md
+++ b/docs/components/button-menu.md
@@ -3,23 +3,21 @@ layout: layouts/component.njk
 title: Button menu
 ---
 
-Use the button menu component to group buttons together in a row or collapsible menu.
-
 {% lastUpdated "button-menu" %}
 
 {% example "/examples/button-menu", 175 %}
 
-## When to use this component
+## When to use
+
+Use the button menu component to group buttons together in a row or collapsible menu.
 
 Use this component when the there are a number of possible actions the user can take.
 
-## When not to use this component
+## When not to use
 
 Don't use this component when a basic in-page form has multiple actions.
 
-## How it works
-
-There are 2 ways to use the button menu component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 By default this component just groups buttons together to ensure they are spaced correctly. But can be turned into a toggle menu at a configurable screen width that:
 
@@ -37,11 +35,3 @@ Use the grey clour when it's not the main action the user needs to take.
 Use the green colour when it's the main action the user needs to take.
 
 {% example "/examples/button-menu-collapsible-alternative", 250 %}
-
-## Research on this component
-
-We need more research. If you have used the button menu component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/39)

--- a/docs/components/currency-input.md
+++ b/docs/components/currency-input.md
@@ -8,25 +8,17 @@ title: Currency input
 You should use [prefixes and suffixes](https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes) in the GOV.UK Design System to help users enter things like currencies.
 {% endbanner %}
 
-
-
-
-
-
-
-Use the currency input component to help users enter an amount of money in a specified currency.
-
 {% lastUpdated "currency-input" %}
 
 {% example "/examples/currency-input", 200 %}
 
-## When to use this component
+## When to use
+
+Use the currency input component to help users enter an amount of money in a specified currency.
 
 Use the currency input component when you need users to tell you an amount of money in a particular currency, for example pounds sterling, euros or dollars.
 
-## How it works
-
-There are 2 ways to use the currency input component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 The component uses `type="text"` rather than `type="number"` to ensure that all users can enter the decimal symbol. The pattern attribute is used to trigger a numeric keypad on iOS devices.
 
@@ -34,14 +26,10 @@ The input does not prevent users from typing invalid numbers because that makes 
 
 The currency symbol is styled differently to the input so that users don't confuse it with the input's value.
 
-## Research on this component
+## Research
 
 The design, code and guidance here are based on [recommendations from the community](https://github.com/alphagov/govuk-design-system-backlog/issues/68).
 
 This component has been used successfully in the following services:
 
 - Claim fees for Crown court defence (Legal Aid Agency)
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/9)

--- a/docs/components/filter.md
+++ b/docs/components/filter.md
@@ -3,13 +3,15 @@ layout: layouts/component.njk
 title: Filter
 ---
 
-Use the filter component to let users filter a large list of items.
-
 {% lastUpdated "filter" %}
 
 {% example "/examples/filter", 1000 %}
 
-## How it works
+## When to use
+
+Use the filter component to let users filter a large list of items.
+
+## How to use
 
 You should use this component with the filter layout as shown in the [filter a list](../../patterns/filter-a-list) pattern.
 
@@ -18,13 +20,3 @@ The filter component can consist of any form control like radio buttons, checkbo
 Users can select 1 or more filters and submit the form. The page refreshes to show the items that match the filters. The selected filters are also marked at the top of the filter to let users see what they've selected and remove them easily.
 
 Clicking on a selected filter, refreshes the page and removes the filter.
-
-## Research on this component
-
-This component is marked as experimental because it needs more research.
-
-If you have used the filter component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/2)

--- a/docs/components/form-validator.md
+++ b/docs/components/form-validator.md
@@ -3,24 +3,18 @@ layout: layouts/component.njk
 title: Form validator
 ---
 
-Use the form validator component to validate forms without a server-side round-trip while also conforming to the established standards set out in the [GOV.UK Design System](https://design-system.service.gov.uk/).
-
 {% lastUpdated "form-validator" %}
 
 {% example "/examples/form-validator", 1000 %}
 
-## How it works
+## When to use
+
+Use the form validator component to validate forms without a server-side round-trip while also conforming to the established standards set out in the [GOV.UK Design System](https://design-system.service.gov.uk/).
+
+## How to use
 
 In alignment with established GOV.UK Design System standards:
 
 - validation is performed on submit. Forms should never be validated as the user types or blurs the field.
 - when the form is submitted with errors, focus moves to the error summary; errors are shown above the field and the `<title>` is prefixed with the error count.
 - submit buttons are never disabled.
-
-## Research on this component
-
-We need more research. If you have used the form validator component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/37)

--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -3,24 +3,20 @@ layout: layouts/component.njk
 title: Header
 ---
 
-Use the header component for any service or system not on GOV.UK like internal staff.
-
-Do not use this for citizen-facing services.
-
 {% lastUpdated "header" %}
 
 {% example "/examples/header", 150 %}
 
-## How it works
+## When to use
 
-There are 2 ways to use the header component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+Use the header component for any service or system not on GOV.UK like internal staff.
 
-The name of the organisation and service or system appears in the top left. You can also add global links in the top right. For example, "Profile" and "Sign out".
+## When not to use
 
-## Research on this component
+Do not use this for citizen-facing services.
 
-We need more research. If you have used the header component, get in touch to share your research findings.
+## How to use
 
-## Contribute to this component
+The name of the organisation and service appears in the top left. 
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/7)
+You can also add global links in the top right. For example, "Sign out".

--- a/docs/components/identity-bar.md
+++ b/docs/components/identity-bar.md
@@ -3,23 +3,21 @@ layout: layouts/component.njk
 title: Identity bar
 ---
 
-Use the identity bar component to give users context of where they are within a service such as viewing a case.
-
 {% lastUpdated "identity-bar" %}
 
 {% example "/examples/identity-bar", 150 %}
 
-## When to use this component
+## When to use
+
+Use the identity bar component to give users context of where they are within a service such as viewing a case.
 
 This component is helpful when an entity consists of additional [sub sections](../sub-navigation).
 
-## When not to use this component
+## When not to use
 
 Don't use this component if there's only one details page. For example, clicking a case in a case list and seeing a single page of information about the case.
 
-## How it works
-
-There are 2 ways to use the identity bar component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 ### Action menu
 
@@ -38,11 +36,3 @@ The action menu uses the [menu](../button-menu) component which can be configure
 This [menu](../button-menu) is made up of multiple menus. The first consists of just one button and is exposed because it's a primary action. The second menu consists of two secondary options, which are placed within a drop down menu.
 
 {% example "/examples/identity-bar-secondary-toggle", 225 %}
-
-## Research on this component
-
-We need more research. If you have used the identity bar component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/38)

--- a/docs/components/messages.md
+++ b/docs/components/messages.md
@@ -3,27 +3,17 @@ layout: layouts/component.njk
 title: Messages
 ---
 
-Use the messages component to display a list of messages in chronological order.
-
 {% lastUpdated "messages" %}
 
 {% example "/examples/messages", 500 %}
 
-## When to use this component
+## When to use
 
 Use this component in your service to display a list of messages in chronological order between different people or systems. For example, between case workers and legal professionals.
 
-## How it works
-
-There are 2 ways to use the messages component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
-
-## Research on this component
+## Research
 
 This component has been used in:
 
 - Claim fees for Crown court defence (Legal Aid Agency)
 - Track a query (Ministry of Justice)
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/14)

--- a/docs/components/multi-file-upload.md
+++ b/docs/components/multi-file-upload.md
@@ -3,27 +3,23 @@ layout: layouts/component.njk
 title: Multi file upload
 ---
 
-Use the multi file upload component to help users upload multiple files at the same time.
-
 {% lastUpdated "multi-file-upload" %}
 
 {% example "/examples/multi-file-upload", 550 %}
 
-## When to use this component
+## When to use
 
-The multi file upload component can be useful if you need to let users upload multiple files at once, on a regular basis. For example, in a caseworking system.
+Use the multi file upload component to help users upload multiple files at the same time, on a regular basis. For example, in a caseworking system.
 
-## When not to use this component
+## When not to use
 
 Do not use this component if users only need to [upload one file](../../patterns/upload-files).
 
-Uploading multiple files at the same time is more error prone than [uploading files, one at a time](../../patterns/upload-files). This is because users have to use a custom form control that may not be as easy to understand.
+Uploading multiple files at the same time is more error prone than uploading files, one at a time. This is because users have to use a custom form control that may not be as easy to understand.
 
 For this reason, do not use this component unless research shows that users need a faster way to upload files.
 
-Read more about how to [ask users to upload files](../../patterns/upload-files).
-
-## How it works
+## How to use
 
 The multi file upload consists of a dropzone and feedback area which starts off hidden.
 
@@ -83,13 +79,3 @@ You can include a check screen at this point if you need to.
 ### Error messages
 
 Use the file upload error messages [from the GOV.UK Design System](https://design-system.service.gov.uk/components/file-upload/#error-messages).
-
-## Research on this component
-
-This component is marked as experimental because it needs more research.
-
-If you have used the multi file upload component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/1)

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -3,20 +3,14 @@ layout: layouts/component.njk
 title: Multi select
 ---
 
-Use the multi select component to let users select multiple items in a list.
-
 {% lastUpdated "multi-select" %}
 
 {% example "/examples/multi-select", 650 %}
 
-## How it works
+## When to use
 
-There are 2 ways to use the multi select component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).
+Use the multi select component to let users select multiple items in a list.
 
-## Research on this component
+## How to use
 
-We need more research. If you have used the multi select component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/40)
+If you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -15,7 +15,7 @@ This component is in the GOV.UK Design System [community backlog](https://design
 
 ## When to use
 
-The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are.
+The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are. 
 
 Only use it if the number changes when the user performs an action.
 ## When not to use

--- a/docs/components/organisation-switcher.md
+++ b/docs/components/organisation-switcher.md
@@ -3,28 +3,18 @@ layout: layouts/component.njk
 title: Organisation switcher
 ---
 
-Use the organisation switcher component to let users navigate between different organisations or accounts like switching between prisons.
-
 {% lastUpdated "organisation-switcher" %}
 
 {% example "/examples/organisation-switcher", 125 %}
 
-## When to use this component
+## When to use
 
-Use the organisation switcher component to let users navigate between different organisations or accounts, for example, switching between prisons. This component comes directly after the header, or phase banner if there is one.
+Use the organisation switcher component to let users navigate between different organisations or accounts, for example, switching between prisons.
 
-## When not to use this component
+## When not to use
 
 Do not use this component if the user has access to only one organisation.
 
-## How it works
+## How to use
 
-There are 2 ways to use the organisation switcher component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
-
-## Research on this component
-
-We need more research. If you have used the organisation switcher component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/3)
+This component comes directly after the header, or phase banner if there is one.

--- a/docs/components/page-header-actions.md
+++ b/docs/components/page-header-actions.md
@@ -3,31 +3,23 @@ layout: layouts/component.njk
 title: Page header actions
 ---
 
-Use the page header actions component for certain actions.
-
 {% lastUpdated "page-header-actions" %}
 
 {% example "/examples/page-header-actions", 150 %}
 
-## When to use this component
+## When to use
+
+Use the page header actions component for certain actions.
 
 Use this when:
 
 - the content of the page is so long that users have to scroll past it to see actions. For example, having a “Create case” button underneath a long list of cases.
 - the action is applied to the page item and not one specific part of the content. For example, in a user profile page, it could make sense to put the “Suspend user” action in the header.
 
-## When not to use this component
+## When not to use
 
 Don’t place buttons next to the header when they are specific to a component within the page.
 
-## How it works
+## How to use
 
 The component ensures the buttons are aligned right in line with the heading. On small screens the buttons tuck underneath the heading.
-
-## Research on this component
-
-We need more research. If you have used the page header actions component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/42)

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -3,15 +3,15 @@ layout: layouts/component.njk
 title: Pagination
 ---
 
-Use the pagination component to let users browse through a long list.
-
 {% lastUpdated "pagination" %}
 
 {% example "/examples/pagination", 125 %}
 
-## How it works
+## When to use
 
-There are 2 ways to use the pagination component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+Use the pagination component to let users browse through a long list.
+
+## How to use
 
 The component can be configured to hide or show the result count, previous and next buttons, ellipses or numbers.
 
@@ -20,11 +20,3 @@ Don't show pagination if there's only one page.
 ### Just previous and next buttons
 
 {% example "/examples/pagination-prev-next", 125 %}
-
-## Research on this component
-
-We need more research. If you have used the pagination component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/13)

--- a/docs/components/password-reveal.md
+++ b/docs/components/password-reveal.md
@@ -3,20 +3,10 @@ layout: layouts/component.njk
 title: Password reveal
 ---
 
-Use the password reveal component to let users check their password safely.
-
 {% lastUpdated "password-reveal" %}
 
 {% example "/examples/password-reveal", 175 %}
 
-## When to use this component
+## When to use
 
 Use the password reveal component to let users check their password safely.
-
-## Research on this component
-
-We need more research. If you have used the password reveal component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/43)

--- a/docs/components/primary-navigation.md
+++ b/docs/components/primary-navigation.md
@@ -3,11 +3,15 @@ layout: layouts/component.njk
 title: Primary navigation
 ---
 
-Use the primary navigation component to let users navigate and search your service.
-
 {% lastUpdated "primary-navigation" %}
 
 {% example "/examples/primary-navigation", 150 %}
+
+## When to use
+
+Use the primary navigation component to let users navigate and search your service.
+
+## How to use
 
 You must use this component with the [header](../header) component.
 
@@ -30,11 +34,3 @@ If your service can only search for certain things, use a toggle search form.
 You must tell users what they are searching for in the form hint text, and how they can search using the `data-moj-search-toggle-text` attribute.
 
 {% example "/examples/primary-navigation-toggle-search", 250 %}
-
-## Research on this component
-
-We need more research. If you have used the primary navigation component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/46)

--- a/docs/components/rich-text-editor.md
+++ b/docs/components/rich-text-editor.md
@@ -3,27 +3,21 @@ layout: layouts/component.njk
 title: Rich text editor
 ---
 
-Use the rich text editor component to let users format their input in a textarea.
-
 {% lastUpdated "rich-text-editor" %}
 
 {% example "/examples/rich-text-editor", 300 %}
 
-### Customise formatting options
+## When to use
 
-You can customise the formatting options shown in the toolbar with the `data-moj-rich-text-editor-toolbar` attribute.
+Use the rich text editor component to let users format their input in a textarea.
 
-{% example "/examples/rich-text-editor-formatting", 300 %}
-
-## When not to use this component
+## When not to use
 
 Don't use this if the user only needs to send a short, simple message.
 
-## How it works
+## How to use
 
-There are 2 ways to use the rich text editor component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
-
-## Configuration
+### Customise formatting options
 
 By default, the toolbar has bullet and numbered list buttons. You can turn these off if you don't need them.
 
@@ -32,10 +26,9 @@ You can also add bold, underline and italic buttons but these styles should be u
 - underlined text can be confused with links
 - bold and italic should be used sparingly
 
-## Research on this component
+You can customise the formatting options shown in the toolbar with the `data-moj-rich-text-editor-toolbar` attribute.
 
-We need more research. If you have used the rich text editor component, get in touch to share your research findings.
+{% example "/examples/rich-text-editor-formatting", 300 %}
 
-## Contribute to this component
 
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/44)
+

--- a/docs/components/search.md
+++ b/docs/components/search.md
@@ -3,22 +3,14 @@ layout: layouts/component.njk
 title: Search
 ---
 
-Use the search component to let users search by word or phrase. This can be used within the [Primary Navigation](../primary-navigation/) component.
-
 {% lastUpdated "search" %}
 
 {% example "/examples/search", 200 %}
 
-## How it works
+## When to use
 
-There are 2 ways to use the search component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+Use the search component to let users search by word or phrase. This can be used within the [Primary Navigation](../primary-navigation/) component.
+
+## How to use
 
 You can configure the search form to be inversed on black and to hide and show labels and hints depending on your use case. You'll see examples of this on the [Primary Navigation](../primary-navigation) component page.
-
-## Research on this component
-
-We need more research. If you have used the search component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/24)

--- a/docs/components/side-navigation.md
+++ b/docs/components/side-navigation.md
@@ -3,34 +3,24 @@ layout: layouts/component.njk
 title: Side navigation
 ---
 
-Use the side navigation component to let users navigate sub sections in a system or service.
-
 {% lastUpdated "side-navigation" %}
 
 {% example "/examples/side-navigation", 250 %}
 
-## When to use this component
+## When to use
+
+Use the side navigation component to let users navigate sub sections in a system or service.
 
 Use this component when you have a second level of navigation. See also the [sub navigation](../sub-navigation) component
 
-## When not to use this component
+## When not to use
 
 Do not use this component for primary level items or global navigation items.
 
-## How it works
-
-There are 2 ways to use the side navigation component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+## How to use
 
 The component can be configured to group navigation items into sections
 
 ### Sections
 
 {% example "/examples/side-navigation-sections", 480 %}
-
-## Research on this component
-
-We need more research. If you have used the side navigation component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/33)

--- a/docs/components/sortable-table.md
+++ b/docs/components/sortable-table.md
@@ -3,24 +3,16 @@ layout: layouts/component.njk
 title: Sortable table
 ---
 
-Use the sortable table component to let users sort columns in ascending or descending order.
-
 {% lastUpdated "sortable-table" %}
 
 {% example "/examples/sortable-table", 450 %}
 
-## When to use this component
+## When to use
+
+Use the sortable table component to let users sort columns in ascending or descending order.
 
 Use this component when sorting is needed to help find data within a large table of data. This might be useful in combination with the [filter](../../patterns/filter-a-list) pattern.
 
-## How it works
+## How to use
 
-There are 2 ways to use the sortable table component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).
-
-## Research on this component
-
-We need more research. If you have used the sortable table component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/23)
+If you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).

--- a/docs/components/sub-navigation.md
+++ b/docs/components/sub-navigation.md
@@ -3,28 +3,17 @@ layout: layouts/component.njk
 title: Sub navigation
 ---
 
-Use the sub navigation component to let users navigate sub sections in a system or service.
 
 {% lastUpdated "sub-navigation" %}
 
 {% example "/examples/sub-navigation", 150 %}
 
-## When to use this component
+## When to use
+
+Use the sub navigation component to let users navigate sub sections in a system or service.
 
 Use this component when you have a second level of navigation. See also the [side navigation](../side-navigation) component
 
-## When not to use this component
+## When not to use
 
 Do not use this component for primary level items or global navigation items.
-
-## How it works
-
-There are 2 ways to use the sub navigation component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
-
-## Research on this component
-
-We need more research. If you have used the sub navigation component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/4)

--- a/docs/components/tag.md
+++ b/docs/components/tag.md
@@ -111,7 +111,3 @@ Additional colours are below, which are not in the GOV.UK Design System.
 </table>
 
 {% lastUpdated "tag" %}
-
-## Contribute to this component
-
-You can contribute to this component in the [GOV.UK Design System](https://design-system.service.gov.uk/components/tag/#help-improve-this-page)

--- a/docs/components/timeline.md
+++ b/docs/components/timeline.md
@@ -3,20 +3,11 @@ layout: layouts/component.njk
 title: Timeline
 ---
 
-Use the timeline component to show a linear record of what’s happened.
-
 {% lastUpdated "timeline" %}
 
 {% example "/examples/timeline", 454 %}
 
-## How it works
+## When to use
 
-There are 2 ways to use the timeline component. You can use HTML or, if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks macro.
+Use the timeline component to show a linear record of what’s happened.
 
-## Research on this component
-
-We need more research. If you have used the timeline component, get in touch to share your research findings.
-
-## Contribute to this component
-
-You can contribute to this component via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/45)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,9 @@ To make your service consistent with GOV.UK, you should:
 
 The MOJ Pattern Library brings together [components](./components) and [patterns](./patterns) created by designers and developers at MOJ.
 
-To contribute your research findings, designs or code to contribute, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
+To use these components and patterns you can either:
 
+- copy the HTML code
+- copy the Nunjucks code (if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)) 
 
-
-
-
+To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>

--- a/docs/patterns/filter-a-list.md
+++ b/docs/patterns/filter-a-list.md
@@ -3,19 +3,17 @@ layout: layouts/patterns.njk
 title: Filter a list
 ---
 
-Use this pattern to let users filter a list of items.
-
 {% example "/examples/patterns/filter-a-list", 1050 %}
 
-## When to use this pattern
+## When to use
 
 Use this pattern to help users refine a set of items either in a list or a set of search results. This pattern should be used instead of advanced search.
 
-## When not to use this pattern
+## When not to use
 
 Don't use this pattern if there aren't many items to filter.
 
-## How it works
+## How to use
 
 The list should first appear unfiltered. After selecting one or more filters, the user submits the form which filters the list.
 
@@ -28,11 +26,3 @@ Filters can be used in combination with [search](../../components/search/). In t
 1. Type a search term and submit the search form
 2. See a search results page with filters
 3. Users can then filter the search results page further or search again starting from (1)
-
-## Research on this pattern.
-
-We need more research. If you have used the filter a list pattern, get in touch to share your research findings.
-
-## Contribute to this pattern
-
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/2)

--- a/docs/patterns/get-help.md
+++ b/docs/patterns/get-help.md
@@ -3,17 +3,13 @@ layout: layouts/patterns.njk
 title: Get help
 ---
 
-Help users get help from within the digital service.
-
 {% example "/examples/patterns/get-help", 250 %}
 
-## When to use this pattern
+## When to use
 
-Use this component at the bottom of every page of your service.
+Help users get help from within the digital service.
 
-Each service will need to determine the best combination of help channels they offer to users. They will also need to determine the response time.
-
-## How it works
+## How to use
 
 Put the component at the bottom of every page of your service.
 
@@ -26,6 +22,7 @@ Determine which combination of channels are best for your service:
 
 You'll need to get agreement of where issues will be sent, who will read it and who will respond to it.
 
+Each service will need to determine the best combination of help channels they offer to users. They will also need to determine the response time.
 ### Contact form
 
 Contact form fields can include:
@@ -43,11 +40,3 @@ The form should also send additional data automatically like:
 - date and time of submission
 
 This will let customer support staff triage the issue and respond quickly.
-
-## Research on this pattern
-
-We need more research. If you have used the support, get in touch to share your research findings.
-
-## Contribute to this pattern
-
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/47)

--- a/docs/patterns/task-list.md
+++ b/docs/patterns/task-list.md
@@ -10,6 +10,6 @@ title: Task list pages
 A coded example of a task list is below, which is not yet in the GOV.UK Design System. There is also a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) in the GOV.UK Prototype Kit.
 
 {% example "/examples/task-list", 600 %}
-## Contribute to this pattern
+## Contribute
 
 You can contribute to this pattern in the [GOV.UK Design System](https://design-system.service.gov.uk/patterns/task-list-pages/#help-improve-this-page)

--- a/docs/patterns/upload-files.md
+++ b/docs/patterns/upload-files.md
@@ -5,11 +5,11 @@ title: Upload files
 
 ![A three step process: Ask the user to upload a file, use the native file browser, and then show them the upload and ask them to confirm it](../../assets/images/upload-file-single.png)
 
-## When to use this pattern
+## When to use
 
 Use this pattern whenever you need users to upload one or more files.
 
-## When not to use this pattern
+## When not to use
 
 Do not ask users to upload files unless you really need to in order to deliver your service.
 
@@ -20,7 +20,7 @@ Uploading files can involve a number of interactions that users might find chall
 - selecting a file from a folder
 - waiting for a file to be uploaded
 
-## How it works
+## How to use
 
 How you help users upload files depends on whether they need to upload:
 
@@ -95,13 +95,3 @@ If you do this, you can store the original file and give users the option to vie
 ### Error messages
 
 Use the [file upload error messages from the GOV.UK Design System](https://design-system.service.gov.uk/components/file-upload/#error-messages).
-
-## Research on this pattern
-
-This pattern is marked as experimental because it needs more research.
-
-If you have used the file upload pattern, get in touch to share your research findings.
-
-## Contribute to this pattern
-
-You can contribute to this pattern via the [design system backlog](https://github.com/ministryofjustice/moj-design-system-backlog/issues/1)


### PR DESCRIPTION
### Description of the change

The following changes have been made with the primary motivation to reduce cognitive load:

- Remove duplicate installation guidance on components and patterns which exists on the landing pages
- Shorten headers referencing HMRC Design Patterns
- Remove empty sections until further information is added, for example 'Research' and 'Contribute'

|Before |After  |
--- | ---
|![design-patterns service justice gov uk_components_header_(iPad Pro) (1)](https://user-images.githubusercontent.com/6122118/123943651-47ec7c80-d994-11eb-9aa5-b688f482312a.png) |![localhost_8080_components_header_(iPad Pro)](https://user-images.githubusercontent.com/6122118/123943701-533fa800-d994-11eb-829a-1ec6d4c58025.png) |

### Release notes

Users will be able to more clearly see the how developed the components and patterns guidance is.