### PR TITLE
docs: add question pages pattern

### DIFF
--- a/docs/_includes/layouts/patterns.njk
+++ b/docs/_includes/layouts/patterns.njk
@@ -39,6 +39,10 @@
             },
             items: [
               {
+                text: 'Question pages',
+                href: ('/patterns/question-pages' | url)
+              },
+              {
                 text: 'Task list pages',
                 href: ('/patterns/task-list' | url)
               }

--- a/docs/patterns/question-pages.md
+++ b/docs/patterns/question-pages.md
@@ -1,0 +1,30 @@
+---
+layout: layouts/patterns.njk
+title: Question pages
+---
+
+{% banner "The GOV.UK Design System has similar guidance" %}
+
+- [Question pages](https://design-system.service.gov.uk/patterns/question-pages) is published in the GOV.UK Design System.
+- [Structuring forms](https://www.gov.uk/service-manual/design/form-structure) is published in the GOV.UK Service Manual.
+
+You should consider following the GOV.UK guidance if it fits your needs.
+{% endbanner %}
+
+## Asking multiple questions per page
+
+Before asking multiple questions per page, you should first:
+
+- follow the guidance to [start by asking one question per page](https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page) in The GOV.UK Design System.
+- follow the guidance to [start with one thing per page](https://www.gov.uk/service-manual/design/form-structure#start-with-one-thing-per-page) the GOV.UK Service Manual.
+
+
+User research will tell you if it makes sense to group a number of related questions on the same page. For example, if you’re designing an internal service for government users who need to repeat and switch between tasks quickly.
+
+If user research tells you to group pages together, you should: 
+
+- follow the guidance on [asking multiple questions on a page](asking-multiple-questions-on-a-page) in the GOV.UK Design System.
+
+### Further reading 
+
+- [Design principles for admin interfaces](https://designnotes.blog.gov.uk/2015/09/25/design-principles-for-admin-interfaces/) including more than one thing per page


### PR DESCRIPTION
### Description of the change

- Add 'Question pages' pattern, which communicates the process in MOJ for deciding on whether to use one or multiple questions per page. 

This pattern utilises existing GOV.UK guidance and content, reducing the overhead for maintenance.

|Question pages pattern |
--- 
|![localhost_8080_patterns_question-pages_(iPad Pro)](https://user-images.githubusercontent.com/6122118/124134869-316d2080-da7b-11eb-9eaf-aa7946678119.png) |

### Release notes

Users will be able to read and follow guidance on questions pages and when to use multiple questions per page. 