### PR TITLE
fix(filter component): add filter submit attribute params to allow customisation of button

### DIFF
--- a/docs/examples/filter/index.njk
+++ b/docs/examples/filter/index.njk
@@ -79,6 +79,13 @@ title: Filter (example)
   heading: {
     text: 'Filter'
   },
+
+  submit: {
+    attributes: {
+        "data-test-id": "submit-button"
+    }
+  },
+
   selectedFilters: {
 
     heading: {

--- a/src/moj/components/filter/template.njk
+++ b/src/moj/components/filter/template.njk
@@ -48,7 +48,8 @@
     <div class="moj-filter__options">
 
       {{ govukButton({
-        text: 'Apply filters'
+        text: 'Apply filters',
+        attributes: params.submit.attributes
       }) }}
 
       {{params.optionsHtml | safe}}


### PR DESCRIPTION
### Identify the bug

Currently it isn't possible to change the behaviour of the filter "Apply filters" button without externally selecting it using an imprecise address, such as `.moj-filter__options button`.

Although there are workarounds (such as wrapping the component in a form and hooking in to its submit event), it would be helpful to future users to provide a more direct way of changing the button's behaviour.

### Description of the change

This adds the ability to directly set the filter component's "Apply filters" button attributes using the filter macro's parameters.

### Alternative designs

Alternative approaches would be to give the button a unique ID, or to specifically allow the click event to be set. This approach allows greater flexibility, and so hopefully caters for more use cases.

### Possible drawbacks

If users have previously unsuccessfully set the `params.submit.attributes` value and left it in place, then it will suddenly start working when they update. However, this isn't very likely.

### Verification process

The documentation has been updated with an example `data-test-id` attribute, which is applied to the filter component example.

### Release notes

None.