### PR TITLE
docs: rename to "MOJ Pattern Library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.
 
-See live examples of MOJ Frontend components, and guidance on when to use them in your service, in the [MOJ Design System](https://design-patterns.service.justice.gov.uk/).
+See live examples of MOJ Frontend components, and guidance on when to use them in your service, in the [MOJ Pattern Library documentation](https://design-patterns.service.justice.gov.uk/).
 
 ## Contribution Guidelines
 
@@ -22,7 +22,7 @@ MOJ Frontend is maintained by staff in the Ministry of Justice. If you need supp
 
 We recommend [installing MOJ Frontend using node package manager (npm)](https://design-patterns.service.justice.gov.uk/get-started/installing-with-npm/).
 
-Once installed, you will be able to use the code from the examples in the [MOJ Design System](https://design-patterns.service.justice.gov.uk/) in your service.
+Once installed, you will be able to use the code from the examples in the [MOJ Pattern Library](https://design-patterns.service.justice.gov.uk/) in your service.
 
 ## Browser support
 

--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -17,7 +17,7 @@
 
     <!--[if lte IE 8]><link href="{{ '/assets/stylesheets/application-ie8.css' | url }}" rel="stylesheet"><![endif]-->
     <!--[if gt IE 8]><!--><link href="{{ '/assets/stylesheets/application.css' | url }}" rel="stylesheet"><!--<![endif]-->
-    <title>{{ title }} - MOJ Design System</title>
+    <title>{{ title }} - MOJ Pattern Library</title>
 
     <script type="text/javascript" src="{{ '/assets/javascript/jquery.js' | url }}"></script>
     <script type="text/javascript" src="{{ '/assets/javascript/all.js' | url }}"></script>

--- a/docs/get-started/production.md
+++ b/docs/get-started/production.md
@@ -4,7 +4,7 @@ subsection: How we work
 title: Production
 ---
 
-This guide explains how to set up your project so you can start using the styles and coded examples in the MOJ Design System in production.
+This guide explains how to set up your project so you can start using the styles and coded examples in the MOJ Pattern Library in production.
 
 ## Before you start
 

--- a/docs/get-started/prototyping.md
+++ b/docs/get-started/prototyping.md
@@ -4,21 +4,21 @@ subsection: How we work
 title: Prototyping
 ---
 
-This guide explains how to create prototypes using the MOJ Design System and GOV.UK Prototype Kit.
+This guide explains how to create prototypes using the MOJ Pattern Library and GOV.UK Prototype Kit.
 
 ## Use a template from Cloud Platform
 
 You can follow the [MOJ Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) to automatically set up a GitHub repository containing the GOV.UK Prototype Kit and a hosting environment.
 
-This template comes with the MOJ Design System pre-installed so you don't need to set it up manually. However you may need to update it using [the instructions below](#updating-moj-frontend).
+This template comes with the MOJ Pattern Library pre-installed so you don't need to set it up manually. However you may need to update it using [the instructions below](#updating-moj-frontend).
 
 ## Manual installation
 
-Alternatively, you can install the GOV.UK Prototype Kit and MOJ Design System manually. You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first. Once you've done that, continue below.
+Alternatively, you can install the GOV.UK Prototype Kit and MOJ Pattern Library manually. You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first. Once you've done that, continue below.
 
 ### Installing MOJ Frontend
 
-The MOJ Design System uses MOJ Frontend. To install it, run these steps:
+The MOJ Pattern Library uses MOJ Frontend. To install it, run these steps:
 
 1. open Terminal
 2. change the directory to your prototype. For example, `cd path/to/prototype`

--- a/docs/get-started/setting-up-javascript.md
+++ b/docs/get-started/setting-up-javascript.md
@@ -4,11 +4,11 @@ subsection: How to guides
 title:  Setting up JavaScript
 ---
 
-Several MOJ Design System components use JavaScript to provide interactive features. In order to fully use these components you will need to add some code to your service to set up the JavaScript.
+Several MOJ Pattern Library components use JavaScript to provide interactive features. In order to fully use these components you will need to add some code to your service to set up the JavaScript.
 
 You can either
 
-- include the MOJ Design System's JavaScript code directly in your HTML templates
+- include the MOJ Pattern Library's JavaScript code directly in your HTML templates
 - import the JavaScript using a bundler like Webpack
 
 ## Add the JavaScript file to your HTML

--- a/package/README.md
+++ b/package/README.md
@@ -6,7 +6,7 @@
 
 MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.
 
-See live examples of MOJ Frontend components, and guidance on when to use them in your service, in the [MOJ Design System](https://moj-design-system.herokuapp.com/).
+See live examples of MOJ Frontend components, and guidance on when to use them in your service, in the [MOJ Pattern Library documentation](https://design-patterns.service.justice.gov.uk/).
 
 ## Contribution Guidelines
 
@@ -14,13 +14,15 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 
 ## Contact the team
 
-MOJ Frontend is maintained by the MOJ Design System team. If you need support [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
+MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
+- [#moj-design-system-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
+- [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
 
 ## Quick start
 
-We recommend [installing MOJ Frontend using node package manager (npm)](docs/installation/installing-with-npm.md).
+We recommend [installing MOJ Frontend using node package manager (npm)](https://design-patterns.service.justice.gov.uk/get-started/installing-with-npm/).
 
-Once installed, you will be able to use the code from the examples in the [MOJ Design System](https://moj-design-system.herokuapp.com/) in your service.
+Once installed, you will be able to use the code from the examples in the [MOJ Pattern Library](https://design-patterns.service.justice.gov.uk/) in your service.
 
 ## Browser support
 


### PR DESCRIPTION
Update remaining instances of "MOJ Design System" to "MOJ Pattern Library" to solidify new name. Notably this includes the title suffix.