### PR TITLE
docs(plugin configuration): add metadata to plugin configuration to be consumed on plugin pages

### DIFF
--- a/package/govuk-prototype-kit.config.json
+++ b/package/govuk-prototype-kit.config.json
@@ -2,7 +2,7 @@
   "meta": {
     "description": "The MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.",
     "urls": {
-      "documentation": "https://github.com/ministryofjustice/moj-frontend#readme",
+      "documentation": "https://design-patterns.service.justice.gov.uk/",
       "releaseNotes": "https://github.com/ministryofjustice/moj-frontend/releases/tag/v{{version}}",
       "versionHistory": "https://github.com/ministryofjustice/moj-frontend/releases"
     }

--- a/package/govuk-prototype-kit.config.json
+++ b/package/govuk-prototype-kit.config.json
@@ -1,4 +1,12 @@
 {
+  "meta": {
+    "description": "The MOJ Frontend contains the code you need to start building user interfaces for UK Ministry of Justice government services.",
+    "urls": {
+      "documentation": "https://github.com/ministryofjustice/moj-frontend#readme",
+      "releaseNotes": "https://github.com/ministryofjustice/moj-frontend/releases/tag/v{{version}}",
+      "versionHistory": "https://github.com/ministryofjustice/moj-frontend/releases"
+    }
+  },
   "nunjucksFilters": [
     "/moj/filters/prototype-kit-13-filters.js"
   ],


### PR DESCRIPTION
### Description of the change

Add metadata to plugin configuration.  The prototype kit team are working on new pages inside "Manage Prototype" which will display additional information about plugins.  The contents of this PR adds this information to the plugin config file.

### Release notes

 - Added additional information to be shown in the prototype kit plugin page for this project