### PR TITLE
Add a default aria-label for sub navigation component

### DIFF
--- a/docs/_includes/arguments/sub-navigation.md
+++ b/docs/_includes/arguments/sub-navigation.md
@@ -1,11 +1,11 @@
 ### Container
 
-| Name       | Type   | Required | Description                                                                  |
-| ---------- | ------ | -------- | ---------------------------------------------------------------------------- |
-| label      | string | No       | The `aria-label` to add to the `nav` container.                              |
-| items      | array  | Yes      | An array of navigation item objects. See [items](#items).                    |
-| classes    | string | No       | Classes to add to the `nav` container.                                       |
-| attributes | object | No       | HTML attributes (for example data attributes) to add to the `nav` container. |
+| Name       | Type   | Required | Description                                                                                |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------------ |
+| label      | string | No       | The `aria-label` to add to the `nav` container. Defaults to 'Secondary navigation region'. |
+| items      | array  | Yes      | An array of navigation item objects. See [items](#items).                                  |
+| classes    | string | No       | Classes to add to the `nav` container.                                                     |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the `nav` container.               |
 
 ### Items
 

--- a/src/moj/components/sub-navigation/template.njk
+++ b/src/moj/components/sub-navigation/template.njk
@@ -1,4 +1,4 @@
-<nav class="moj-sub-navigation {{- ' ' + params.classes if params.classes}}" {%- if (params.label) %} aria-label="{{ params.label }}"{% endif %} {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
+<nav class="moj-sub-navigation {{- ' ' + params.classes if params.classes}}" aria-label="{{ params.label or 'Secondary navigation region' }}" {%- for attribute, value in params.attributes -%} {{ attribute }}="{{ value }}"{% endfor %}>
 
   <ul class="moj-sub-navigation__list">
 


### PR DESCRIPTION
### Issue or RFC endorsed by the maintainers

Rather than opening an issue, I thought I'd use this PR for any necessary discussion, because the code change itself is small.

### Description of the change

[hmpps-manage-supervisions](https://github.com/ministryofjustice/hmpps-manage-supervisions) recently underwent a [DAC accessibility review](https://digitalaccessibilitycentre.org/). One of the issues they brought up in their audit was the lack of an `aria-label` on the sub navigation element in the app.

This PR sets a default `label` property on `mojSubNavigation` of "Secondary navigation region".

It looks like this in the accessibility inspector:

![image](https://user-images.githubusercontent.com/1650875/141307619-ec619545-c7a3-4351-bb2e-5cfda6444e79.png)


### Alternative designs

`label` could be made into a required property and produce a build error when it's not specified. This would break most apps that update to the latest version of the design system. I think silently filling in a sensible default is less friction for users of the design system.

### Possible drawbacks

An app updating to this version could conceivably already have a different navigation region which is coincidentally also called "Secondary navigation region", and a navigation region without a label, which would default to the same label. This wouldn't break anything, but it could slightly confuse assistive technology users, as there would now be two regions that are named the same. I think it is highly unlikely that someone would do this in practice, filling in a label for one region but not another.

### Verification process

I didn't spend much time on this yet as I'm waiting for feedback. Follow-up work on this PR:

- [x] Write automated tests if deemed necessary
- [x] Update documentation for this option

### Release notes

- Add a default aria-label for sub navigation component
