### PR TITLE
docs: nudge users towards GDS Pagination component

### DIFF
--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -3,6 +3,12 @@ layout: layouts/component.njk
 title: Pagination
 ---
 
+{% banner "The GOV.UK Design System has a similar component" %}
+The [Pagination component](https://design-system.service.gov.uk/components/pagination/) in the GOV.UK Design System has a similar function and visual design to this component.
+
+You should use the GOV.UK version if it fits your needs.
+{% endbanner %}
+
 {% lastUpdated "pagination" %}
 
 {% example "/examples/pagination", 125 %}


### PR DESCRIPTION
Now that the GOV.UK Design System has a Pagination component, nudge people towards it. In the future we'd hope to deprecate our Pagination component to reduce duplication.

![image](https://user-images.githubusercontent.com/100852/175966189-966e0fac-f18a-4fb9-988a-6b1797931fc8.png)
