### PR TITLE
docs: fix old URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -9,7 +9,7 @@ Have you read the Code of Conduct? By filing an Issue, you are expected to compl
 
 https://github.com/ministryofjustice/moj-frontend/blob/main/CODE_OF_CONDUCT.md
 
-Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
+Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://design-patterns.service.justice.gov.uk/get-in-touch).
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -9,7 +9,7 @@ Have you read the Code of Conduct? By filing an Issue, you are expected to compl
 
 https://github.com/ministryofjustice/moj-frontend/blob/main/CODE_OF_CONDUCT.md
 
-Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch).
+Do you want to ask a question? Are you looking for support? You can [contact the Design System team](https://design-patterns.service.justice.gov.uk/get-in-touch).
 
 ---
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing or otherwise unacceptable behaviour may be reported by [contacting the Design System team](https://moj-design-system.herokuapp.com/get-in-touch). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality concerning the reporter of an incident.
+Instances of abusive, harassing or otherwise unacceptable behaviour may be reported by [contacting the Design System team](https://design-patterns.service.justice.gov.uk/get-in-touch). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality concerning the reporter of an incident.
 
 Further details of specific enforcement policies may be posted separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please note we have a [code of conduct](https://github.com/ministryofjustice/moj
 
 If you’ve got an idea or suggestion you can:
 
-- [Contact the Design System team](https://moj-design-system.herokuapp.com/get-in-touch)
+- [Contact the Design System team](https://design-patterns.service.justice.gov.uk/get-in-touch)
 - [Create a GitHub issue](https://github.com/ministryofjustice/moj-frontend/issues)
 
 ## Raising bugs
@@ -50,7 +50,7 @@ If you need to install a newer version of node, you should set the version in th
 - Run `nvm use`
 - Run `npm install`
 - Run `npm run build:package`
-  
+
 You can now run `npm run start` to run a local version of the site.
 
 ### Versioning

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 ## Contact the team
 
 MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
-- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
-- [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
+- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on Justice Digital Slack
+- [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital Slack
 
 ## Quick start
 

--- a/docs/get-in-touch.md
+++ b/docs/get-in-touch.md
@@ -1,0 +1,10 @@
+---
+layout: layouts/plain.njk
+title: Get in touch
+---
+
+There are various ways to get in touch with the maintainers of the MOJ Pattern Library
+
+- Opening [a GitHub issue](https://github.com/ministryofjustice/moj-frontend/issues)
+- The [#moj-pattern-library-support channel](https://mojdt.slack.com/messages/moj-pattern-library-support) on Justice Digital Slack
+- The [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/moj-design-system) on UK Government Digital Slack

--- a/package/README.md
+++ b/package/README.md
@@ -15,8 +15,8 @@ If you want to help us build MOJ Frontend, view our [contribution guidelines](CO
 ## Contact the team
 
 MOJ Frontend is maintained by staff in the Ministry of Justice. If you need support, you can use [GitHub discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or one of our Slack channels:
-- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on MOJ Digital & Technology
-- [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital
+- [#moj-pattern-library-support](https://mojdt.slack.com/archives/CH5RUSB27) on Justice Digital Slack
+- [#moj-design-system channel](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC) on UK Government Digital Slack
 
 ## Quick start
 

--- a/src/moj/components/action-bar/README.md
+++ b/src/moj/components/action-bar/README.md
@@ -1,6 +1,5 @@
 # Action bar
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/action-bar)
-- [Preview](https://moj-frontend.herokuapp.com/components/action-bar)
+- [Guidance](https://design-patterns.service.justice.gov.uk/patterns/filter-a-list)
 
 ## Arguments

--- a/src/moj/components/add-another/README.md
+++ b/src/moj/components/add-another/README.md
@@ -1,6 +1,5 @@
 # Add another
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/add-another)
-- [Preview](https://moj-frontend.herokuapp.com/components/add-another)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/add-another)
 
 ## Arguments

--- a/src/moj/components/badge/README.md
+++ b/src/moj/components/badge/README.md
@@ -1,7 +1,6 @@
 # Badge
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/badge)
-- [Preview](https://moj-frontend.herokuapp.com/components/badge)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/badge)
 
 ## Example
 
@@ -16,35 +15,35 @@
 
 This component accepts the following arguments.
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the span. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the span. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|Yes|Classes to add to the `span` container. See available [classes](#classes).|
-|label|string|No|The `aria-label` to add to the `span` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the `span` container.|
+| Name       | Type   | Required | Description                                                                                                                      |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| text       | string | Yes      | If `html` is set, this is not required. Text to use within the span. If `html` is provided, the `text` argument will be ignored. |
+| html       | string | Yes      | If `text` is set, this is not required. HTML to use within the span. If `html` is provided, the `text` argument will be ignored. |
+| classes    | string | Yes      | Classes to add to the `span` container. See available [classes](#classes).                                                       |
+| label      | string | No       | The `aria-label` to add to the `span` container.                                                                                 |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the `span` container.                                                    |
 
 ### Classes
 
-|Name|Colour code|Colour contrast|
-|---|---|---|
-|moj-badge--purple|#2e358b|Pass|
-|moj-badge--light-purple|#6f72af|Fail|
-|moj-badge--bright-purple|#912b88|Pass|
-|moj-badge--pink|#d53880|Fail|
-|moj-badge--light-pink|#f499be|Fail|
-|moj-badge--red|#b10e1e|Pass|
-|moj-badge--orange|#f47738|Fail|
-|moj-badge--brown|#b58840|Fail|
-|moj-badge--yellow|#ffbf47|Fail|
-|moj-badge--light-green|#85994b|Fail|
-|moj-badge--green|#006435|Pass|
-|moj-badge--turquoise|#28a197|Fail|
-|moj-badge--light-blue|#2b8cc4|Fail|
-|moj-badge--blue|#005ea5|Pass|
-|moj-badge--black|#0b0c0c|Pass|
-|moj-badge--dark-grey|#6f777b|Pass|
-|moj-badge--mid-grey|#bfc1c3|Fail|
-|moj-badge--light-grey|#dee0e2|Fail|
-|moj-badge--light-grey|#f8f8f8|Fail|
-|moj-badge--white|#ffffff|Fail|
+| Name                     | Colour code | Colour contrast |
+| ------------------------ | ----------- | --------------- |
+| moj-badge--purple        | #2e358b     | Pass            |
+| moj-badge--light-purple  | #6f72af     | Fail            |
+| moj-badge--bright-purple | #912b88     | Pass            |
+| moj-badge--pink          | #d53880     | Fail            |
+| moj-badge--light-pink    | #f499be     | Fail            |
+| moj-badge--red           | #b10e1e     | Pass            |
+| moj-badge--orange        | #f47738     | Fail            |
+| moj-badge--brown         | #b58840     | Fail            |
+| moj-badge--yellow        | #ffbf47     | Fail            |
+| moj-badge--light-green   | #85994b     | Fail            |
+| moj-badge--green         | #006435     | Pass            |
+| moj-badge--turquoise     | #28a197     | Fail            |
+| moj-badge--light-blue    | #2b8cc4     | Fail            |
+| moj-badge--blue          | #005ea5     | Pass            |
+| moj-badge--black         | #0b0c0c     | Pass            |
+| moj-badge--dark-grey     | #6f777b     | Pass            |
+| moj-badge--mid-grey      | #bfc1c3     | Fail            |
+| moj-badge--light-grey    | #dee0e2     | Fail            |
+| moj-badge--light-grey    | #f8f8f8     | Fail            |
+| moj-badge--white         | #ffffff     | Fail            |

--- a/src/moj/components/button-menu/README.md
+++ b/src/moj/components/button-menu/README.md
@@ -1,7 +1,6 @@
 # Button menu
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/button-menu)
-- [Preview](https://moj-frontend.herokuapp.com/components/button-menu)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/button-menu)
 
 ## Examples
 
@@ -40,26 +39,27 @@ new MOJFrontend.ButtonGroup({
 ## Arguments
 
 ### Container
-|Name|Type|Required|Description|
-|---|---|---|---|
-|items|array|Yes|An array of button item objects. See [items](#items).|
-|buttonClasses|String|No|Classes to add to the button items.|
-|attributes|Object|No|HTML attributes (for example data attributes) to add to the button group.|
+
+| Name          | Type   | Required | Description                                                               |
+| ------------- | ------ | -------- | ------------------------------------------------------------------------- |
+| items         | array  | Yes      | An array of button item objects. See [items](#items).                     |
+| buttonClasses | String | No       | Classes to add to the button items.                                       |
+| attributes    | Object | No       | HTML attributes (for example data attributes) to add to the button group. |
 
 ### Items
 
 See the [button component](https://design-system.service.gov.uk/components/button/) in the GOV.UK Design System for more details.
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|element|String|No|Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.|
-|text|String|Yes|If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.|
-|html|String|Yes|If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` argument will be ignored and element will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.|
-|name|String|Yes|Name for the `input` or `button`. This has no effect on `a` elements.|
-|type|String|Yes|Type of `input` or `button`. The options are `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.|
-|value|String|Yes|Value for the `button` tag. This has no effect on `a` or `input` elements.|
-|disabled|Boolean|No|Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.|
-|href|String|No|The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.|
-|classes|String|No|Classes to add to the button component.|
-|attributes|Object|No|HTML attributes (for example data attributes) to add to the button component.|
-|preventDoubleClick|Boolean|No|Prevent accidental double clicks on submit buttons from submitting forms multiple times.|
+| Name               | Type    | Required | Description                                                                                                                                                                                                                                                                                                |
+| ------------------ | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| element            | String  | No       | Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.                                                                                                                   |
+| text               | String  | Yes      | If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`. |
+| html               | String  | Yes      | If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` argument will be ignored and element will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.   |
+| name               | String  | Yes      | Name for the `input` or `button`. This has no effect on `a` elements.                                                                                                                                                                                                                                      |
+| type               | String  | Yes      | Type of `input` or `button`. The options are `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.                                                                                                                                                                      |
+| value              | String  | Yes      | Value for the `button` tag. This has no effect on `a` or `input` elements.                                                                                                                                                                                                                                 |
+| disabled           | Boolean | No       | Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.                                                                                                                                                                 |
+| href               | String  | No       | The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.                                                                                                                                                                     |
+| classes            | String  | No       | Classes to add to the button component.                                                                                                                                                                                                                                                                    |
+| attributes         | Object  | No       | HTML attributes (for example data attributes) to add to the button component.                                                                                                                                                                                                                              |
+| preventDoubleClick | Boolean | No       | Prevent accidental double clicks on submit buttons from submitting forms multiple times.                                                                                                                                                                                                                   |

--- a/src/moj/components/cookie-banner/README.md
+++ b/src/moj/components/cookie-banner/README.md
@@ -1,6 +1,5 @@
 # Cookie banner
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/cookie-banner)
-- [Preview](https://moj-frontend.herokuapp.com/components/cookie-banner)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/cookie-banner)
 
 ## Arguments

--- a/src/moj/components/currency-input/README.md
+++ b/src/moj/components/currency-input/README.md
@@ -1,7 +1,6 @@
 # Currency input
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/currency-input)
-- [Preview](https://moj-frontend.herokuapp.com/components/currency-input)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/currency-input)
 
 ## Dependencies
 
@@ -27,7 +26,9 @@ The currency input component is dependent on the following components from the [
   }
 }) }}
 ```
+
 ### With currency specified
+
 ```
 {{ mojCurrencyInput({
   id: "amount",
@@ -49,58 +50,64 @@ The currency input component is dependent on the following components from the [
 ## Arguments
 
 ### Container
-|Name|Type|Required|Description|
-|---|---|---|---|
-|id|string|Yes|Optional `id` attribute to add to the text input.|
-|name|string|Yes|Name attribute for the text input.|
-|value|string|No|Optional value of the text input.|
-|type|string|No|Type of input control to render. Defaults to text.|
-|formGroup|object|No|Options for the form-group wrapper. See [formGroup](#formgroup).|
-|label|object|No|Options for the label component (e.g. text). See [label](#label).|
-|hint|object|No|Options for the hint component (e.g. text). See [hint](#hint).|
-|errorMessage|object|No|Options for the errorMessage component (e.g. text). See [errorMessage](#errormessage).|
-|currencyLabel|object|No|Options for the currency label (e.g. text). See [currencyLabel](#currencylabel).|
-|classes|string|No|Classes to add to the text input.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the text input.|
+
+| Name          | Type   | Required | Description                                                                            |
+| ------------- | ------ | -------- | -------------------------------------------------------------------------------------- |
+| id            | string | Yes      | Optional `id` attribute to add to the text input.                                      |
+| name          | string | Yes      | Name attribute for the text input.                                                     |
+| value         | string | No       | Optional value of the text input.                                                      |
+| type          | string | No       | Type of input control to render. Defaults to text.                                     |
+| formGroup     | object | No       | Options for the form-group wrapper. See [formGroup](#formgroup).                       |
+| label         | object | No       | Options for the label component (e.g. text). See [label](#label).                      |
+| hint          | object | No       | Options for the hint component (e.g. text). See [hint](#hint).                         |
+| errorMessage  | object | No       | Options for the errorMessage component (e.g. text). See [errorMessage](#errormessage). |
+| currencyLabel | object | No       | Options for the currency label (e.g. text). See [currencyLabel](#currencylabel).       |
+| classes       | string | No       | Classes to add to the text input.                                                      |
+| attributes    | object | No       | HTML attributes (for example data attributes) to add to the text input.                |
 
 ### formGroup
-|Name|Type|Required|Description|
-|---|---|---|---|
-|classes|string|No|Classes to add to the form group wrapper.|
+
+| Name    | Type   | Required | Description                               |
+| ------- | ------ | -------- | ----------------------------------------- |
+| classes | string | No       | Classes to add to the form group wrapper. |
 
 ### Label
-|Name|Type|Required|Description|
-|---|---|---|---|
-|for|string|Yes|The value of the `for` attribute, the `id` of the `input` the label is associated with.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.|
-|isPageHeading|boolean|No|Whether the label also acts as the heading for the page.|
-|classes|string|No|Classes to add to the label tag.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the label tag.|
+
+| Name          | Type    | Required | Description                                                                                                                       |
+| ------------- | ------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| for           | string  | Yes      | The value of the `for` attribute, the `id` of the `input` the label is associated with.                                           |
+| text          | string  | Yes      | If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored. |
+| html          | string  | Yes      | If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored. |
+| isPageHeading | boolean | No       | Whether the label also acts as the heading for the page.                                                                          |
+| classes       | string  | No       | Classes to add to the label tag.                                                                                                  |
+| attributes    | object  | No       | HTML attributes (for example data attributes) to add to the label tag.                                                            |
 
 ### Hint
-|Name|Type|Required|Description|
-|---|---|---|---|
-|id|string|No|Optional `id` attribute to add to the hint span tag.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the hint. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the hint span tag.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the hint span tag.|
+
+| Name       | Type   | Required | Description                                                                                                                      |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| id         | string | No       | Optional `id` attribute to add to the hint span tag.                                                                             |
+| text       | string | Yes      | If `html` is set, this is not required. Text to use within the hint. If `html` is provided, the `text` argument will be ignored. |
+| html       | string | Yes      | If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored. |
+| classes    | string | No       | Classes to add to the hint span tag.                                                                                             |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the hint span tag.                                                       |
 
 ### errorMessage
-|Name|Type|Required|Description|
-|---|---|---|---|
-|id|string|No|Optional `id` attribute to add to the error span tag.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the error. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the error. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the error span tag.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the error span tag.|
+
+| Name       | Type   | Required | Description                                                                                                                       |
+| ---------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| id         | string | No       | Optional `id` attribute to add to the error span tag.                                                                             |
+| text       | string | Yes      | If `html` is set, this is not required. Text to use within the error. If `html` is provided, the `text` argument will be ignored. |
+| html       | string | Yes      | If `text` is set, this is not required. HTML to use within the error. If `html` is provided, the `text` argument will be ignored. |
+| classes    | string | No       | Classes to add to the error span tag.                                                                                             |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the error span tag.                                                       |
 
 ### currencyLabel
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the error. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the error. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the currency span tag.|
 
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+| Name    | Type   | Required | Description                                                                                                                       |
+| ------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| text    | string | Yes      | If `html` is set, this is not required. Text to use within the error. If `html` is provided, the `text` argument will be ignored. |
+| html    | string | Yes      | If `text` is set, this is not required. HTML to use within the error. If `html` is provided, the `text` argument will be ignored. |
+| classes | string | No       | Classes to add to the currency span tag.                                                                                          |
+
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/filter-toggle-button/README.md
+++ b/src/moj/components/filter-toggle-button/README.md
@@ -1,6 +1,5 @@
 # Filter toggle button
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/filter-toggle-button)
-- [Preview](https://moj-frontend.herokuapp.com/components/filter-toggle-button)
+- [Guidance](https://design-patterns.service.justice.gov.uk/patterns/filter-a-list)
 
 ## Arguments

--- a/src/moj/components/form-validator/README.md
+++ b/src/moj/components/form-validator/README.md
@@ -1,6 +1,5 @@
 # Form validator
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/form-validator)
-- [Preview](https://moj-frontend.herokuapp.com/components/form-validator)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/form-validator)
 
 ## Arguments

--- a/src/moj/components/header/README.md
+++ b/src/moj/components/header/README.md
@@ -1,7 +1,6 @@
 # Header
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/header)
-- [Preview](https://moj-frontend.herokuapp.com/components/header)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/header)
 
 ## Examples
 
@@ -35,38 +34,37 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|organisationLabel|object|Yes|An object containing the organisation's details. See [organisationLabel](#organisationlabel).|
-|serviceLabel|object|Yes|An object containing the service's details. See [serviceLabel](#servicelabel).|
-|navigation|array|No|An array of navigation item objects. See [navigation](#navigation).|
-|containerClasses|string|No|Classes for the container, useful if you want to make the header fixed width.|
-|classes|string|No|Classes to add to the `header` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the header container.|
+| Name              | Type   | Required | Description                                                                                   |
+| ----------------- | ------ | -------- | --------------------------------------------------------------------------------------------- |
+| organisationLabel | object | Yes      | An object containing the organisation's details. See [organisationLabel](#organisationlabel). |
+| serviceLabel      | object | Yes      | An object containing the service's details. See [serviceLabel](#servicelabel).                |
+| navigation        | array  | No       | An array of navigation item objects. See [navigation](#navigation).                           |
+| containerClasses  | string | No       | Classes for the container, useful if you want to make the header fixed width.                 |
+| classes           | string | No       | Classes to add to the `header` container.                                                     |
+| attributes        | object | No       | HTML attributes (for example data attributes) to add to the header container.                 |
 
 ### organisationLabel
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|Header title that is placed next to the crest. Used for organisation names (e.g., CICA, HMCTS, HMPPS, LAA and OPG).|
-|href|string|Yes|URL for the organisation name anchor.|
+| Name | Type   | Required | Description                                                                                                         |
+| ---- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------- |
+| text | string | Yes      | Header title that is placed next to the crest. Used for organisation names (e.g., CICA, HMCTS, HMPPS, LAA and OPG). |
+| href | string | Yes      | URL for the organisation name anchor.                                                                               |
 
 ### serviceLabel
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|Header title that is placed next to the organisation name. Used for service names (e.g., Claim fees for Crown court defence; Send money to prisoners).|
-|href|string|Yes|URL for the service name anchor.|
+| Name | Type   | Required | Description                                                                                                                                            |
+| ---- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| text | string | Yes      | Header title that is placed next to the organisation name. Used for service names (e.g., Claim fees for Crown court defence; Send money to prisoners). |
+| href | string | Yes      | URL for the service name anchor.                                                                                                                       |
 
 ### Navigation
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|href|string|Yes|URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|active|boolean|No|Flag to mark the navigation item as active or not. Defaults to `false`.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the navigation item anchor.|
+| Name       | Type    | Required | Description                                                                                                                        |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| href       | string  | Yes      | URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.       |
+| text       | string  | Yes      | If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| html       | string  | Yes      | If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| active     | boolean | No       | Flag to mark the navigation item as active or not. Defaults to `false`.                                                            |
+| attributes | object  | No       | HTML attributes (for example data attributes) to add to the navigation item anchor.                                                |
 
-
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/messages/README.md
+++ b/src/moj/components/messages/README.md
@@ -1,7 +1,6 @@
 # Messages
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/messages)
-- [Preview](https://moj-frontend.herokuapp.com/components/messages)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/messages)
 
 ### Installation
 
@@ -17,6 +16,7 @@ Object.keys(mojFilters).forEach(function (filterName) {
 ```
 
 ## Example
+
 Below is a typical example of the timeline component in use.
 
 ```
@@ -67,19 +67,19 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|items|array|Yes|An array of message item objects. See [items](#items).|
-|classes|string|No|Classes to add to the messages's container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the message's container.|
+| Name       | Type   | Required | Description                                                                      |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------- |
+| items      | array  | Yes      | An array of message item objects. See [items](#items).                           |
+| classes    | string | No       | Classes to add to the messages's container.                                      |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the message's container. |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|id|string|No|The unique ID of the item|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|type|string|Yes|Used to show sent or received messages. Sent messages are blue and aligned to the right, received messages are grey and aligned to the left. Options: `sent` or `received`.|
-|sender|string|Yes|The thing that created the message.|
-|timestamp|string|Yes|A valid datetime string to be formatted. For example: `1970-01-01T11:59:59.000Z`|
+| Name      | Type   | Required | Description                                                                                                                                                                 |
+| --------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| id        | string | No       | The unique ID of the item                                                                                                                                                   |
+| text      | string | Yes      | If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.                                            |
+| html      | string | Yes      | If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.                                            |
+| type      | string | Yes      | Used to show sent or received messages. Sent messages are blue and aligned to the right, received messages are grey and aligned to the left. Options: `sent` or `received`. |
+| sender    | string | Yes      | The thing that created the message.                                                                                                                                         |
+| timestamp | string | Yes      | A valid datetime string to be formatted. For example: `1970-01-01T11:59:59.000Z`                                                                                            |

--- a/src/moj/components/multi-select/README.md
+++ b/src/moj/components/multi-select/README.md
@@ -1,5 +1,3 @@
 # Table multi-select
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/table-multi-select)
-- [Preview](https://moj-frontend.herokuapp.com/components/table-multi-select)
-
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/table-multi-select)

--- a/src/moj/components/notification-badge/README.md
+++ b/src/moj/components/notification-badge/README.md
@@ -1,9 +1,8 @@
 # Notification badge
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/notification-badge)
-- [Preview](https://moj-frontend.herokuapp.com/components/notification-badge)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/notification-badge)
 
 ## Arguments
 
-|Name|Type|Required|Description|
-|---|---|---|---|
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |

--- a/src/moj/components/organisation-switcher/README.md
+++ b/src/moj/components/organisation-switcher/README.md
@@ -1,9 +1,8 @@
 # Organisation switcher
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/organisation-switcher)
-- [Preview](https://moj-frontend.herokuapp.com/components/organisation-switcher)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/organisation-switcher)
 
 ## Arguments
 
-|Name|Type|Required|Description|
-|---|---|---|---|
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |

--- a/src/moj/components/page-header-actions/README.md
+++ b/src/moj/components/page-header-actions/README.md
@@ -1,6 +1,5 @@
 # Page header actions
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/page-header-actions)
-- [Preview](https://moj-frontend.herokuapp.com/components/page-header-actions)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/page-header-actions)
 
 ## Arguments

--- a/src/moj/components/pagination/README.md
+++ b/src/moj/components/pagination/README.md
@@ -1,6 +1,5 @@
 # Pagination
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/pagination)
-- [Preview](https://moj-frontend.herokuapp.com/components/pagination)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/pagination)
 
 ## Arguments

--- a/src/moj/components/password-reveal/README.md
+++ b/src/moj/components/password-reveal/README.md
@@ -1,4 +1,3 @@
 # Password reveal
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/password-reveal)
-- [Preview](https://moj-frontend.herokuapp.com/components/password-reveal)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/password-reveal)

--- a/src/moj/components/primary-navigation/README.md
+++ b/src/moj/components/primary-navigation/README.md
@@ -1,7 +1,6 @@
 # Primary navigation
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/primary-navigation)
-- [Preview](https://moj-frontend.herokuapp.com/components/primary-navigation)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/primary-navigation)
 
 ## Example
 
@@ -28,24 +27,23 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|label|string|No|The `aria-label` to add to the navigation container.|
-|items|array|Yes|An array of navigation item objects. See [items](#items).|
-|searchHtml|sting|No||
-|containerClasses|string|No|Classes to add to the parent `div` container.|
-|classes|string|No|Classes to add to the `nav` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the `nav` container.|
+| Name             | Type   | Required | Description                                                                  |
+| ---------------- | ------ | -------- | ---------------------------------------------------------------------------- |
+| label            | string | No       | The `aria-label` to add to the navigation container.                         |
+| items            | array  | Yes      | An array of navigation item objects. See [items](#items).                    |
+| searchHtml       | sting  | No       |                                                                              |
+| containerClasses | string | No       | Classes to add to the parent `div` container.                                |
+| classes          | string | No       | Classes to add to the `nav` container.                                       |
+| attributes       | object | No       | HTML attributes (for example data attributes) to add to the `nav` container. |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|href|string|Yes|URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|active|boolean|No|Flag to mark the navigation item as active or not. Defaults to `false`.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the navigation item anchor.|
+| Name       | Type    | Required | Description                                                                                                                        |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| href       | string  | Yes      | URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.       |
+| text       | string  | Yes      | If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| html       | string  | Yes      | If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| active     | boolean | No       | Flag to mark the navigation item as active or not. Defaults to `false`.                                                            |
+| attributes | object  | No       | HTML attributes (for example data attributes) to add to the navigation item anchor.                                                |
 
-
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/progress-bar/README.md
+++ b/src/moj/components/progress-bar/README.md
@@ -1,9 +1,8 @@
 # Progress bar
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/progress-bar)
-- [Preview](https://moj-frontend.herokuapp.com/components/progress-bar)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/progress-bar)
 
 ## Arguments
 
-|Name|Type|Required|Description|
-|---|---|---|---|
+| Name | Type | Required | Description |
+| ---- | ---- | -------- | ----------- |

--- a/src/moj/components/rich-text-editor/README.md
+++ b/src/moj/components/rich-text-editor/README.md
@@ -1,7 +1,6 @@
 # Rich text editor
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/rich-text-editor)
-- [Preview](https://moj-frontend.herokuapp.com/components/rich-text-editor)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/rich-text-editor)
 
 ## Example
 
@@ -15,4 +14,3 @@
 ```
 
 ## Options
-

--- a/src/moj/components/search/README.md
+++ b/src/moj/components/search/README.md
@@ -1,6 +1,5 @@
 # Search
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/search)
-- [Preview](https://moj-frontend.herokuapp.com/components/search)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/search)
 
 ## Arguments

--- a/src/moj/components/side-navigation/README.md
+++ b/src/moj/components/side-navigation/README.md
@@ -1,7 +1,6 @@
 # Side navigation
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/side-navigation)
-- [Preview](https://moj-frontend.herokuapp.com/components/side-navigation)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/side-navigation)
 
 ## Example
 
@@ -28,40 +27,39 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|label|string|No|The `aria-label` to add to the navigation container.|
-|items|array|Yes|An array of navigation item objects. See [items](#items).|
-|sections|array|No|An array of navigation section objects. See [sections](#sections).|
-|classes|string|No|Classes to add to the `nav` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the `nav` container.|
+| Name       | Type   | Required | Description                                                                  |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------- |
+| label      | string | No       | The `aria-label` to add to the navigation container.                         |
+| items      | array  | Yes      | An array of navigation item objects. See [items](#items).                    |
+| sections   | array  | No       | An array of navigation section objects. See [sections](#sections).           |
+| classes    | string | No       | Classes to add to the `nav` container.                                       |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the `nav` container. |
 
 ### Sections
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|items|array|Yes|An array of navigation item objects. See [items](#items).|
-|heading|object|Yes|See [heading](#headings)|
+| Name    | Type   | Required | Description                                               |
+| ------- | ------ | -------- | --------------------------------------------------------- |
+| items   | array  | Yes      | An array of navigation item objects. See [items](#items). |
+| heading | object | Yes      | See [heading](#headings)                                  |
 
 #### Headings
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|headingLevel|numeric|No|A number for the heading level. Defaults to 4 (`<h4>`)|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the heading. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the heading. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the heading.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the navigation item anchor.|
+| Name         | Type    | Required | Description                                                                                                                         |
+| ------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| headingLevel | numeric | No       | A number for the heading level. Defaults to 4 (`<h4>`)                                                                              |
+| text         | string  | Yes      | If `html` is set, this is not required. Text to use within the heading. If `html` is provided, the `text` argument will be ignored. |
+| html         | string  | Yes      | If `text` is set, this is not required. HTML to use within the heading. If `html` is provided, the `text` argument will be ignored. |
+| classes      | string  | No       | Classes to add to the heading.                                                                                                      |
+| attributes   | object  | No       | HTML attributes (for example data attributes) to add to the navigation item anchor.                                                 |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|href|string|Yes|URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|active|boolean|No|Flag to mark the navigation item as active or not. Defaults to `false`.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the navigation item anchor.|
+| Name       | Type    | Required | Description                                                                                                                        |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| href       | string  | Yes      | URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.       |
+| text       | string  | Yes      | If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| html       | string  | Yes      | If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| active     | boolean | No       | Flag to mark the navigation item as active or not. Defaults to `false`.                                                            |
+| attributes | object  | No       | HTML attributes (for example data attributes) to add to the navigation item anchor.                                                |
 
-
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/sortable-table/README.md
+++ b/src/moj/components/sortable-table/README.md
@@ -1,6 +1,5 @@
 # Sortable table
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/sortable-table)
-- [Preview](https://moj-frontend.herokuapp.com/components/sortable-table)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/sortable-table)
 
 ## Arguments

--- a/src/moj/components/sub-navigation/README.md
+++ b/src/moj/components/sub-navigation/README.md
@@ -1,7 +1,6 @@
 # Sub navigation
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/sub-navigation)
-- [Preview](https://moj-frontend.herokuapp.com/components/sub-navigation)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/sub-navigation)
 
 ## Example
 
@@ -28,23 +27,22 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|label|string|No|The `aria-label` to add to the `nav` container.|
-|items|array|Yes|An array of navigation item objects. See [items](#items).|
-|classes|string|No|Classes to add to the `nav` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the `nav` container.|
-
+| Name       | Type   | Required | Description                                                                  |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------- |
+| label      | string | No       | The `aria-label` to add to the `nav` container.                              |
+| items      | array  | Yes      | An array of navigation item objects. See [items](#items).                    |
+| classes    | string | No       | Classes to add to the `nav` container.                                       |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the `nav` container. |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|href|string|Yes|URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|active|boolean|No|Flag to mark the navigation item as active or not. Defaults to `false`.|
-|classes|string|No|Classes to add to the list `li` item.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the navigation item anchor.|
+| Name       | Type    | Required | Description                                                                                                                        |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| href       | string  | Yes      | URL of the navigation item anchor. Both href and text attributes for navigation items need to be provided to create an item.       |
+| text       | string  | Yes      | If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| html       | string  | Yes      | If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| active     | boolean | No       | Flag to mark the navigation item as active or not. Defaults to `false`.                                                            |
+| classes    | string  | No       | Classes to add to the list `li` item.                                                                                              |
+| attributes | object  | No       | HTML attributes (for example data attributes) to add to the navigation item anchor.                                                |
 
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/tag/README.md
+++ b/src/moj/components/tag/README.md
@@ -1,29 +1,28 @@
 # Badge
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/tag)
-- [Preview](https://moj-frontend.herokuapp.com/components/tag)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/tag)
 
 ## Classes
 
-|Name|Colour code|Colour contrast|
-|---|---|---|
-|moj-tag--purple|#2e358b||
-|moj-tag--light-purple|#6f72af||
-|moj-tag--bright-purple|#912b88||
-|moj-tag--pink|#d53880||
-|moj-tag--light-pink|#f499be||
-|moj-tag--red|#b10e1e||
-|moj-tag--orange|#f47738||
-|moj-tag--brown|#b58840||
-|moj-tag--yellow|#ffbf47||
-|moj-tag--light-green|#85994b||
-|moj-tag--green|#006435||
-|moj-tag--turquoise|#28a197||
-|moj-tag--light-blue|#2b8cc4||
-|moj-tag--blue|#005ea5||
-|moj-tag--black|#0b0c0c||
-|moj-tag--dark-grey|#6f777b||
-|moj-tag--mid-grey|#bfc1c3||
-|moj-tag--light-grey|#dee0e2||
-|moj-tag--light-grey|#f8f8f8||
-|moj-tag--white|#ffffff||
+| Name                   | Colour code | Colour contrast |
+| ---------------------- | ----------- | --------------- |
+| moj-tag--purple        | #2e358b     |                 |
+| moj-tag--light-purple  | #6f72af     |                 |
+| moj-tag--bright-purple | #912b88     |                 |
+| moj-tag--pink          | #d53880     |                 |
+| moj-tag--light-pink    | #f499be     |                 |
+| moj-tag--red           | #b10e1e     |                 |
+| moj-tag--orange        | #f47738     |                 |
+| moj-tag--brown         | #b58840     |                 |
+| moj-tag--yellow        | #ffbf47     |                 |
+| moj-tag--light-green   | #85994b     |                 |
+| moj-tag--green         | #006435     |                 |
+| moj-tag--turquoise     | #28a197     |                 |
+| moj-tag--light-blue    | #2b8cc4     |                 |
+| moj-tag--blue          | #005ea5     |                 |
+| moj-tag--black         | #0b0c0c     |                 |
+| moj-tag--dark-grey     | #6f777b     |                 |
+| moj-tag--mid-grey      | #bfc1c3     |                 |
+| moj-tag--light-grey    | #dee0e2     |                 |
+| moj-tag--light-grey    | #f8f8f8     |                 |
+| moj-tag--white         | #ffffff     |                 |

--- a/src/moj/components/task-list/README.md
+++ b/src/moj/components/task-list/README.md
@@ -1,7 +1,6 @@
 # Task list
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/task-list)
-- [Preview](https://moj-frontend.herokuapp.com/components/task-list)
+- [Guidance](https://design-patterns.service.justice.gov.uk/patterns/task-list)
 
 ## Example
 
@@ -49,39 +48,38 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|sections|array|No|An array of section objects containing task list items. See [sections](#sections).|
-|classes|string|No|Classes to add to the `nav` container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the `ol` container.|
+| Name       | Type   | Required | Description                                                                        |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------------------- |
+| sections   | array  | No       | An array of section objects containing task list items. See [sections](#sections). |
+| classes    | string | No       | Classes to add to the `nav` container.                                             |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the `ol` container.        |
 
 ### Sections
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|items|array|Yes|An array of task list item objects. See [items](#items).|
-|heading|object|Yes|See [heading](#headings)|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the section `li`.|
+| Name       | Type   | Required | Description                                                               |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------- |
+| items      | array  | Yes      | An array of task list item objects. See [items](#items).                  |
+| heading    | object | Yes      | See [heading](#headings)                                                  |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the section `li`. |
 
 #### Headings
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|headingLevel|numeric|No|A number for the heading level. Defaults to 2 (`<h2>`)|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the heading. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the heading. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the heading.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the item anchor.|
+| Name         | Type    | Required | Description                                                                                                                         |
+| ------------ | ------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| headingLevel | numeric | No       | A number for the heading level. Defaults to 2 (`<h2>`)                                                                              |
+| text         | string  | Yes      | If `html` is set, this is not required. Text to use within the heading. If `html` is provided, the `text` argument will be ignored. |
+| html         | string  | Yes      | If `text` is set, this is not required. HTML to use within the heading. If `html` is provided, the `text` argument will be ignored. |
+| classes      | string  | No       | Classes to add to the heading.                                                                                                      |
+| attributes   | object  | No       | HTML attributes (for example data attributes) to add to the item anchor.                                                            |
 
 #### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|href|string|Yes|URL of the item anchor. Both href and text attributes for items need to be provided to create an item.|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored.|
-|complete|boolean|No|Flag to mark the item as complete or not. Defaults to `false`.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the item anchor.|
+| Name       | Type    | Required | Description                                                                                                                        |
+| ---------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| href       | string  | Yes      | URL of the item anchor. Both href and text attributes for items need to be provided to create an item.                             |
+| text       | string  | Yes      | If `html` is set, this is not required. Text to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| html       | string  | Yes      | If `text` is set, this is not required. HTML to use within the anchor. If `html` is provided, the `text` argument will be ignored. |
+| complete   | boolean | No       | Flag to mark the item as complete or not. Defaults to `false`.                                                                     |
+| attributes | object  | No       | HTML attributes (for example data attributes) to add to the item anchor.                                                           |
 
-
-*Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).*
+_Warning: If you’re using Nunjucks macros in production be aware that using HTML arguments, or ones ending with `.html` can be at risk from [cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) attacks. More information about security vulnerabilities can be found in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning)._

--- a/src/moj/components/ticket-panel/README.md
+++ b/src/moj/components/ticket-panel/README.md
@@ -1,9 +1,9 @@
 # Ticket Panel
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/ticket-panel)
-- [Preview](https://moj-frontend.herokuapp.com/components/ticket-panel)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/ticket-panel)
 
 ## Example
+
 Below is a typical example of the timeline component in use.
 
 ```
@@ -30,27 +30,27 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|classes|string|No|Classes to add to the ticket panel's container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the ticket panel's container.|
+| Name       | Type   | Required | Description                                                                           |
+| ---------- | ------ | -------- | ------------------------------------------------------------------------------------- |
+| classes    | string | No       | Classes to add to the ticket panel's container.                                       |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the ticket panel's container. |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|classes|string|No|Classes to add to the ticket panel's container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the ticket panel's container.|
+| Name       | Type   | Required | Description                                                                                                                      |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| text       | string | Yes      | If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored. |
+| html       | string | Yes      | If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored. |
+| classes    | string | No       | Classes to add to the ticket panel's container.                                                                                  |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the ticket panel's container.                                            |
 
 ### Classes
 
-|Name|
-|---|
-|moj-ticket-panel__content--blue|
-|moj-ticket-panel__content--red|
-|moj-ticket-panel__content--yellow|
-|moj-ticket-panel__content--green|
-|moj-ticket-panel__content--purple|
-|moj-ticket-panel__content--orange|
+| Name                                |
+| ----------------------------------- |
+| moj-ticket-panel\_\_content--blue   |
+| moj-ticket-panel\_\_content--red    |
+| moj-ticket-panel\_\_content--yellow |
+| moj-ticket-panel\_\_content--green  |
+| moj-ticket-panel\_\_content--purple |
+| moj-ticket-panel\_\_content--orange |

--- a/src/moj/components/timeline/README.md
+++ b/src/moj/components/timeline/README.md
@@ -1,7 +1,6 @@
 # Timeline
 
-- [Guidance](https://moj-design-system.herokuapp.com/components/timeline)
-- [Preview](https://moj-frontend.herokuapp.com/components/timeline)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/timeline)
 
 ### Installation
 
@@ -17,6 +16,7 @@ Object.keys(mojFilters).forEach(function (filterName) {
 ```
 
 ## Example
+
 Below is a typical example of the timeline component in use.
 
 ```
@@ -110,41 +110,41 @@ This component accepts the following arguments.
 
 ### Container
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|classes|string|No|Classes to add to the timeline's container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the timeline's container.|
+| Name       | Type   | Required | Description                                                                       |
+| ---------- | ------ | -------- | --------------------------------------------------------------------------------- |
+| classes    | string | No       | Classes to add to the timeline's container.                                       |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the timeline's container. |
 
 ### Items
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|label|object|Yes|See [item label](#itemlabel).|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored.|
-|datetime|object|No|See [item date and time](#itemdatetime).|
-|byline|object|No|See [item byline](#itembyline).|
-|classes|string|No|Classes to add to the timeline's items container.|
-|attributes|object|No|HTML attributes (for example data attributes) to add to the timeline's items container.|
+| Name       | Type   | Required | Description                                                                                                                      |
+| ---------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| label      | object | Yes      | See [item label](#itemlabel).                                                                                                    |
+| text       | string | Yes      | If `html` is set, this is not required. Text to use within the item. If `html` is provided, the `text` argument will be ignored. |
+| html       | string | Yes      | If `text` is set, this is not required. HTML to use within the item. If `html` is provided, the `text` argument will be ignored. |
+| datetime   | object | No       | See [item date and time](#itemdatetime).                                                                                         |
+| byline     | object | No       | See [item byline](#itembyline).                                                                                                  |
+| classes    | string | No       | Classes to add to the timeline's items container.                                                                                |
+| attributes | object | No       | HTML attributes (for example data attributes) to add to the timeline's items container.                                          |
 
 #### Item label
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the item label. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the item label. If `html` is provided, the `text` argument will be ignored.|
+| Name | Type   | Required | Description                                                                                                                            |
+| ---- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| text | string | Yes      | If `html` is set, this is not required. Text to use within the item label. If `html` is provided, the `text` argument will be ignored. |
+| html | string | Yes      | If `text` is set, this is not required. HTML to use within the item label. If `html` is provided, the `text` argument will be ignored. |
 
 #### Item datetime
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|timestamp|string|Yes|A valid datetime string to be formatted. For example: `1970-01-01T11:59:59.000Z`|
-|type|string|Yes|If `format` is set, this is not required. The standard date format to use within the item. If `type` is provided, the `format` argument will be ignored. Values include: `datetime`, `shortdatetime`, `date`, `shortdate` and `time`|
-|format|string|Yes|If `type` is set, this is not required. The user-defined date format to use within the item. If `type` is provided, the `format` argument will be ignored. See the [Moment.js document on display formats](https://momentjs.com/docs/).|
+| Name      | Type   | Required | Description                                                                                                                                                                                                                             |
+| --------- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| timestamp | string | Yes      | A valid datetime string to be formatted. For example: `1970-01-01T11:59:59.000Z`                                                                                                                                                        |
+| type      | string | Yes      | If `format` is set, this is not required. The standard date format to use within the item. If `type` is provided, the `format` argument will be ignored. Values include: `datetime`, `shortdatetime`, `date`, `shortdate` and `time`    |
+| format    | string | Yes      | If `type` is set, this is not required. The user-defined date format to use within the item. If `type` is provided, the `format` argument will be ignored. See the [Moment.js document on display formats](https://momentjs.com/docs/). |
 
 #### Item byline
 
-|Name|Type|Required|Description|
-|---|---|---|---|
-|text|string|Yes|If `html` is set, this is not required. Text to use within the item byline. If `html` is provided, the `text` argument will be ignored.|
-|html|string|Yes|If `text` is set, this is not required. HTML to use within the item byline. If `html` is provided, the `text` argument will be ignored.|
+| Name | Type   | Required | Description                                                                                                                             |
+| ---- | ------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| text | string | Yes      | If `html` is set, this is not required. Text to use within the item byline. If `html` is provided, the `text` argument will be ignored. |
+| html | string | Yes      | If `text` is set, this is not required. HTML to use within the item byline. If `html` is provided, the `text` argument will be ignored. |


### PR DESCRIPTION
- Update all moj-design-system Heroku URLs to Pattern library domain
- Add a `/get-in-touch` page since various things link there
- Fix some of the Guidance links in component READMEs
- Remove Preview links in component READMEs because they're in the guidance now

My editor also auto-formatted markdown files which I included because it makes them much more readable