### PR TITLE
feat(password-reveal): set spellcheck attribute to false

### DIFF
--- a/docs/components/password-reveal.md
+++ b/docs/components/password-reveal.md
@@ -10,3 +10,5 @@ title: Password reveal
 ## When to use
 
 Use the password reveal component to let users check their password safely.
+
+This component automatically sets the `spellcheck` attribute to `false` to prevent users' passwords being stored in their browsers.

--- a/src/moj/components/password-reveal/password-reveal.js
+++ b/src/moj/components/password-reveal/password-reveal.js
@@ -7,6 +7,7 @@ MOJFrontend.PasswordReveal = function(element) {
   }
 
   $el.data('moj-password-reveal-initialised', true);
+  $el.attr('spellcheck', 'false');
 
   $el.wrap('<div class="moj-password-reveal"></div>');
   this.container = $(this.el).parent();


### PR DESCRIPTION
Automatically set spellcheck attribute to false to protect users' passwords from being sent to remote spellcheck services.

Chrome and Edge [both send plain text to their servers for spellchecking](https://www.bleepingcomputer.com/news/security/google-microsoft-can-get-your-passwords-via-web-browsers-spellcheck/). Setting the `spellcheck` attribute to `false` prevents this behaviour.