### PR TITLE
feat(filter component): add parameter for apply filters button text

### DIFF
--- a/src/moj/components/filter/template.njk
+++ b/src/moj/components/filter/template.njk
@@ -48,7 +48,7 @@
     <div class="moj-filter__options">
 
       {{ govukButton({
-        text: 'Apply filters',
+        text: params.submit.text if params.submit.text else 'Apply filters',
         attributes: params.submit.attributes
       }) }}
 


### PR DESCRIPTION
### Issue or RFC endorsed by the maintainers

https://github.com/ministryofjustice/moj-frontend/issues/486

### Description of the change

Added the ability to override the filter component's 'Apply filters' text using the newly-added `submit` section of the component's parameters.

### Alternative designs

This text could be updated externally using JavaScript or similar, but this allows the users to configure it from within the application's parameters.

### Possible drawbacks

Conceivably this functionality could be used to add a less descriptive or misleading description, but that would be an issue for the user themselves.

### Verification process

The filter example was updated to verify this functionality locally, but updating the button description in the documentation permanently seemed to present the option as mandatory.

### Release notes

Added the ability to override the filter component's 'Apply filters' button text.