### PR TITLE
fix(filter-toggle-button): make `bigModeMediaQuery` optional

### DIFF
--- a/src/moj/components/filter-toggle-button/filter-toggle-button.js
+++ b/src/moj/components/filter-toggle-button/filter-toggle-button.js
@@ -10,9 +10,11 @@ MOJFrontend.FilterToggleButton = function(options) {
 };
 
 MOJFrontend.FilterToggleButton.prototype.setupResponsiveChecks = function() {
-  this.mq = window.matchMedia(this.options.bigModeMediaQuery);
-  this.mq.addListener($.proxy(this, 'checkMode'));
-  this.checkMode(this.mq);
+  if (this.options.bigModeMediaQuery) {
+    this.mq = window.matchMedia(this.options.bigModeMediaQuery);
+    this.mq.addListener($.proxy(this, 'checkMode'));
+    this.checkMode(this.mq);
+  }
 };
 
 MOJFrontend.FilterToggleButton.prototype.createToggleButton = function() {


### PR DESCRIPTION
Currently if `bigModeMediaQuery` isn't set then the component will always initialise in "small" mode, where the filter bar is hidden, even if `startHidden` is set to false or not specified.

This change makes `bigModeMediaQuery` optional so that, if it isn't set, `startHidden` is adhered to.

`bigModeMediaQuery` still takes priority over `startHidden` if both are set.

BREAKING CHANGE: If you specify neither `bigModeMediaQuery` nor `startHidden`, the filter will now be initially open on larger screens. To avoid this behaviour, add the `startHidden: true` property.
