### PR TITLE
chore: auto-deploy to staging when label added to PR

### DIFF
--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -1,4 +1,4 @@
-name: Continuous Deployment
+name: Staging environment
 
 # For a description of how this works, see this Cloud Platform User Guide page:
 # https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/github-actions-continuous-deployment.html

--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -1,0 +1,32 @@
+name: Push a tagged PR to staging env
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+jobs:
+  push-to-staging:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'staging:request' }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Remove active labels from other PRs
+        run: |
+          for number in $(gh pr list --label "staging:active" --json number | jq -r '.[].number'); do
+          gh pr edit ${number} --remove-label "staging:active"
+          done
+      - name: Push to staging branch
+        run: |
+          git checkout -b staging-pr-$PRNUM
+          git push -f origin staging-pr-$PRNUM:staging
+        env:
+          PRNUM: ${{ github.event.number }}
+      - name: Update PR with success
+        run: |
+          gh pr comment $PRNUM --body "🚀 Deploying to [staging environment](https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/)"
+          gh pr edit $PRNUM --remove-label "staging:request"
+          gh pr edit $PRNUM --add-label "staging:active"
+        env:
+          PRNUM: ${{ github.event.number }}

--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -2,13 +2,16 @@
 
 {% if env.isStaging %}
   <style>
-    body { border: 10px solid orangered; }
+    body { border: 10px solid #d4351c; }
     .app-staging {
       padding: 20px;
       text-align: center;
-      background-color: orangered;
+      background-color: #d4351c;
       color: white;
       font-family: "GDS Transport",arial,sans-serif;
+    }
+    .app-staging a {
+      color: inherit;
     }
   </style>
   <aside class="app-staging">


### PR DESCRIPTION
If the `staging:request` label is added, the PR will be pushed to `staging` and deployed to the staging env. If any other PRs are currently deployed, their label will be removed.