### PR TITLE
fix: use syntax compatible with postcss-calc

### DIFF
--- a/src/moj/objects/_scrollable-pane.scss
+++ b/src/moj/objects/_scrollable-pane.scss
@@ -9,7 +9,7 @@
       to right,
       $scrollableBgColor,
       $scrollableBgColor,
-      $scrollableTransparentColor calc($scrollableShadowSize * 2)
+      $scrollableTransparentColor calc(var($scrollableShadowSize) * 2)
     ),
     radial-gradient(
       farthest-side at 0 50%,
@@ -20,7 +20,7 @@
       to left,
       $scrollableBgColor,
       $scrollableBgColor,
-      $scrollableTransparentColor calc($scrollableShadowSize * 2)
+      $scrollableTransparentColor calc(var($scrollableShadowSize) * 2)
     ),
     radial-gradient(
         farthest-side at 100% 50%,


### PR DESCRIPTION
postcss-calc isn't happy about the `calc()` function without a `var()` (see #433). This new syntax is compatible and produces the same output in our distributed file.
