### PR TITLE
feat(primary-navigation): auto-hide search toggle when it loses focus

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -41,7 +41,7 @@ module.exports = function (eleventyConfig) {
   );
 
   eleventyConfig.addShortcode("example", function (exampleHref, height) {
-    const { data, content: nunjucksCode } = matter(
+    let { data, content: nunjucksCode } = matter(
       fs
         .readFileSync(
           path.join(__dirname, "docs", exampleHref, "index.njk"),
@@ -49,6 +49,8 @@ module.exports = function (eleventyConfig) {
         )
         .trim()
     );
+
+    nunjucksCode = nunjucksCode.split('<!--no include-->')[0].trim();
 
     const rawHtmlCode = nunjucksEnv.renderString(nunjucksCode);
 

--- a/docs/examples/primary-navigation-toggle-search/index.njk
+++ b/docs/examples/primary-navigation-toggle-search/index.njk
@@ -50,3 +50,9 @@ title: Primary navigation with toggleable search (example)
   ],
   searchHtml: toggleSearchHtml
 }) }}
+
+<!--no include-->
+
+<div class="govuk-main-wrapper app-prose-scope">
+  <p class="govuk-body">Some text with <a href="#" class="govuk-link">a link to something else</a> that would be obscured by the toggle.</p>
+</div>

