### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @ministryofjustice/mojds-maintainers


### PR DESCRIPTION
Specify MOJ Enablers as code owners so all PRs can require their final approval. We can review this in the future, e.g. assigning `/docs/` to all org members