### PR TITLE
docs: load version into docs dynamically

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,6 +8,7 @@ const mojFilters = require("./src/moj/filters/all");
 const nunjucks = require("nunjucks");
 const path = require("path");
 const { execSync } = require("child_process");
+const releasePackage = require('./package/package.json');
 
 module.exports = function (eleventyConfig) {
   const nunjucksEnv = nunjucks.configure([
@@ -89,6 +90,10 @@ module.exports = function (eleventyConfig) {
       .split(",");
 
     return `<p>Last updated: <a href="https://github.com/ministryofjustice/moj-frontend/commit/${commit}">${lastUpdated}</a></p>`;
+  });
+
+  eleventyConfig.addShortcode("version", function () {
+    return releasePackage.version;
   });
 
   eleventyConfig.addPairedShortcode("banner", function (content, title) {

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,7 +10,7 @@
       "pkgRoot": "package"
     }],
     ["@semantic-release/git", {
-      "assets": ["CHANGELOG.md", "package.json"],
+      "assets": ["CHANGELOG.md", "package.json", "package/package.json"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@semantic-release/github", {

--- a/docs/get-started/prototyping.md
+++ b/docs/get-started/prototyping.md
@@ -27,14 +27,14 @@ The MOJ Pattern Library uses MOJ Frontend. To install it, run these steps:
 
 ## Updating MOJ Frontend
 
-The current version of MOJ Frontend is **0.2.1**.
+The current version of MOJ Frontend is **{% version %}**.
 
 You can check which version your prototype is running by opening `package.json` in the root folder of your prototype. Look for `"@ministryofjustice/frontend"` under `"dependencies"`.
 
 To update your prototype to the latest version of MOJ Frontend:
 
 1. open `package.json` in the root folder of your prototype in a text editor
-2. Under `dependencies`, update the reference to MOJ Frontend to `"@ministryofjustice/frontend": "0.2.1",`
+2. Under `dependencies`, update the reference to MOJ Frontend to `"@ministryofjustice/frontend": "{% version %}",`
 3. save `package.json`
 4. open Terminal/command line
 5. change the directory to your prototype's directory. For example, `cd path/to/prototype`

--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ministryofjustice/frontend",
   "description": "The MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.",
-  "version": "1.3.2",
+  "version": "1.4.2",
   "main": "moj/all.js",
   "sass": "moj/all.scss",
   "engines": {


### PR DESCRIPTION
Load version from package info, rather than hard-coding it

Also, ensure package is updated by CI release processes
