### PR TITLE
docs: fix Slack channel name and GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 ## Contact the team
 
 MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
-- [#moj-design-system-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
+- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
 - [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
 
 ## Quick start

--- a/docs/_includes/layouts/partials/contact-panel.njk
+++ b/docs/_includes/layouts/partials/contact-panel.njk
@@ -1,7 +1,7 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <h2 class="govuk-heading-m">Need help?</h2>
-<p class="govuk-body">You can edit the page via <a href="#" class="govuk-link">GitHub</a>
- or if you’ve got a question, idea or suggestion share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
+<p class="govuk-body">You can edit the page via <a href="https://github.com/ministryofjustice/moj-frontend/tree/main/docs" class="govuk-link">GitHub</a>
+ or if you’ve got a question, idea or suggestion share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-support</a> channel on Slack.</p>
 
  <div class="govuk-!-padding-bottom-7"></div>

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -9,8 +9,8 @@ Components in this section have been created by designers and developers at MOJ.
 To use these components you can either:
 
 - copy the HTML code
-- copy the Nunjucks code (if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)) 
+- copy the Nunjucks code (if you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs))
 
-To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
+To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-support</a> channel on Slack.</p>
 
 If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MOJ component will be [archived](archived-components).

--- a/docs/get-started/deploying-your-prototype.md
+++ b/docs/get-started/deploying-your-prototype.md
@@ -24,7 +24,7 @@ You can also use Heroku to host your prototypes. This is recommended for staff o
 
 You'll need to be a member of the [moj-design](https://dashboard.heroku.com/teams/moj-design/apps) Heroku team and have your prototype in [MOJ's GitHub account](https://github.com/ministryofjustice).
 
-If you don't have access to these, ask in the Slack channel [#moj-design-system-support](https://mojdt.slack.com/messages/moj-design-system-support) and whoever is managing support that day should be able to add you.
+If you don't have access to these, ask in the Slack channel [#moj-pattern-library-support](https://mojdt.slack.com/messages/moj-pattern-library-support) and whoever is managing support that day should be able to add you.
 
 <!-- If you don't know how to setup GitHub read the [version your prototype](#) guide. -->
 

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -5,6 +5,6 @@ title: Patterns
 
 Patterns in this section have been created by designers and developers at MOJ.
 
-To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-design-system-support</a> channel on Slack.</p>
+To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-supportt</a> channel on Slack.</p>
 
 If a similar pattern is in the [GOV.UK Design System](https://design-system.service.gov.uk/patterns/), you should use that pattern instead.

--- a/package/README.md
+++ b/package/README.md
@@ -15,7 +15,7 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 ## Contact the team
 
 MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
-- [#moj-design-system-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
+- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
 - [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
 
 ## Quick start


### PR DESCRIPTION
Update the name of the support channel in Slack, and add a more helpful GitHub link
