### PR TITLE
WIP: docs(component): adds the progress bar component to documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 ## Contact the team
 
 MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
+
 - [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
 - [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
 

--- a/docs/_includes/arguments/progress-bar.md
+++ b/docs/_includes/arguments/progress-bar.md
@@ -1,0 +1,19 @@
+### Container
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|attributes|object|No|HTML attributes (for example data attributes) to add to the progress bars's container.|
+|items|object|Yes|Items to add to the progress bar.|
+
+### Items
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|id|string|No|Gives each step a unique id for rendering purposes. If not set then one will be created for you.|
+|active|boolean|No|Sets the item as the currently active step. Only one item in the list should have this set to true.|
+|complete|boolean|No|Sets the item to the completed state so the user is aware of progress in that section.|
+|label->text|string|Yes|If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.|
+|label->html|string|Yes|If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.|
+|classes|string|No|Classes to add to the ticket panel's container.|                                    |
+
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -75,6 +75,10 @@
               href: ('/components/page-header-actions' | url)
             },
             {
+              text: 'Progress bar',
+              href: ('/components/progress-bar' | url)
+            },
+            {
               text: 'Button menu',
               href: ('/components/button-menu' | url)
             },

--- a/docs/components/progress-bar.md
+++ b/docs/components/progress-bar.md
@@ -1,0 +1,48 @@
+---
+layout: layouts/component.njk
+title: Progress Bar
+---
+
+{% lastUpdated "progress-bar" %}
+
+{% example "/examples/progress-bar", 300 %}
+
+## When to use
+
+TBC
+
+## When not to use
+
+TBC
+
+## How to use
+
+This component can be used by passing an array of items to render progress on a multistep form.
+
+Using the [arguments table below as a reference](#arguments) you can set the completed, active and current step of the user through their journey.
+
+## Research on this component
+
+This component is marked as experimental because it needs more research.
+
+If you have used the progress bar component, get in touch to share your research findings.
+
+## Arguments
+
+### Container
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|attributes|object|No|HTML attributes (for example data attributes) to add to the progress bars's container.|
+|items|object|Yes|Items to add to the progress bar.|
+
+### Items
+
+|Name|Type|Required|Description|
+|---|---|---|---|
+|id|string|No|Gives each step a unique id for rendering purposes. If not set then one will be created for you.|
+|active|boolean|No|Sets the item as the currently active step. Only one item in the list should have this set to true.|
+|complete|boolean|No|Sets the item to the completed state so the user is aware of progress in that section.|
+|label->text|string|Yes|If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.|
+|label->html|string|Yes|If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.|
+|classes|string|No|Classes to add to the ticket panel's container.|

--- a/docs/components/progress-bar.md
+++ b/docs/components/progress-bar.md
@@ -3,17 +3,17 @@ layout: layouts/component.njk
 title: Progress Bar
 ---
 
+{% banner "Unknown accessibility and Responsive Design standards" %}
+This component has not been accessibility tested and has no Responsive Design styling. Therefore it should not be used on live sites until it has. If you have had an accessibility check on this component or added responsive design styling, please update this component with any details or changes and remove this message.
+{% endbanner %}
+
 {% lastUpdated "progress-bar" %}
 
 {% example "/examples/progress-bar", 300 %}
 
-## When to use
+## When to use and not to use
 
-TBC
-
-## When not to use
-
-TBC
+Please follow the official guidance from [GDS on advice when using progress indicators](https://design-system.service.gov.uk/patterns/question-pages/#using-progress-indicators).
 
 ## How to use
 

--- a/docs/examples/progress-bar/index.njk
+++ b/docs/examples/progress-bar/index.njk
@@ -1,0 +1,58 @@
+---
+layout: layouts/example.njk
+title: Progress bar (example)
+arguments: progress-bar
+---
+
+{%- from "moj/components/progress-bar/macro.njk" import mojProgressBar -%}
+
+{{ mojProgressBar({
+  attributes: {
+    'aria-label': 'Progress of your application'
+  },
+  items: [{
+    id: 'progress-item-1',
+    active: false,
+    complete: true,
+    label: {
+      html: '<p>Your Details</p>'
+    },
+    classes: ''
+  },
+  {
+    id: 'progress-item-2',
+    active: false,
+    complete: true,
+    label: {
+      text: 'Address'
+    },
+    classes: ''
+  },
+  {
+    id: 'progress-item-3',
+    active: true,
+    complete: false,
+    label: {
+      text: 'Passport details'
+    },
+    classes: ''
+  },
+  {
+    id: 'progress-item-4',
+    active: false,
+    complete: false,
+    label: {
+      text: 'Review'
+    },
+    classes: ''
+  },
+  {
+    id: 'progress-item-5',
+    active: false,
+    complete: false,
+    label: {
+      text: 'Application Complete'
+    },
+    classes: ''
+  }]
+}) }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27723,7 +27723,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "1.4.2",
+      "version": "1.6.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Description of the change

Adds documentation for the Progress Bar component to the pattern library documentation site.

Before merging this we require the following.

- [ ] Responsive Design adding and testing
- [ ] Accessibility Audit completed on this ticket

### Release notes

Adds documentation for the Progress Bar component to the pattern library documentation site.

![image](https://user-images.githubusercontent.com/5390820/195050572-488796d1-ea42-4305-ba6a-281feb1abb69.png)

