### PR TITLE
fix(add-another): shrink remove button

### DIFF
--- a/src/moj/components/add-another/_add-another.scss
+++ b/src/moj/components/add-another/_add-another.scss
@@ -16,7 +16,7 @@
 
   &__title {
     float: left;
-    padding: 4px 0;
+    padding: 4px 100px 4px 0;
     width: 100%;
 
     & + .govuk-form-group {
@@ -28,6 +28,7 @@
     position: absolute;
     right: 0;
     top: 0;
+    width: auto;
   }
 
   &__add-button {


### PR DESCRIPTION
The GOV.UK Design System extends buttons to 100% width on small screens. The Add another
component's "Remove" button is absolutely positioned, so it covers up content when it's at 100%
width.

This change shrinks the button back down to `width: auto`, so that it's only as wide as the text
and any content "underneath" can be seen.

I've also added right padding to the title so that it wraps before going underneath the remove
button.

This does reduce the clickable area for the button, which may make it harder for touchscreen users,
however there should not be any other clickable targets nearby, so users are unlikely to press the
wrong thing.

| Before | After |
|--------|-------|
| ![Screenshot 2021-09-15 at 10 59 21](https://user-images.githubusercontent.com/100852/133413561-1fd19d6b-8abf-4966-b482-937d703d18a9.png) | ![Screenshot 2021-09-15 at 10 59 52](https://user-images.githubusercontent.com/100852/133413583-9ef26885-b661-482a-92c4-30569bf7d99d.png) |
