### PR TITLE
docs: update get started links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,13 +3,16 @@ layout: layouts/get-started.njk
 title: Get started
 ---
 
-To make your service consistent with GOV.UK, you should:
+To make your service consistent with GOV.UK, you should start by checking what exists in the [GOV.UK Design System](https://design-system.service.gov.uk/).
 
-- use the [GOV.UK Design System](https://design-system.service.gov.uk/) 
-- follow the [government design principles](https://www.gov.uk/guidance/government-design-principles).
-- use the MOJ Pattern Library (if you can't find what you need in the GOV.UK Design System)
+If something is not in the GOV.UK Design System, you should check what exists in the:
 
-## About the MOJ Pattern Library 
+- MOJ Pattern Library
+- [other departments pattern libraries](https://github.com/ctdesign/gov-design-systems-list)
+- [GOV.UK community backlog](https://design-system.service.gov.uk/community/backlog/)
+
+Reuse as much as possible and iterate based on user needs.
+## Using the Pattern Library
 
 The MOJ Pattern Library brings together [components](./components) and [patterns](./patterns) created by designers and developers at MOJ.
 
@@ -18,4 +21,6 @@ To use these components and patterns you can either:
 - copy the HTML code
 - copy the Nunjucks code (if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)) 
 
-To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
+## Contributing to the Pattern Library
+
+You can contribute your research findings, designs or code to the MOJ Pattern Library by commenting on [existing discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or starting a [new discussion](https://github.com/ministryofjustice/moj-frontend/discussions/new) on GitHub.


### PR DESCRIPTION
Related issue: https://github.com/ministryofjustice/moj-frontend/issues/211

### Description of the change

Update the 'Get started' page with:

- links to the department design systems and community backlog
- links to GitHub Discussions for contributing

To make the process clearer on what users should do first before using the MOJ Pattern Library, and what they should do if they want to contribute.

This guidance utilises an existing list of department design systems, reducing the overhead for maintenance.

|Before |After  |
--- | ---
|![design-patterns service justice gov uk_(iPad Pro)](https://user-images.githubusercontent.com/6122118/124633395-25b79a80-de7d-11eb-8d5e-d7f6719fc25a.png) |![localhost_8080_(iPad Pro) (1)](https://user-images.githubusercontent.com/6122118/124633453-32d48980-de7d-11eb-9cfe-7a6165af296b.png) |

### Release notes

Users will be able to read and follow guidance on when to use the MOJ Pattern Library and how to contribute.