### PR TITLE
docs: add discussion links to pages

### DIFF
--- a/docs/components/filter.md
+++ b/docs/components/filter.md
@@ -20,3 +20,7 @@ The filter component can consist of any form control like radio buttons, checkbo
 Users can select 1 or more filters and submit the form. The page refreshes to show the items that match the filters. The selected filters are also marked at the top of the filter to let users see what they've selected and remove them easily.
 
 Clicking on a selected filter, refreshes the page and removes the filter.
+
+## Contribute
+
+[Discuss filters on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/197)

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -14,3 +14,7 @@ Use the multi select component to let users select multiple items in a list.
 ## How to use
 
 If you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).
+
+## Contribute
+
+[Discuss multi select on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/206)

--- a/docs/patterns/add-to-a-list.md
+++ b/docs/patterns/add-to-a-list.md
@@ -70,7 +70,7 @@ This pattern:
 
 ## Contribute 
 
-[Join the discussion](https://github.com/ministryofjustice/moj-frontend/discussions/203) on GitHub.
+[Discuss add to a list on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/203)
 
 ### Things we don't know enough about 
 

--- a/docs/patterns/question-pages.md
+++ b/docs/patterns/question-pages.md
@@ -23,8 +23,12 @@ User research will tell you if it makes sense to group a number of related quest
 
 If user research tells you to group pages together, you should: 
 
-- follow the guidance on [asking multiple questions on a page](asking-multiple-questions-on-a-page) in the GOV.UK Design System.
+- follow the guidance on [asking multiple questions on a page](https://design-system.service.gov.uk/patterns/question-pages/#asking-multiple-questions-on-a-page) in the GOV.UK Design System.
 
 ### Further reading 
 
 - [Design principles for admin interfaces](https://designnotes.blog.gov.uk/2015/09/25/design-principles-for-admin-interfaces/) including more than one thing per page
+
+## Contribute 
+
+[Discuss question pages on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/215)


### PR DESCRIPTION
### Description of the change

Add discussion links to these pages:

- Filter
- Multi select
- Add to a list
- Question pages

### Release notes

Users will be able to navigate to discussion pages on these components and patterns. 