### PR TITLE
build: use `build` for Renovate semantic versioning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":semanticCommitTypeAll(build)"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
By default it uses `fix` for production dependencies, but the `package.json` file only affects the docs site and semantic versioning affects the distributed package. So any changes to root dependencies, even production ones, just count as a build chore.