### PR TITLE
docs: update component categories

### DIFF
--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -16,7 +16,34 @@
         sections: [
           {
             heading: {
-              text: "Structure"
+              text: "Form elements"
+            },
+            items: [
+            {
+              text: 'Add another',
+              href: ('/components/add-another' | url)
+            },
+            {
+              text: 'Form validator',
+              href: ('/components/form-validator' | url)
+            },
+            {
+              text: 'Multi file upload',
+              href: ('/components/multi-file-upload' | url)
+            },
+            {
+              text: 'Password reveal',
+              href: ('/components/password-reveal' | url)
+            },
+            {
+              text: 'Rich text editor',
+              href: ('/components/rich-text-editor' | url)
+            }
+            ]
+          },
+          {
+            heading: {
+              text: "Navigation"
             },
             items: [
             {
@@ -34,14 +61,7 @@
             {
               text: 'Organisation switcher',
               href: ('/components/organisation-switcher' | url)
-            }
-            ]
-          },
-          {
-            heading: {
-              text: "Navigation"
             },
-            items: [
             {
               text: 'Primary navigation',
               href: ('/components/primary-navigation' | url)
@@ -78,34 +98,7 @@
           },
           {
             heading: {
-              text: "Forms"
-            },
-            items: [
-            {
-              text: 'Add another',
-              href: ('/components/add-another' | url)
-            },
-            {
-              text: 'Form validator',
-              href: ('/components/form-validator' | url)
-            },
-            {
-              text: 'Multi file upload',
-              href: ('/components/multi-file-upload' | url)
-            },
-            {
-              text: 'Password reveal',
-              href: ('/components/password-reveal' | url)
-            },
-            {
-              text: 'Rich text editor',
-              href: ('/components/rich-text-editor' | url)
-            }
-            ]
-          },
-          {
-            heading: {
-              text: "Content"
+              text: "Content presentation"
             },
             items: [
             {


### PR DESCRIPTION
### Description of the change

The following changes have been made using the [NHS Design System](https://service-manual.nhs.uk/design-system/components) as reference, in order to improve component navigation

- Rename `Content` to `Content presentation` (so as not to be confused with writing)
- Rename `Forms` to `Form elements` (to be clearer it is parts of forms)
- Merge `Structure` and `Navigation` (components like `Header` are seen as a form of navigation)
- Reorder, moving `Form elements` to the top (as they are the most used components)

|Before |After  |
--- | ---
|![design-patterns service justice gov uk_components_notification-badge_(iPad Pro) (1)](https://user-images.githubusercontent.com/6122118/123982769-37033180-d9bb-11eb-898f-490cd30cd668.png) |![localhost_8080_components_notification-badge_(iPad Pro) (4)](https://user-images.githubusercontent.com/6122118/123983250-a0834000-d9bb-11eb-9318-f3ed238b8270.png) |

### Release notes

Users will be able to more clearly find components within the section headers.