### PR TITLE
docs: add password for staging environment

### DIFF
--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -52,7 +52,8 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
-          gh pr comment $PRNUM --body "🚀 Deploying to [staging environment](https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/)"
+          echo -e "🚀 Deploying to [staging environment](https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`staging\`, **Password:** \`moj\`" > comment.txt
+          gh pr comment $PRNUM --body-file comment.txt
           gh pr edit $PRNUM --remove-label "staging:request"
           gh pr edit $PRNUM --add-label "staging:active"
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM nginxinc/nginx-unprivileged:alpine AS nginx
 
 EXPOSE 3000
 
+COPY docker/htpasswd /etc/nginx/.htpasswd
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=build /app/public /usr/share/nginx/html

--- a/docker/htpasswd
+++ b/docker/htpasswd
@@ -1,0 +1,1 @@
+staging:$apr1$aOnwYL2z$pC8FxfkQ8MQbYJ0ScqJv10

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -7,6 +7,9 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
+
+        auth_basic "Staging site";
+        auth_basic_user_file /etc/nginx/.htpasswd;
     }
 
     error_page   500 502 503 504  /50x.html;


### PR DESCRIPTION
This will avoid the staging environment being indexed by search engines

The username/password are published publicly on the PR because they're not secret
