### PR TITLE
fix attributes in pagination's template.njk

### DIFF
--- a/src/moj/components/pagination/template.njk
+++ b/src/moj/components/pagination/template.njk
@@ -1,6 +1,6 @@
-<nav class="moj-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label">
+<nav class="moj-pagination {{- ' ' + params.classes if params.classes}}" aria-labelledby="pagination-label">
 
-  <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
+  <p class="govuk-visually-hidden" id="pagination-label">Pagination navigation</p>
 
   <ul class="moj-pagination__list">
     {%- if params.previous %}


### PR DESCRIPTION
### Identify the bug

`id` and `aria-labelledby` attributes were swapped resulting in screen readers not reading out the pagination label

### Description of the change
Swapped the attributes

### Alternative designs

N/A

### Possible drawbacks
None

### Verification process

Tested with NVDA

### Release notes
N/A