### PR TITLE
fix(filter): ensure the clear link is shown

### DIFF
--- a/src/moj/components/filter/_filter.scss
+++ b/src/moj/components/filter/_filter.scss
@@ -163,6 +163,7 @@
 
 .moj-filter__heading-title,
 .moj-filter__heading-action {
+  @include govuk-font(16);
   display: inline-block;
   text-align: left;
   vertical-align: middle;


### PR DESCRIPTION
The parent `font-size:0` rule was cascading to the clear link, meaning it wasn't shown. By adding an
explicit font size to it, we can ensure it is shown.

fixes #274