### PR TITLE
docs: remove reference to TinyMCE

### DIFF
--- a/docs/components/archived-components.md
+++ b/docs/components/archived-components.md
@@ -33,7 +33,7 @@ For more complex validation, use an accessible validation library.
 
 This component was deemed not sufficiently accessible to be used in live services and too complex to maintain.
 
-You should use an accessible rich text editor like [TinyMCE](https://www.tiny.cloud/tinymce/).
+You should use an accessible rich text editor.
 
 ## Tag
 

--- a/docs/components/rich-text-editor.md
+++ b/docs/components/rich-text-editor.md
@@ -7,7 +7,7 @@ title: Rich text editor
 
 This component is not sufficiently accessible to be used in live services.
 
-You should use an accessible rich text editor like [TinyMCE](https://www.tiny.cloud/tinymce/).
+You should use an accessible rich text editor.
 {% endbanner %}
 
 {% lastUpdated "rich-text-editor" %}


### PR DESCRIPTION
It's not suitably accessible to specifically suggest. If we find an accessible rich text editor in the future, we'll add that in here instead.