### PR TITLE
chore: add staging environment

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -82,6 +82,8 @@ module.exports = function (eleventyConfig) {
   });
 
   eleventyConfig.addShortcode("lastUpdated", function (component) {
+    if (process.env.STAGING) return '';
+
     const dirPath = path.join(__dirname, "src/moj/components", component);
     const [commit, lastUpdated] = execSync(
       `LANG=en_GB git log -n1 --pretty=format:%H,%ad --date=format:'%e %B %Y' ${dirPath}`

--- a/.github/workflows/cd-staging.yaml
+++ b/.github/workflows/cd-staging.yaml
@@ -1,0 +1,48 @@
+name: Continuous Deployment
+
+# For a description of how this works, see this Cloud Platform User Guide page:
+# https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/github-actions-continuous-deployment.html
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'staging'
+
+env:
+  ECR_NAME: ${{ secrets.ECR_NAME }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+
+jobs:
+  staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: docker build -t foo .
+      - name: Push to ECR
+        id: ecr
+        uses: jwalton/gh-ecr-push@v1
+        with:
+          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
+          region: eu-west-2
+          local-image: foo
+          image: ${ECR_NAME}:${{ github.sha }}
+      - name: Update image tag and branch name
+        run: export IMAGE_TAG=${{ github.sha }} && export BRANCH=${GITHUB_REF##*/} && cat kubernetes-deploy-${GITHUB_REF##*/}.tpl | envsubst > kubernetes-deploy.yaml
+      - name: Authenticate to the cluster
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+        run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+      - name: Apply the updated manifest
+        run: |
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:lts-slim AS build
+
+RUN apt-get update && apt-get -y install autoconf gcc make
+
+WORKDIR /app
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+RUN npm ci
+
+COPY assets assets
+COPY docs docs
+COPY src src
+COPY package package
+COPY .eleventy.js .eleventy.js
+COPY gulp gulp
+COPY gulpfile.js gulpfile.js
+COPY README.md README.md
+COPY webpack.config.js webpack.config.js
+RUN STAGING=1 npm run build:docs
+
+FROM nginxinc/nginx-unprivileged:alpine AS nginx
+
+EXPOSE 3000
+
+RUN sed -i -e 's/8080;/3000;/g' /etc/nginx/conf.d/default.conf
+
+COPY --from=build /app/public /usr/share/nginx/html

--- a/docs/_data/env.js
+++ b/docs/_data/env.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    isStaging: process.env.STAGING || false
+  };
+};

--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -1,5 +1,23 @@
 {% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
 
+{% if env.isStaging %}
+  <style>
+    body { border: 10px solid orangered; }
+    .app-staging {
+      padding: 20px;
+      text-align: center;
+      background-color: orangered;
+      color: white;
+      font-family: "GDS Transport",arial,sans-serif;
+    }
+  </style>
+  <aside class="app-staging">
+    <h1>This is a staging environment!</h1>
+    <p>This site is designed to show upcoming previews of changes to the documentation and may not reflect what's actually possible or best practices.</p>
+    <p>See <a href="https://design-patterns.service.justice.gov.uk/">the real documentation</a> for up-to-date information.</p>
+  </aside>
+{% endif %}
+
 {% set html %}
   <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use the service and make improvements.</p>
 {% endset %}

--- a/kubernetes-deploy-staging.tpl
+++ b/kubernetes-deploy-staging.tpl
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moj-prototype-${BRANCH}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prototype-${BRANCH}
+  template:
+    metadata:
+      labels:
+        app: prototype-${BRANCH}
+    spec:
+      containers:
+      - name: prototype
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME}:${IMAGE_TAG}
+        env:
+          - name: USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: username
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: password
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prototype-service-${BRANCH}
+  labels:
+    app: prototype-service-${BRANCH}
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: prototype-${BRANCH}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prototype-ingress-${BRANCH}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: prototype-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+spec:
+  ingressClassName: default
+  tls:
+  - hosts:
+    - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: prototype-service-${BRANCH}
+            port:
+              number: 3000


### PR DESCRIPTION
Provides a preview environment at https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/ of whatever is deployed to the `staging` branch.

The staging environment gets a garish banner to inform people that it's not the real documentation.

Next step: auto-push to staging when someone adds a label to a PR