### PR TITLE
Fix sortable tables for row headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25703,7 +25703,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/moj/components/sortable-table/sortable-table.js
+++ b/src/moj/components/sortable-table/sortable-table.js
@@ -104,8 +104,8 @@ MOJFrontend.SortableTable.prototype.getTableRowsArray = function() {
 
 MOJFrontend.SortableTable.prototype.sort = function(rows, columnNumber, sortDirection) {
 	var newRows = rows.sort($.proxy(function(rowA, rowB) {
-		var tdA = $(rowA).find('td').eq(columnNumber);
-		var tdB = $(rowB).find('td').eq(columnNumber);
+		var tdA = $(rowA).find('td,th').eq(columnNumber);
+		var tdB = $(rowB).find('td,th').eq(columnNumber);
 		var valueA = this.getCellValue(tdA);
 		var valueB = this.getCellValue(tdB);
 		if(sortDirection === 'ascending') {


### PR DESCRIPTION
### Identify the bug

https://github.com/ministryofjustice/moj-frontend/issues/441

### Description of the change

This fixes the above issue by updating the finder in the `sort` function, which looks for a table cell OR a table header within the rows to ensure the index is correct.

### Alternative designs

N/A

### Possible drawbacks

N/A

### Verification process

#### Before

![CZm4v2H5zD](https://user-images.githubusercontent.com/109774/217811001-68b83e6f-7bde-4a83-9ab9-47633a6db44f.gif)

#### After

![nqijZhLaBo](https://user-images.githubusercontent.com/109774/217811177-6802112c-b409-4948-bf71-62a37bb12af4.gif)



### Release notes

Allow sortable tables to sort the correct column when the table rows have headers.