### PR TITLE
Update deployment workflow to replace use of long-lived credentials

### DIFF
--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -12,6 +12,9 @@ env:
 jobs:
   push-to-staging:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ github.event.label.name == 'staging:request' }}
     steps:
       - uses: actions/checkout@v3
@@ -20,32 +23,32 @@ jobs:
           for number in $(gh pr list --label "staging:active" --json number | jq -r '.[].number'); do
           gh pr edit ${number} --remove-label "staging:active"
           done
-      - name: Build
-        run: docker build -t foo .
-      - name: Push to ECR
-        id: ecr
-        uses: jwalton/gh-ecr-push@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          local-image: foo
-          image: ${ECR_NAME}:${{ github.sha }}
-      - name: Update image tag and branch name
-        run: export IMAGE_TAG=${{ github.sha }} && export BRANCH=staging && cat kubernetes-deploy-staging.tpl | envsubst > kubernetes-deploy-staging.yaml
-      - name: Authenticate to the cluster
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+      - uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
+      - run: |
+          docker build -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          cat kubernetes-deploy-staging.tpl | envsubst > kubernetes-deploy-staging.yaml
         env:
-          KUBE_CERT: ${{ secrets.KUBE_CERT }}
-          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-        run: |
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+          BRANCH: "staging"
+      - run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
           kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
           kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
           kubectl config use-context ${KUBE_CLUSTER}
-      - name: Apply the updated manifest
-        run: |
-          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy-staging.yaml
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy.yaml
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
           gh pr comment $PRNUM --body "🚀 Deploying to [staging environment](https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/)"

--- a/kubernetes-deploy-staging.tpl
+++ b/kubernetes-deploy-staging.tpl
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: prototype
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/${ECR_NAME}:${IMAGE_TAG}
+        image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
         env:
           - name: USERNAME
             valueFrom:


### PR DESCRIPTION
As per [Deprecating long-lived credentials for container repositories](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html).