### PR TITLE
docs: fix accessibility and usability issues

### DIFF
--- a/assets/sass/application.scss
+++ b/assets/sass/application.scss
@@ -16,6 +16,7 @@ $govuk-assets-path: "../" !default;
 @import "./components/back-to-top";
 @import "./components/copy-button";
 @import "./components/example";
+@import "./components/flex-container";
 @import "./components/markdown";
 @import "./components/masthead";
 @import "./components/panel";

--- a/assets/sass/components/flex-container.scss
+++ b/assets/sass/components/flex-container.scss
@@ -1,0 +1,4 @@
+/** Causes child elements to fill vertical space, allowing `position:sticky` to work as intended */
+.app-flex-container {
+  display: flex;
+}

--- a/assets/sass/components/flex-container.scss
+++ b/assets/sass/components/flex-container.scss
@@ -1,4 +1,6 @@
 /** Causes child elements to fill vertical space, allowing `position:sticky` to work as intended */
 .app-flex-container {
-  display: flex;
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+  }
 }

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -2,7 +2,7 @@
   <span class="app-example__new-window">
     <a href="{{ href | url }}" target="_blank">Open this example <span class="govuk-visually-hidden">({{ title }})</span> in a new window</a>
   </span>
-  <iframe class="app-example__frame" scrolling="auto" frameborder="0" height="{{ height }}" src="{{ href | url }}" aria-label="{{ title }}"></iframe>
+  <iframe class="app-example__frame" scrolling="auto" frameborder="0" height="{{ height }}" src="{{ href | url }}" title="{{ title }}"></iframe>
 </div>
 <div class="app-tabs" data-module="app-tabs">
   <ul class="app-tabs__list" role="tablist">

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% block content %}
-  <div class="govuk-width-container govuk-grid-row">
+  <div class="govuk-width-container govuk-grid-row app-flex-container">
     <div class="govuk-grid-column-one-third">
       {{ appSideNavigation({
         classes: 'govuk-!-padding-top-6',
@@ -138,7 +138,7 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <main class="govuk-main-wrapper app-prose-scope" role="main">
+      <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
         <h1 class="govuk-heading-xl">
           {% if not isIndex %}<span class="govuk-caption-xl">Components</span>{% endif %}
           {{ title }}

--- a/docs/_includes/layouts/get-started.njk
+++ b/docs/_includes/layouts/get-started.njk
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% block content %}
-  <div class="govuk-width-container govuk-grid-row">
+  <div class="govuk-width-container govuk-grid-row app-flex-container">
     <div class="govuk-grid-column-one-third">
       {{ appSideNavigation({
         classes: 'govuk-!-padding-top-6',
@@ -55,7 +55,7 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <main class="govuk-main-wrapper app-prose-scope" role="main">
+      <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
         <h1 class="govuk-heading-xl">
           {% if subsection %}<span class="govuk-caption-xl">{{ subsection }}</span>{% endif %}
           {{ title }}

--- a/docs/_includes/layouts/partials/contact-panel.njk
+++ b/docs/_includes/layouts/partials/contact-panel.njk
@@ -1,7 +1,7 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-<h2 class="govuk-heading-m">Need help?</h2>
+<h2 class="govuk-heading-l">Need help?</h2>
 <p class="govuk-body">You can edit the page via <a href="https://github.com/ministryofjustice/moj-frontend/tree/main/docs" class="govuk-link">GitHub</a>
  or if you’ve got a question, idea or suggestion share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-support</a> channel on Slack.</p>
 
- <div class="govuk-!-padding-bottom-7"></div>
+<div class="govuk-!-padding-bottom-7"></div>

--- a/docs/_includes/layouts/partials/footer.njk
+++ b/docs/_includes/layouts/partials/footer.njk
@@ -1,52 +1,35 @@
-<footer class="govuk-footer" role="contentinfo">
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-  <div class="govuk-width-container">
-
-    <div class="govuk-footer__navigation">
-
-      <div class="govuk-footer__section">
-
-        <h2 class="govuk-footer__heading govuk-heading-m">Related resources</h2>
-
-        <ul class="govuk-footer__list govuk-footer__list--columns-1">
-          <li class="govuk-footer__list-item"><a class="govuk-footer__link" href="https://www.gov.uk/guidance/government-design-principles">Government Design Principles</a></li>
-          <li class="govuk-footer__list-item"><a class="govuk-footer__link" href="https://design-system.service.gov.uk/">GOV.UK Design System</a></li>
-          <li class="govuk-footer__list-item"><a class="govuk-footer__link" href="https://www.gov.uk/service-manual">GOV.UK Service Manual</a></li>
-        </ul>
-
-      </div>
-
-    </div>
-
-    <hr class="govuk-section-break">
-
-    <div class="govuk-footer__meta">
-
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-        <h2 class="govuk-visually-hidden">Support links</h2>
-
-        <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/cookies' | url }}">Cookies</a></li>
-          <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/accessibility' | url }}">Accessibility statement</a></li>
-        </ul>
-
-        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"></path>
-        </svg>
-
-        <span class="govuk-footer__licence-description">All content is available under the
-          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-        </span>
-
-      </div>
-
-      <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">&copy; Crown copyright</a>
-      </div>
-
-    </div>
-
-  </div>
-
-</footer>
+{{ govukFooter({
+  navigation: [
+    {
+      title: "Related resources",
+      items: [
+        {
+          href: "https://www.gov.uk/guidance/government-design-principles",
+          text: "Government Design Principles"
+        },
+        {
+          href: "https://design-system.service.gov.uk/",
+          text: "GOV.UK Design System"
+        },
+        {
+          href: "https://www.gov.uk/service-manual",
+          text: "GOV.UK Service Manual"
+        }
+      ]
+    }
+  ],
+  meta: {
+    items: [
+      {
+        href: '/cookies' | url,
+        text: "Cookies"
+      },
+      {
+        href: '/accessibility' | url,
+        text: "Accessibility"
+      }
+    ]
+  }
+}) }}

--- a/docs/_includes/layouts/partials/footer.njk
+++ b/docs/_includes/layouts/partials/footer.njk
@@ -28,6 +28,7 @@
 
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/cookies' | url }}">Cookies</a></li>
+          <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/accessibility' | url }}">Accessibility statement</a></li>
         </ul>
 
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">

--- a/docs/_includes/layouts/partials/footer.njk
+++ b/docs/_includes/layouts/partials/footer.njk
@@ -28,7 +28,6 @@
 
         <ul class="govuk-footer__inline-list">
           <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/cookies' | url }}">Cookies</a></li>
-          <li class="govuk-footer__inline-list-item"><a class="govuk-footer__link" href="{{ '/privacy-policy' | url }}">Privacy policy</a></li>
         </ul>
 
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
@@ -42,7 +41,7 @@
       </div>
 
       <div class="govuk-footer__meta-item">
-        <a class="govuk-footer__link govuk-footer__copyright-logo" href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/">&copy; Crown copyright</a>
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">&copy; Crown copyright</a>
       </div>
 
     </div>

--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -43,10 +43,11 @@
         <image src="{{ '/assets/images/moj-logotype-crest.png' | url }}" xlink:href="" class="moj-header__logotype-crest-fallback-image" width="40" height="40"></image>
 
       </svg>
+      <a class="moj-header__link" href="{{ '/' | url }}">
+        <span class="moj-header__link--organisation-name">Ministry of Justice</span>
 
-      <span class="moj-header__link moj-header__link--organisation-name">Ministry of Justice</span>
-
-      <a class="moj-header__link moj-header__link--service-name" href="{{ '/' | url }}">Pattern Library</a>
+        <span class="moj-header__link--service-name">Pattern Library</span>
+      </a>
     </div>
   </div>
 

--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -29,6 +29,8 @@
   ]
 }) }}
 
+<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+
 <header class="moj-header moj-header--docs" role="banner">
 
   <div class="moj-header__container">
@@ -42,7 +44,7 @@
 
       </svg>
 
-      <a class="moj-header__link moj-header__link--organisation-name" href="{{ '/' | url }}">Ministry of Justice</a>
+      <span class="moj-header__link moj-header__link--organisation-name">Ministry of Justice</span>
 
       <a class="moj-header__link moj-header__link--service-name" href="{{ '/' | url }}">Pattern Library</a>
     </div>

--- a/docs/_includes/layouts/patterns.njk
+++ b/docs/_includes/layouts/patterns.njk
@@ -9,7 +9,7 @@
 {% endmacro %}
 
 {% block content %}
-  <div class="govuk-width-container govuk-grid-row">
+  <div class="govuk-width-container govuk-grid-row app-flex-container">
     <div class="govuk-grid-column-one-third">
       {{ appSideNavigation({
         classes: 'govuk-!-padding-top-6',
@@ -63,7 +63,7 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <main class="govuk-main-wrapper app-prose-scope" role="main">
+      <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
         <h1 class="govuk-heading-xl">
           {% if subsection %}<span class="govuk-caption-xl">{{ subsection }}</span>{% endif %}
           {{ title }}

--- a/docs/_includes/layouts/plain.njk
+++ b/docs/_includes/layouts/plain.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 <div class="govuk-width-container">
-  <main class="govuk-main-wrapper app-prose-scope" role="main">
+  <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
     <h1 class="govuk-heading-xl">
       {{ title }}
     </h1>

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,6 +1,6 @@
 ---
 layout: layouts/plain.njk
-title: Accessibility statement
+title: Accessibility
 ---
 
 Coming soon

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,6 @@
+---
+layout: layouts/plain.njk
+title: Accessibility statement
+---
+
+Coming soon

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -5,6 +5,6 @@ title: Patterns
 
 Patterns in this section have been created by designers and developers at MOJ.
 
-To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-supportt</a> channel on Slack.</p>
+To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-support</a> channel on Slack.</p>
 
 If a similar pattern is in the [GOV.UK Design System](https://design-system.service.gov.uk/patterns/), you should use that pattern instead.


### PR DESCRIPTION
Fixing the issues [identified in testing](https://docs.google.com/spreadsheets/d/1j7Ms7OcbMyEt4-AlZ-SGpUIl8XN3ylyFJixHQW9Z1XE/edit#gid=1536858132) (as much as possible)

Fixes:
- Adds a skip link before the site header
- Removes the link from "Ministry of Justice" (only "Pattern Library" should link to the homepage)
- Size of "Need help?" header now matches header level
- iframe examples now have `title` attribute set (rather than `aria-label`, which was intended to do the same but isn't the standard)
- "Back to top"  button scrolls with the page
- Crown copyright link is fixed
- Privacy policy removed as we don't have one
- Fix spelling of channel name on Patterns page