### PR TITLE
fix(scrollable): fix CSS shadow effect

### DIFF
--- a/docs/examples/patterns/filter-a-list/index.njk
+++ b/docs/examples/patterns/filter-a-list/index.njk
@@ -144,134 +144,129 @@ title: Filter a list pattern (example)
   </div>
 
   <div class="moj-scrollable-pane">
-
-    <div class="moj-scrollable-pane__wrapper">
-
-      {{ govukTable({
-        firstCellIsHeader: true,
-        head: [
-          {text: 'Reference'},
-          {text: 'Person'},
-          {text: 'Colour'},
-          {text: 'Status'},
-          {text: 'Date of last event'}
+    {{ govukTable({
+      firstCellIsHeader: true,
+      head: [
+        {text: 'Reference'},
+        {text: 'Person'},
+        {text: 'Colour'},
+        {text: 'Status'},
+        {text: 'Date of last event'}
+      ],
+      rows: [
+        [
+          {html: '<a href="#" class="govuk-link">44455453</a>'},
+          {html: 'John Smith'},
+          {text: 'Blue'},
+          {html: 'Complete'},
+          {text: '25 Jan 2018'}
         ],
-        rows: [
-          [
-            {html: '<a href="#" class="govuk-link">44455453</a>'},
-            {html: 'John Smith'},
-            {text: 'Blue'},
-            {html: 'Complete'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12323212</a>'},
-            {html: 'Warren Sutton'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">45678765</a>'},
-            {html: 'Alan Jones'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12345678</a>'},
-            {html: 'Jennifer Langley'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">89009800</a>'},
-            {html: 'Susan Francis'},
-            {text: 'Red'},
-            {html: 'Incomplete'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">44455453</a>'},
-            {html: 'John Smith'},
-            {text: 'Blue'},
-            {html: 'Complete'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12323212</a>'},
-            {html: 'Warren Sutton'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">45678765</a>'},
-            {html: 'Alan Jones'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12345678</a>'},
-            {html: 'Jennifer Langley'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">89009800</a>'},
-            {html: 'Susan Francis'},
-            {text: 'Red'},
-            {html: 'Incomplete'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">45456765</a>'},
-            {html: 'John Smith'},
-            {text: 'Red'},
-            {html: 'Incomplete'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">88675411</a>'},
-            {html: 'Margaret Blake'},
-            {text: 'Red'},
-            {html: 'Incomplete'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">44455453</a>'},
-            {html: 'John Smith'},
-            {text: 'Blue'},
-            {html: 'Complete'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12323212</a>'},
-            {html: 'Warren Sutton'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '25 Jan 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">45678765</a>'},
-            {html: 'Alan Jones'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ],
-          [
-            {html: '<a href="#" class="govuk-link">12345678</a>'},
-            {html: 'Jennifer Langley'},
-            {text: 'Yellow'},
-            {html: 'In progress'},
-            {text: '9 May 2018'}
-          ]
+        [
+          {html: '<a href="#" class="govuk-link">12323212</a>'},
+          {html: 'Warren Sutton'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '25 Jan 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">45678765</a>'},
+          {html: 'Alan Jones'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">12345678</a>'},
+          {html: 'Jennifer Langley'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">89009800</a>'},
+          {html: 'Susan Francis'},
+          {text: 'Red'},
+          {html: 'Incomplete'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">44455453</a>'},
+          {html: 'John Smith'},
+          {text: 'Blue'},
+          {html: 'Complete'},
+          {text: '25 Jan 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">12323212</a>'},
+          {html: 'Warren Sutton'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '25 Jan 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">45678765</a>'},
+          {html: 'Alan Jones'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">12345678</a>'},
+          {html: 'Jennifer Langley'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">89009800</a>'},
+          {html: 'Susan Francis'},
+          {text: 'Red'},
+          {html: 'Incomplete'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">45456765</a>'},
+          {html: 'John Smith'},
+          {text: 'Red'},
+          {html: 'Incomplete'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">88675411</a>'},
+          {html: 'Margaret Blake'},
+          {text: 'Red'},
+          {html: 'Incomplete'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">44455453</a>'},
+          {html: 'John Smith'},
+          {text: 'Blue'},
+          {html: 'Complete'},
+          {text: '25 Jan 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">12323212</a>'},
+          {html: 'Warren Sutton'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '25 Jan 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">45678765</a>'},
+          {html: 'Alan Jones'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
+        ],
+        [
+          {html: '<a href="#" class="govuk-link">12345678</a>'},
+          {html: 'Jennifer Langley'},
+          {text: 'Yellow'},
+          {html: 'In progress'},
+          {text: '9 May 2018'}
         ]
-      }) }}
-    </div>
-
+      ]
+    }) }}
   </div>
 </div>

--- a/src/moj/objects/_scrollable-pane.scss
+++ b/src/moj/objects/_scrollable-pane.scss
@@ -1,46 +1,43 @@
 .moj-scrollable-pane {
+  $scrollableBgColor: white;
+  $scrollableTransparentColor: rgba(255, 255, 255, 0);
+  $scrollableShadowColor: rgba(0, 0, 0, 0.2);
+  $scrollableShadowSize: 0.75em;
 
-  @include govuk-media-query($until: 1020px) {
-    position: relative;
-    overflow: hidden; // Hides the shadow
-    clear: both; // Fixes render bug
-    // width: 100% // Fixes render bug
-
-    &:after {
-      position: absolute;
-      top: 0;
-      left: 100%;
-      width: 50px;
-      height: 100%;
-      border-radius: 10px 0 0 10px / 50% 0 0 50%;
-      box-shadow: -5px 0 10px rgba(0, 0, 0, 0.25);
-      content:"";
-    }
-  }
-
+  overflow-x: scroll;
+  background: linear-gradient(
+      to right,
+      $scrollableBgColor,
+      $scrollableBgColor,
+      $scrollableTransparentColor calc($scrollableShadowSize * 2)
+    ),
+    radial-gradient(
+      farthest-side at 0 50%,
+      $scrollableShadowColor,
+      $scrollableTransparentColor
+    ),
+    linear-gradient(
+      to left,
+      $scrollableBgColor,
+      $scrollableBgColor,
+      $scrollableTransparentColor calc($scrollableShadowSize * 2)
+    ),
+    radial-gradient(
+        farthest-side at 100% 50%,
+        $scrollableShadowColor,
+        $scrollableTransparentColor
+      )
+      100%;
+  background-color: $scrollableBgColor;
+  background-repeat: no-repeat;
+  background-attachment: local, scroll, local, scroll;
+  background-size: 100% 100%, $scrollableShadowSize 100%, 100% 100%,
+    $scrollableShadowSize 100%;
 }
 
 @include govuk-media-query($until: 1020px) {
-  .moj-scrollable-pane__wrapper {
-    overflow-x: auto;
-  }
-
-  .moj-scrollable-pane__wrapper .govuk-table__header,
-  .moj-scrollable-pane__wrapper .govuk-table__cell {
+  .moj-scrollable-pane .govuk-table__header,
+  .moj-scrollable-pane .govuk-table__cell {
     white-space: nowrap;
-  }
-
-  .moj-scrollable-pane > div::-webkit-scrollbar {
-    height: 10px; // Match GOVUK spacing units
-  }
-
-  .moj-scrollable-pane > div::-webkit-scrollbar-track {
-    background: govuk-colour("light-grey");
-    box-shadow: 0 0 2px rgba(0,0,0,.15) inset; // Simulate scrollbar look and feel
-  }
-
-  .moj-scrollable-pane > div::-webkit-scrollbar-thumb {
-    background: govuk-colour("dark-grey");
-    border-radius: govuk-spacing(1);
   }
 }


### PR DESCRIPTION
The `.scrollable-pane` class is supposed to add shadows to indicate that its contents are scrollable, but it is not suitably dynamic.

This CSS uses [scroll shadows](https://www.bram.us/2019/10/24/pure-css-scroll-shadows-vertical-horizontal/) to make the shadows dynamically appear on the left and right when there's overflow content there.

If there's no overflow content, or the container is scrolled all the way to one side, the shadows are hidden.

I removed the `.moj-scrollable-pane__wrapper` class because it's unnecessary.