--- a/src/moj/components/search-toggle/search-toggle.js
+++ b/src/moj/components/search-toggle/search-toggle.js
@@ -1,26 +1,51 @@
-MOJFrontend.SearchToggle = function(options) {
+MOJFrontend.SearchToggle = function (options) {
   this.options = options;
 
-  if (this.options.search.container.data('moj-search-toggle-initialised')) {
-    return
+  if (this.options.search.container.data("moj-search-toggle-initialised")) {
+    return;
   }
 
-  this.options.search.container.data('moj-search-toggle-initialised', true);
+  this.options.search.container.data("moj-search-toggle-initialised", true);
 
-  const svg = '<svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="moj-search-toggle__button__icon"><path d="M7.433,12.5790048 C6.06762625,12.5808611 4.75763941,12.0392925 3.79217348,11.0738265 C2.82670755,10.1083606 2.28513891,8.79837375 2.28699522,7.433 C2.28513891,6.06762625 2.82670755,4.75763941 3.79217348,3.79217348 C4.75763941,2.82670755 6.06762625,2.28513891 7.433,2.28699522 C8.79837375,2.28513891 10.1083606,2.82670755 11.0738265,3.79217348 C12.0392925,4.75763941 12.5808611,6.06762625 12.5790048,7.433 C12.5808611,8.79837375 12.0392925,10.1083606 11.0738265,11.0738265 C10.1083606,12.0392925 8.79837375,12.5808611 7.433,12.5790048 L7.433,12.5790048 Z M14.293,12.579 L13.391,12.579 L13.071,12.269 C14.2300759,10.9245158 14.8671539,9.20813198 14.866,7.433 C14.866,3.32786745 11.5381325,-1.65045755e-15 7.433,-1.65045755e-15 C3.32786745,-1.65045755e-15 -1.65045755e-15,3.32786745 -1.65045755e-15,7.433 C-1.65045755e-15,11.5381325 3.32786745,14.866 7.433,14.866 C9.208604,14.8671159 10.9253982,14.2296624 12.27,13.07 L12.579,13.39 L12.579,14.294 L18.296,20 L20,18.296 L14.294,12.579 L14.293,12.579 Z"></path></svg>';
+  const svg =
+    '<svg viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="moj-search-toggle__button__icon"><path d="M7.433,12.5790048 C6.06762625,12.5808611 4.75763941,12.0392925 3.79217348,11.0738265 C2.82670755,10.1083606 2.28513891,8.79837375 2.28699522,7.433 C2.28513891,6.06762625 2.82670755,4.75763941 3.79217348,3.79217348 C4.75763941,2.82670755 6.06762625,2.28513891 7.433,2.28699522 C8.79837375,2.28513891 10.1083606,2.82670755 11.0738265,3.79217348 C12.0392925,4.75763941 12.5808611,6.06762625 12.5790048,7.433 C12.5808611,8.79837375 12.0392925,10.1083606 11.0738265,11.0738265 C10.1083606,12.0392925 8.79837375,12.5808611 7.433,12.5790048 L7.433,12.5790048 Z M14.293,12.579 L13.391,12.579 L13.071,12.269 C14.2300759,10.9245158 14.8671539,9.20813198 14.866,7.433 C14.866,3.32786745 11.5381325,-1.65045755e-15 7.433,-1.65045755e-15 C3.32786745,-1.65045755e-15 -1.65045755e-15,3.32786745 -1.65045755e-15,7.433 C-1.65045755e-15,11.5381325 3.32786745,14.866 7.433,14.866 C9.208604,14.8671159 10.9253982,14.2296624 12.27,13.07 L12.579,13.39 L12.579,14.294 L18.296,20 L20,18.296 L14.294,12.579 L14.293,12.579 Z"></path></svg>';
 
-  this.toggleButton = $('<button class="moj-search-toggle__button" type="button" aria-haspopup="true" aria-expanded="false">' + this.options.toggleButton.text + svg + '</button>');
-	this.toggleButton.on('click', $.proxy(this, 'onToggleButtonClick'));
+  this.toggleButton = $(
+    '<button class="moj-search-toggle__button" type="button" aria-haspopup="true" aria-expanded="false">' +
+      this.options.toggleButton.text +
+      svg +
+      "</button>"
+  );
+  this.toggleButton.on("click", $.proxy(this, "onToggleButtonClick"));
   this.options.toggleButton.container.append(this.toggleButton);
+  $(document).on("click", this.onDocumentClick.bind(this));
+  $(document).on("focusin", this.onDocumentClick.bind(this));
 };
 
-MOJFrontend.SearchToggle.prototype.onToggleButtonClick = function() {
-  if(this.toggleButton.attr('aria-expanded') == 'false') {
-    this.toggleButton.attr('aria-expanded', 'true');
-    this.options.search.container.removeClass('moj-js-hidden');
-    this.options.search.container.find('input').first().focus();
-	} else {
-		this.options.search.container.addClass('moj-js-hidden');
-		this.toggleButton.attr('aria-expanded', 'false');
-	}
+MOJFrontend.SearchToggle.prototype.showMenu = function () {
+  this.toggleButton.attr("aria-expanded", "true");
+  this.options.search.container.removeClass("moj-js-hidden");
+  this.options.search.container.find("input").first().focus();
+};
+
+MOJFrontend.SearchToggle.prototype.hideMenu = function () {
+  this.options.search.container.addClass("moj-js-hidden");
+  this.toggleButton.attr("aria-expanded", "false");
+};
+
+MOJFrontend.SearchToggle.prototype.onToggleButtonClick = function () {
+  if (this.toggleButton.attr("aria-expanded") == "false") {
+    this.showMenu();
+  } else {
+    this.hideMenu();
+  }
+};
+
+MOJFrontend.SearchToggle.prototype.onDocumentClick = function (e) {
+  if (
+    !$.contains(this.options.toggleButton.container[0], e.target) &&
+    !$.contains(this.options.search.container[0], e.target)
+  ) {
+    this.hideMenu();
+  }
 };


### PR DESCRIPTION
WCAG's [Focus Not Obscured (Minimum) success criterion](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum) states:
> When a user interface component receives keyboard focus, the component is not entirely hidden due to author-created content.

The Primary navigation search toggle fails this criterion as it continues to overlay interactive content when it loses focus. This can lead to focused content being entirely hidden.

This change auto-closes the toggle when it loses focus, either through another element being focused, or through the user clicking elsewhere on the page. It can be manually re-opened by pressing the toggle button again.

[Interactive example of old and new behaviour](https://mojpl-520-autoclose.glitch.me/)

See #519 for initial conversation on this topic
