### PR TITLE
fix(sortable-table): Sort the columns of the sortable table on page load

### DIFF
--- a/src/moj/components/sortable-table/sortable-table.js
+++ b/src/moj/components/sortable-table/sortable-table.js
@@ -11,6 +11,7 @@ MOJFrontend.SortableTable = function(params) {
 	this.body = this.table.find('tbody');
 	this.createHeadingButtons();
 	this.createStatusBox();
+  this.initialiseSortedColumn();
 	this.table.on('click', 'th button', $.proxy(this, 'onSortButtonClick'));
 };
 
@@ -42,6 +43,20 @@ MOJFrontend.SortableTable.prototype.createHeadingButton = function(heading, i) {
 MOJFrontend.SortableTable.prototype.createStatusBox = function() {
 	this.status = $('<div aria-live="polite" role="status" aria-atomic="true" class="govuk-visually-hidden" />');
 	this.table.parent().append(this.status);
+};
+
+MOJFrontend.SortableTable.prototype.initialiseSortedColumn = function () {
+  var rows = this.getTableRowsArray();
+
+  this.table.find("th")
+    .filter('[aria-sort="ascending"], [aria-sort="descending"]')
+    .first()
+    .each((index, el) => {
+      var sortDirection = $(el).attr('aria-sort');
+      var columnNumber = $(el).find('button').attr('data-index');
+      var sortedRows = this.sort(rows, columnNumber, sortDirection);
+      this.addRows(sortedRows);
+    })
 };
 
 MOJFrontend.SortableTable.prototype.onSortButtonClick = function(e) {


### PR DESCRIPTION
When using the sortable table, the attribute `"aria-sort": "ascending"` can be set in the nunjucks document. This makes the page load with the column header marked as ascending or descending depending on what the consumer has set. 

However, the values in the column are not sorted initially. This PR sorts the columns on the initial load of the page using the sort direction which is defined in the nunjucks file.