### PR TITLE
chore: perform patch/minor updates in one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Patch & Minor Updates",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": [
+        "dependencies"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "prCreation": "immediate",
+      "stabilityDays": 3
+    }
   ]
 }


### PR DESCRIPTION
To reduce noise when we get lots of dependency updates at the same time.