### PR TITLE
docs(moj to moj): decapitalising the o in MOJ

### DIFF
--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -12,12 +12,12 @@
     <link rel="apple-touch-icon" href="{{ '/assets/images/moj-apple-touch-icon-152x152.png' | url }}" sizes="152x152">
     <link rel="apple-touch-icon" href="{{ '/assets/images/moj-apple-touch-icon.png' | url }}">
 
-    <meta name="description" content="Design your service using MOJ styles, components and patterns">
+    <meta name="description" content="Design your service using MoJ styles, components and patterns">
     <meta property="og:image" content="{{ '/assets/images/moj-opengraph-image.png' | url }}">
 
     <!--[if lte IE 8]><link href="{{ '/assets/stylesheets/application-ie8.css' | url }}" rel="stylesheet"><![endif]-->
     <!--[if gt IE 8]><!--><link href="{{ '/assets/stylesheets/application.css' | url }}" rel="stylesheet"><!--<![endif]-->
-    <title>{% block title %}{{ title }} - MOJ Design System{% endblock %}</title>
+    <title>{% block title %}{{ title }} - MoJ Design System{% endblock %}</title>
 
     <script type="text/javascript" src="https://www.googletagmanager.com/gtag/js?id=G-VTGX4YLSVL" async></script>
     <script type="text/javascript" src="{{ '/assets/javascript/jquery.js' | url }}"></script>

--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -1,6 +1,6 @@
 {% extends "./base.njk" %}
 
-{% block title %}MOJ Design System{% endblock %}
+{% block title %}MoJ Design System{% endblock %}
 
 {% block content %}
 <main id="main-content" class="govuk-main-wrapper govuk-!-padding-top-0 app-prose-scope" role="main">
@@ -12,7 +12,7 @@
           {{ title }}
         </h1>
         <p>
-          Use the MOJ Design System to learn from the work and experiences of others, contribute back into the design system to share your knowledge, and reuse as much as possible to avoid repeating what has already been done.
+          Use the MoJ Design System to learn from the work and experiences of others, contribute back into the design system to share your knowledge, and reuse as much as possible to avoid repeating what has already been done.
         </p>
         <a href="./get-started" class="govuk-button govuk-button--start govuk-!-margin-bottom-0" data-module="govuk-button">
           Get started

--- a/docs/_includes/layouts/partials/get-help.njk
+++ b/docs/_includes/layouts/partials/get-help.njk
@@ -5,12 +5,12 @@
 
 <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
   <div class="govuk-notification-banner__content">
-  
+
     <p class="govuk-notification-banner__heading">
       Need help?
     </p>
       <p class="govuk-notification-banner__body">
-        The MOJ Design System Group provides support for users of the MOJ Design System. <a href="/community/help-and-feedback" class="govuk-link">Contact us</a> to ask for help.
+        The MoJ Design System Group provides support for users of the MoJ Design System. <a href="/community/help-and-feedback" class="govuk-link">Contact us</a> to ask for help.
       </p>
 
   </div>

--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -26,13 +26,13 @@
 {% endset %}
 
 {{ govukCookieBanner({
-  ariaLabel: "Cookies on MOJ Design System",
+  ariaLabel: "Cookies on MoJ Design System",
   attributes: {
     "data-module": "app-cookies"
   },
   messages: [
     {
-      headingText: "Cookies on MOJ Design System",
+      headingText: "Cookies on MoJ Design System",
       html: html,
       actions: [
         {

--- a/docs/_includes/layouts/partials/suggest-a-change-and-help.njk
+++ b/docs/_includes/layouts/partials/suggest-a-change-and-help.njk
@@ -9,10 +9,10 @@
     Suggest a change
   </p>
     <p class="govuk-notification-banner__body">
-      To help improve the MOJ Design System, you can suggest changes.
+      To help improve the MoJ Design System, you can suggest changes.
     </p>
     <p class="govuk-notification-banner__body">
-      Tell us about the change you're proposing by using the <a href="https://forms.gle/FpDpbgttwmfmcz8o7" class="govuk-link">suggest a change form</a>. The MOJ Design System Group will be notified of your suggestion and will review it.
+      Tell us about the change you're proposing by using the <a href="https://forms.gle/FpDpbgttwmfmcz8o7" class="govuk-link">suggest a change form</a>. The MoJ Design System Group will be notified of your suggestion and will review it.
     </p>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -21,7 +21,7 @@
       Need help?
     </p>
       <p class="govuk-notification-banner__body">
-        The MOJ Design System Group provides support for users of the MOJ Design System. <a href="/community/help-and-feedback" class="govuk-link">Contact us</a> to ask for help.
+        The MoJ Design System Group provides support for users of the MoJ Design System. <a href="/community/help-and-feedback" class="govuk-link">Contact us</a> to ask for help.
       </p>
 
   </div>

--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -3,13 +3,13 @@ layout: layouts/community.njk
 title: Propose a component or pattern
 ---
 
-Our contribution process supports teams to add components and patterns based on their users needs and service requirements, whilst guaranteeing the quality and usefulness of the MOJ Design System.
+Our contribution process supports teams to add components and patterns based on their users needs and service requirements, whilst guaranteeing the quality and usefulness of the MoJ Design System.
 
 Anyone can propose a new component or pattern.
 
 ### Step 1: Check the contribution criteria
 
-The MOJ Design System Group review contributions against a [contribution criteria](/community/criteria). To support the review of contributions, first check that your proposal meets the [criteria](/community/criteria).
+The MoJ Design System Group review contributions against a [contribution criteria](/community/criteria). To support the review of contributions, first check that your proposal meets the [criteria](/community/criteria).
 
 ### Step 2: Check for similar contributions
 
@@ -20,5 +20,5 @@ Check if someone has already suggested your idea, or something similar, by viewi
 Propose a contribution using the [contribution form](https://forms.gle/Hp56F9mYxz8Mh4BZ8). When submitted, your contribution can be viewed on the [contribution backlog](https://docs.google.com/spreadsheets/d/1TlF5XxAoE_SPB9JBg1IktY0W30d4kMElwSLGclzL0wQ/edit?usp=sharing).
 
 <div class="govuk-inset-text">
-  If you're unsure about making a contribution, we would encourage you to do so. The MOJ Design System Group will review all contributions and reach out to you to discuss your contribution even if it's not accepted into the design system.
+  If you're unsure about making a contribution, we would encourage you to do so. The MoJ Design System Group will review all contributions and reach out to you to discuss your contribution even if it's not accepted into the design system.
 </div>

--- a/docs/community/criteria.md
+++ b/docs/community/criteria.md
@@ -3,7 +3,7 @@ layout: layouts/community.njk
 title: Contribution criteria
 ---
 
-The MOJ Design System supports the design, build, and delivery of accessible and consistent services. To guarantee the quality of the design system, all styles, components and patterns need to meet certain criteria.
+The MoJ Design System supports the design, build, and delivery of accessible and consistent services. To guarantee the quality of the design system, all styles, components and patterns need to meet certain criteria.
 
 ## Criteria
 
@@ -12,8 +12,8 @@ For a contribution to be considered for the design system, the style, component 
 | Criteria  | Description |
 | --------- | ----------- |
 | **Useful** | The contribution would be useful for many teams or services.<br><br>To support your contribution, it's helpful if you have evidence to suggest that other teams or services have user needs that can be met by your contribution. |
-| **Unique** | The contribution does not replicate something already in the MOJ Design System or [GOV.UK Design System](https://design-system.service.gov.uk/). |
+| **Unique** | The contribution does not replicate something already in the MoJ Design System or [GOV.UK Design System](https://design-system.service.gov.uk/). |
 
 ## Developing a contribution
 
-The MOJ Design System Group reviews contributions to check they meet the criteria. If your contribution is accepted into the design system, the Group will work with you to support the development of your contribution into a common style, component or pattern that other teams can reuse.
+The MoJ Design System Group reviews contributions to check they meet the criteria. If your contribution is accepted into the design system, the Group will work with you to support the development of your contribution into a common style, component or pattern that other teams can reuse.

--- a/docs/community/help-and-feedback.md
+++ b/docs/community/help-and-feedback.md
@@ -3,13 +3,13 @@ layout: layouts/community.njk
 title: Help and feedback
 ---
 
-<span class="govuk-caption-xl">The MOJ Design System Group provides support for users of the MOJ Design System. Contact us to ask for help or to provide feedback.</span>
+<span class="govuk-caption-xl">The MoJ Design System Group provides support for users of the MoJ Design System. Contact us to ask for help or to provide feedback.</span>
 
 ### Contact us on Slack
 
 The group monitors the following channels and provides support as time permits. If you have any questions or feedback, get in touch via Slack.
 
-- For MOJ staff: [#moj-design-system-support](https://moj.enterprise.slack.com/archives/CH5RUSB27)
+- For MoJ staff: [#moj-design-system-support](https://moj.enterprise.slack.com/archives/CH5RUSB27)
 - For UK Government staff:[#moj-design-system](https://ukgovernmentdigital.slack.com/archives/CJ6QDRDGC)
 
 ### Contact us on email

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -3,8 +3,8 @@ layout: layouts/community.njk
 title: Community
 ---
 
-The MOJ Design System supports the design, build, and delivery of accessible and consistent services. It does this by helping people, teams, professions, and communities across the Ministry of Justice to learn from the experiences of each other, contribute and share knowledge, and reuse as much as possible.
+The MoJ Design System supports the design, build, and delivery of accessible and consistent services. It does this by helping people, teams, professions, and communities across the Ministry of Justice to learn from the experiences of each other, contribute and share knowledge, and reuse as much as possible.
 
 ## What's new
 
-View our [latest updates](/community/updates) to see what has been happening with the MOJ Design System, and [our roadmap](/community/roadmap) for the future plans.
+View our [latest updates](/community/updates) to see what has been happening with the MoJ Design System, and [our roadmap](/community/roadmap) for the future plans.

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -4,28 +4,28 @@ subsection: What's new
 title: Roadmap
 ---
 
-This is the roadmap for the MOJ Design System. It shows what we’re working on now, and whilst some things on the roadmap might change, it gives a guide for what we’re planning to do in the future.
+This is the roadmap for the MoJ Design System. It shows what we’re working on now, and whilst some things on the roadmap might change, it gives a guide for what we’re planning to do in the future.
 
 This roadmap was last updated in **November 2023**.
 
 ## Working on now
 
-- ~~Publish roadmap on the public MOJ Design System.~~
-- ~~Setup a MOJ Design System Group.~~
-- ~~Create a contribution criteria for the MOJ Design System. Publish onto the public MOJ Design System.~~
+- ~~Publish roadmap on the public MoJ Design System.~~
+- ~~Setup a MoJ Design System Group.~~
+- ~~Create a contribution criteria for the MoJ Design System. Publish onto the public MoJ Design System.~~
 - Develop a low-barrier contribution process. Test and iterate.
-- Review all styles, components, and patterns that exist in the MOJ Design System, and that have also been contributed to sandbox areas. Check what does and doesn’t meet the contribution criteria.
+- Review all styles, components, and patterns that exist in the MoJ Design System, and that have also been contributed to sandbox areas. Check what does and doesn’t meet the contribution criteria.
 - Resolve any styles, components, or patterns that do not meet our contribution criteria. Roadmap to be updated based on the required resolution work.
 
 ## Working on next
 
-- Canvas the MOJ design, engineering, and product communities for styles, component, pattern, and service pattern contributions.
+- Canvas the MoJ design, engineering, and product communities for styles, component, pattern, and service pattern contributions.
 - Prioritise contributions with the communities.
-- The MOJ Design System Group to work through the prioritised contribution list. Roadmap to be updated based on the list.
-- Publish service patterns onto the public MOJ Design System.
+- The MoJ Design System Group to work through the prioritised contribution list. Roadmap to be updated based on the list.
+- Publish service patterns onto the public MoJ Design System.
 
 ## Working on later
 
 - Develop low-barrier change request process. Test and iterate.
 - Improve online guidance for prototyping (and include guidance for prototyping with other tools like Figma).
-- Run a discovery to understand how the MOJ Design System might further support teams.
+- Run a discovery to understand how the MoJ Design System might further support teams.

--- a/docs/community/suggest-a-change.md
+++ b/docs/community/suggest-a-change.md
@@ -3,7 +3,7 @@ layout: layouts/community.njk
 title: Suggest a change
 ---
 
-To help improve the MOJ Design System, you can suggest changes to components and patterns.
+To help improve the MoJ Design System, you can suggest changes to components and patterns.
 
 Useful suggestions may look like:
 
@@ -12,7 +12,7 @@ Useful suggestions may look like:
 
 ## Tell us your suggestion
 
-Tell us about the change you're proposing by using the [suggest a change form](https://forms.gle/FpDpbgttwmfmcz8o7). The MOJ Design System Group will be notified of your suggestion and will review it.
+Tell us about the change you're proposing by using the [suggest a change form](https://forms.gle/FpDpbgttwmfmcz8o7). The MoJ Design System Group will be notified of your suggestion and will review it.
 
 Once reviewed, the group will either:
 

--- a/docs/community/users-and-data.md
+++ b/docs/community/users-and-data.md
@@ -14,10 +14,10 @@ We aim to continuously improve our design system around the people that use it, 
   </div>
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-m">Contributions</h3>
-    <p class="govuk-body">We aim to have an easy contribution model to encourage the use of the MOJ Design System. Tracking contributions helps us to spot trends and address any barriers.</p>
+    <p class="govuk-body">We aim to have an easy contribution model to encourage the use of the MoJ Design System. Tracking contributions helps us to spot trends and address any barriers.</p>
     <p class="govuk-body">Since December 2023:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>5 contributions have been proposed into the MOJ Design System</li>
+        <li>5 contributions have been proposed into the MoJ Design System</li>
         <li>2 have been accepted</li>
         <li>1 has been declined</li>
         <li>2 are in review</li>
@@ -33,10 +33,10 @@ We aim to continuously improve our design system around the people that use it, 
   </div>
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-m">Usability</h3>
-    <p class="govuk-body">We aim to have a design system that has high levels of engagement and usability. Monitoring engagement and usability helps the direction of the MOJ Design System to be led by data.</p>
+    <p class="govuk-body">We aim to have a design system that has high levels of engagement and usability. Monitoring engagement and usability helps the direction of the MoJ Design System to be led by data.</p>
     <p class="govuk-body">In the last 12 months:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>The MOJ Design System website has received 37,200 visits</li>
+      <li>The MoJ Design System website has received 37,200 visits</li>
     </ul>
   </div>
 </div>
@@ -49,7 +49,7 @@ We aim to continuously improve our design system around the people that use it, 
   </div>
   <div class="govuk-grid-column-one-half">
     <h3 class="govuk-heading-m">User research</h3>
-    <p class="govuk-body">We aim to have a design system that is led by its users. Talking to users of the MOJ Design System helps us to meet their needs.</p>
+    <p class="govuk-body">We aim to have a design system that is led by its users. Talking to users of the MoJ Design System helps us to meet their needs.</p>
     <p class+"govuk-body">Since December 2023:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>1 research session has been carried out</li>

--- a/docs/components/archived-components.md
+++ b/docs/components/archived-components.md
@@ -3,7 +3,7 @@ layout: layouts/component.njk
 title: Archived components
 ---
 
-MOJ components are archived when similar components are published in the GOV.UK Design System, or when it is no longer practical to support them.
+MoJ components are archived when similar components are published in the GOV.UK Design System, or when it is no longer practical to support them.
 
 ### Contents
 

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -4,7 +4,7 @@ isIndex: true
 title: Components
 ---
 
-Components in this section have been created by designers and developers at MOJ.
+Components in this section have been created by designers and developers at MoJ.
 
 To use these components you can either:
 
@@ -13,4 +13,4 @@ To use these components you can either:
 
 To contribute your research findings, designs or code, share it on the <a href="https://mojdt.slack.com/archives/CH5RUSB27" class="govuk-link">#moj-pattern-library-support</a> channel on Slack.</p>
 
-If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MOJ component will be [archived](archived-components).
+If a similar component is in the [GOV.UK Design System](https://design-system.service.gov.uk/components/), you should use that component instead. The MoJ component will be [archived](archived-components).

--- a/docs/cookies.md
+++ b/docs/cookies.md
@@ -3,7 +3,7 @@ layout: layouts/plain.njk
 title: Cookies
 ---
 
-We use cookies to understand how you navigate and use the MOJ Design System documentation the service, so that we can understand interest in components and make improvements to the documentation's structure and content.
+We use cookies to understand how you navigate and use the MoJ Design System documentation the service, so that we can understand interest in components and make improvements to the documentation's structure and content.
 
 <div data-module="app-cookies" data-persistent>
   <div class="govuk-button-group">

--- a/docs/get-started/deploying-your-prototype.md
+++ b/docs/get-started/deploying-your-prototype.md
@@ -4,7 +4,7 @@ subsection: How to guides
 title:  Deploying your prototype
 ---
 
-If you work for the Ministry of Justice, we recommend using MOJ Cloud Platform to deploy your prototype.
+If you work for the Ministry of Justice, we recommend using MoJ Cloud Platform to deploy your prototype.
 
 The [Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) shows you how to set up a GitHub repository with the prototype kit installed, along with a Cloud Platform hosting environment. Changes to your repository will automatically be deployed to Cloud Platform.
 

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -7,14 +7,14 @@ To make your service consistent with GOV.UK, you should start by checking what e
 
 If something is not in the GOV.UK Design System, you should check what exists in the:
 
-- MOJ Design System
+- MoJ Design System
 - [other departments pattern libraries](https://github.com/ctdesign/gov-design-systems-list)
 - [GOV.UK community backlog](https://github.com/orgs/alphagov/projects/43/views/1)
 
 Reuse as much as possible and iterate based on user needs.
 ## Using the Design System
 
-The MOJ Design System brings together [components](./components) and [patterns](./patterns) created by designers and developers at MOJ.
+The MoJ Design System brings together [components](./components) and [patterns](./patterns) created by designers and developers at MoJ.
 
 To use these components and patterns you can either:
 
@@ -23,4 +23,4 @@ To use these components and patterns you can either:
 
 ## Contributing to the Design System
 
-You can contribute your research findings, designs or code to the MOJ Design System by commenting on [existing discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or starting a [new discussion](https://github.com/ministryofjustice/moj-frontend/discussions/new) on GitHub.
+You can contribute your research findings, designs or code to the MoJ Design System by commenting on [existing discussions](https://github.com/ministryofjustice/moj-frontend/discussions) or starting a [new discussion](https://github.com/ministryofjustice/moj-frontend/discussions/new) on GitHub.

--- a/docs/get-started/installing-compiled.md
+++ b/docs/get-started/installing-compiled.md
@@ -1,9 +1,9 @@
 ---
 layout: layouts/get-started.njk
-title: Installing MOJ Frontend using compiled files
+title: Installing MoJ Frontend using compiled files
 ---
 
-You can install MOJ Frontend using the compiled files released with each version. However, by doing so, you will **not** be able to:
+You can install MoJ Frontend using the compiled files released with each version. However, by doing so, you will **not** be able to:
 
 - selectively include the CSS or JavaScript for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
@@ -14,7 +14,7 @@ In a live application, we recommend that you [install with npm](../installing-wi
 
 ## Copy the files
 
-1. Download the `release-<VERSION-NUMBER>.zip` file at the bottom of the [latest MOJ Frontend release note](https://github.com/ministryofjustice/moj-frontend/releases/latest).
+1. Download the `release-<VERSION-NUMBER>.zip` file at the bottom of the [latest MoJ Frontend release note](https://github.com/ministryofjustice/moj-frontend/releases/latest).
 2. Unzip the zip file.
 3. Copy the `assets` folder to the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/assets/images/moj-logotype-crest.png` shows the `images/moj-logotype-crown.png` image in your users’ browsers.
 4. Copy the 2 `.css` files to a stylesheets folder in the root of your project’s public folder, so that for example `<YOUR-SITE-URL>/stylesheets/moj-frontend.min.css` shows the CSS file in your users’ browsers.
@@ -25,7 +25,7 @@ In a live application, we recommend that you [install with npm](../installing-wi
 ### With the GOV.UK Design System
 
 1. Follow [the instructions for installing the GOV.UK Design System](https://frontend.design-system.service.gov.uk/install-using-precompiled-files/)
-2. Add `link` tags for the MOJ Frontend CSS, alongside the GOV.UK ones in the `head`:
+2. Add `link` tags for the MoJ Frontend CSS, alongside the GOV.UK ones in the `head`:
    ```html
    <!--[if !IE 8]><!-->
    <link rel="stylesheet" href="/stylesheets/moj-frontend.min.css" />
@@ -34,7 +34,7 @@ In a live application, we recommend that you [install with npm](../installing-wi
      <link rel="stylesheet" href="/stylesheets/moj-frontend-ie8.min.css" />
    <![endif]-->
    ```
-3. Add `script` tags for the MOJ Frontend JavaScript, alongside the GOV.UK at the bottom of the `body`. This includes jQuery, which is a dependency of MOJ Frontend.
+3. Add `script` tags for the MoJ Frontend JavaScript, alongside the GOV.UK at the bottom of the `body`. This includes jQuery, which is a dependency of MoJ Frontend.
    ```html
    <script
      src="https://code.jquery.com/jquery-3.6.0.min.js"
@@ -49,7 +49,7 @@ In a live application, we recommend that you [install with npm](../installing-wi
 
 ### Without the GOV.UK Design System
 
-It is unlikely that you would ever want to install the MOJ Design System alone, but if so you can follow the guide below to check that it is working.
+It is unlikely that you would ever want to install the MoJ Design System alone, but if so you can follow the guide below to check that it is working.
 
 1. Create a page in your project using the following HTML (in your live application, you should use the [Design System page template](https://design-system.service.gov.uk/styles/page-template/) instead):
 
@@ -57,7 +57,7 @@ It is unlikely that you would ever want to install the MOJ Design System alone, 
    <!DOCTYPE html>
    <html lang="en" class="govuk-template ">
      <head>
-       <title>Example - MOJ Frontend</title>
+       <title>Example - MoJ Frontend</title>
        <meta
          name="viewport"
          content="width=device-width, initial-scale=1, viewport-fit=cover"

--- a/docs/get-started/installing-with-npm.md
+++ b/docs/get-started/installing-with-npm.md
@@ -1,11 +1,11 @@
 ---
 layout: layouts/get-started.njk
-title: Installing MOJ Frontend with NPM
+title: Installing MoJ Frontend with NPM
 ---
 
 ## Requirements
 
-To use MOJ Frontend with NPM you must:
+To use MoJ Frontend with NPM you must:
 
 1. Install the long-term support (LTS) version of [Node.js](https://nodejs.org/en/), which includes NPM. The minimum version of Node required is 4.2.0.
 
@@ -13,13 +13,13 @@ To use MOJ Frontend with NPM you must:
 
 2. Create a [package.json file](https://docs.npmjs.com/files/package.json) if you don’t already have one. You can create a default `package.json` file by running `npm init` from the root of your application.
 
-3. Install [jQuery](https://jquery.com/), which is required by the MOJ Frontend JavaScript
+3. Install [jQuery](https://jquery.com/), which is required by the MoJ Frontend JavaScript
 
 ```
 npm install jquery --save
 ```
 
-1. If you want to use the MOJ Frontend Nunjucks macros, install Nunjucks - the minimum version required is 3.0.0.
+1. If you want to use the MoJ Frontend Nunjucks macros, install Nunjucks - the minimum version required is 3.0.0.
 
 ```
 npm install nunjucks --save
@@ -33,11 +33,11 @@ To install, run:
 npm install --save @ministryofjustice/frontend
 ```
 
-After you have installed MOJ Frontend the `@ministryofjustice/frontend` package will appear in your `node_modules` folder.
+After you have installed MoJ Frontend the `@ministryofjustice/frontend` package will appear in your `node_modules` folder.
 
 ## Importing styles
 
-You need to import the MOJ Frontend styles into the main Sass file in your project. You should place the below code before your own Sass rules (or Sass imports) if you want to override MOJ Frontend with your own styles.
+You need to import the MoJ Frontend styles into the main Sass file in your project. You should place the below code before your own Sass rules (or Sass imports) if you want to override MoJ Frontend with your own styles.
 
 1. To import all components, add the below to your Sass file:
 
@@ -71,7 +71,7 @@ gulp.task('sass', function () {
 If you compile Sass to CSS in your project, your build tasks will already include something similar to the above task - in that case, you will just need
 to include add `includePaths` to it.
 
-After resolving the import paths you can import MOJ Frontend by using:
+After resolving the import paths you can import MoJ Frontend by using:
 
 ```CSS
 @import "@ministryofjustice/frontend/moj/components/button/button";
@@ -79,7 +79,7 @@ After resolving the import paths you can import MOJ Frontend by using:
 
 ## Importing assets
 
-In order to import MOJ Frontend images and fonts to your project, you should configure your application to reference or copy the relevant MOJ Frontend assets.
+In order to import MoJ Frontend images and fonts to your project, you should configure your application to reference or copy the relevant MoJ Frontend assets.
 
 Follow either [Recommended solution](#recommended-solution) or [Alternative solution](#alternative-solution).
 
@@ -95,7 +95,7 @@ app.use('/assets', express.static(path.join(__dirname, '/node_modules/@ministryo
 
 ### Alternative solution
 
-Manually copy the images and fonts from `/node_modules/@ministryofjustice/frontend/moj/assets` into a public facing directory in your project. Ideally copying the files to your project should be an automated task or part of your build pipeline to ensure that the MOJ Frontend assets stay up-to-date.
+Manually copy the images and fonts from `/node_modules/@ministryofjustice/frontend/moj/assets` into a public facing directory in your project. Ideally copying the files to your project should be an automated task or part of your build pipeline to ensure that the MoJ Frontend assets stay up-to-date.
 
 The default paths used for assets are `assets/images` and `assets/fonts`. **If your asset folders follow this structure, you will not need to complete the following steps.**
 

--- a/docs/get-started/our-approach.md
+++ b/docs/get-started/our-approach.md
@@ -4,13 +4,13 @@ subsection: How we work
 title: Our approach
 ---
 
-The MOJ understands user experience is key to delivery. The Design System Working Group and Design System team's ways of working are focussed on delivering better products for users by being **open**, **collaborative** and **pragmatic**.
+The MoJ understands user experience is key to delivery. The Design System Working Group and Design System team's ways of working are focussed on delivering better products for users by being **open**, **collaborative** and **pragmatic**.
 
 **Being open**
 
 - our service teams have visibility of our work and backlog and understand how it feeds into delivery
 - our service teams provide input to the focus, priority and direction of our work
-- we invest time to ensure our work has wider value across the MOJ
+- we invest time to ensure our work has wider value across the MoJ
 
 **Being collaborative**
 

--- a/docs/get-started/production.md
+++ b/docs/get-started/production.md
@@ -4,19 +4,19 @@ subsection: How we work
 title: Production
 ---
 
-This guide explains how to set up your project so you can start using the styles and coded examples in the MOJ Design System in production.
+This guide explains how to set up your project so you can start using the styles and coded examples in the MoJ Design System in production.
 
 ## Before you start
 
 First you must have followed the [GOV.UK Design System production setup guide](https://design-system.service.gov.uk/get-started/production/).
 
-## Include the MOJ Frontend in your project
+## Include the MoJ Frontend in your project
 
-To start using MOJ styles, components and patterns contained here, you’ll need to include MOJ Frontend in your project.
+To start using MoJ styles, components and patterns contained here, you’ll need to include MoJ Frontend in your project.
 
 ### Option 1: install using npm
 
-We recommend [installing MOJ Frontend using npm](../installing-with-npm). Using this option, you will be able to:
+We recommend [installing MoJ Frontend using npm](../installing-with-npm). Using this option, you will be able to:
 
 - selectively include the CSS or JavaScript for individual components
 - build your own styles or components based on the palette or typography and spacing mixins
@@ -27,7 +27,7 @@ You will also need to [set up JavaScript](../setting-up-javascript) if you want 
 
 ### Option 2: include compiled files
 
-If your project does not use npm, or if you want to try out MOJ Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](../installing-compiled).
+If your project does not use npm, or if you want to try out MoJ Frontend in your project without installing it through npm, you can [download and include compiled stylesheets, JavaScript and the asset files](../installing-compiled).
 
 Using this option, you will be able to include all the CSS and JavaScript of GOV.UK Frontend in your project.
 

--- a/docs/get-started/prototyping.md
+++ b/docs/get-started/prototyping.md
@@ -4,25 +4,25 @@ subsection: How we work
 title: Prototyping
 ---
 
-This guide explains how to create prototypes using the MOJ Design System and GOV.UK Prototype Kit.
+This guide explains how to create prototypes using the MoJ Design System and GOV.UK Prototype Kit.
 
 ## Use a template from Cloud Platform
 
-You can follow the [MOJ Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) to automatically set up a GitHub repository containing the GOV.UK Prototype Kit and a hosting environment.
+You can follow the [MoJ Cloud Platform guide](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/prototype-kit.html) to automatically set up a GitHub repository containing the GOV.UK Prototype Kit and a hosting environment.
 
-This template comes with the MOJ Design System pre-installed so you don't need to set it up manually. However you may need to update it using [the instructions below](#updating-moj-frontend).
+This template comes with the MoJ Design System pre-installed so you don't need to set it up manually. However you may need to update it using [the instructions below](#updating-moj-frontend).
 
 ## Manual installation
 
-You can also install the GOV.UK Prototype Kit and MOJ Design System manually. You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first.
+You can also install the GOV.UK Prototype Kit and MoJ Design System manually. You must follow the [GOV.UK Design System prototype setup guide](https://design-system.service.gov.uk/get-started/prototyping/) first.
 
-You then need to install the NPM package for the MOJ Design System:
+You then need to install the NPM package for the MoJ Design System:
 
 1. Open a command prompt application (e.g. Terminal on MacOS)
 2. Change the directory to your prototype's directory. For example, `cd path/to/prototype`
 3. Run `npm install @ministryofjustice/frontend --save`
 
-If you're using version 13 or later of the GOV.UK Prototype Kit, the components of the MOJ Design System will now be available to you.
+If you're using version 13 or later of the GOV.UK Prototype Kit, the components of the MoJ Design System will now be available to you.
 
 <details class="govuk-details">
   <summary class="govuk-details__summary">
@@ -32,7 +32,7 @@ If you're using version 13 or later of the GOV.UK Prototype Kit, the components 
   </summary>
   <div class="govuk-details__text">
 
-If you're using a version of the GOV.UK Prototype Kit before 13, you need to take additional steps to use the MOJ Design System in your prototype:
+If you're using a version of the GOV.UK Prototype Kit before 13, you need to take additional steps to use the MoJ Design System in your prototype:
 
 1. Open `app/assets/javascripts/application.js`
 2. Add `window.MOJFrontend.initAll()` below the line that does the same for `GOVUKFrontend`
@@ -40,17 +40,17 @@ If you're using a version of the GOV.UK Prototype Kit before 13, you need to tak
   </div>
 </details>
 
-## Updating MOJ Frontend
+## Updating MoJ Frontend
 
-The current version of MOJ Frontend is **{% version %}**.
+The current version of MoJ Frontend is **{% version %}**.
 
 You can check which version your prototype is running by opening `package.json` in the root folder of your prototype. Look for `"@ministryofjustice/frontend"` under `"dependencies"`.
 
-To update your prototype to the latest version of MOJ Frontend:
+To update your prototype to the latest version of MoJ Frontend:
 
 1. Check that you're using the latest long-term support version of npm (for example by using [Node Version Manager](https://github.com/nvm-sh/nvm))
 2. Open `package.json` in the root folder of your prototype in a text editor
-3. Under `dependencies`, update the reference to MOJ Frontend to `"@ministryofjustice/frontend": "{% version %}",`
+3. Under `dependencies`, update the reference to MoJ Frontend to `"@ministryofjustice/frontend": "{% version %}",`
 4. Save `package.json`
 5. Open a command prompt application (e.g. Terminal on MacOS)
 6. Change the directory to your prototype's directory. For example, `cd path/to/prototype`

--- a/docs/get-started/setting-up-javascript.md
+++ b/docs/get-started/setting-up-javascript.md
@@ -4,11 +4,11 @@ subsection: How to guides
 title:  Setting up JavaScript
 ---
 
-Several MOJ Design System components use JavaScript to provide interactive features. In order to fully use these components you will need to add some code to your service to set up the JavaScript.
+Several MoJ Design System components use JavaScript to provide interactive features. In order to fully use these components you will need to add some code to your service to set up the JavaScript.
 
 You can either
 
-- include the MOJ Design System's JavaScript code directly in your HTML templates
+- include the MoJ Design System's JavaScript code directly in your HTML templates
 - import the JavaScript using a bundler like Webpack
 
 ## Add the JavaScript file to your HTML

--- a/docs/get-started/supporting-internet-explorer-8.md
+++ b/docs/get-started/supporting-internet-explorer-8.md
@@ -3,11 +3,11 @@ layout: layouts/get-started.njk
 title: Supporting Internet Explorer 8
 ---
 
-If you are including MOJ Frontend as part of your application's stylesheets then you'll need to do some additional work to support Internet Explorer 8 (IE8).
+If you are including MoJ Frontend as part of your application's stylesheets then you'll need to do some additional work to support Internet Explorer 8 (IE8).
 
 The first thing you need to do is follow [GOV.UK Frontend's setup instructions](https://frontend.design-system.service.gov.uk/supporting-ie8/) for supporting Internet Explorer 8.
 
-When [generating your IE8-specific stylesheet](https://frontend.design-system.service.gov.uk/supporting-ie8/#2-generate-an-ie8-specific-stylesheet), your `application.scss` will also include the MOJ Frontend import:
+When [generating your IE8-specific stylesheet](https://frontend.design-system.service.gov.uk/supporting-ie8/#2-generate-an-ie8-specific-stylesheet), your `application.scss` will also include the MoJ Frontend import:
 
 ```scss
 // application.scss

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@ title: Design, build, and deliver accessible and consistent services
 
 ---
 
-## Contribute to the MOJ Design System
+## Contribute to the MoJ Design System
 
-Anyone can contribute to the MOJ Design System by proposing a new style, component, or pattern.
+Anyone can contribute to the MoJ Design System by proposing a new style, component, or pattern.
 
 [Propose a contribution](./community/contribute)
 
@@ -15,6 +15,6 @@ Anyone can contribute to the MOJ Design System by proposing a new style, compone
 
 ## Roadmap and latest updates
 
-Find out what the plans are for the MOJ Design System over the coming months, as well as updates on the latest changes and improvements.
+Find out what the plans are for the MoJ Design System over the coming months, as well as updates on the latest changes and improvements.
 
 [View the roadmap](./community/roadmap)

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -3,7 +3,7 @@ layout: layouts/patterns.njk
 title: Patterns
 ---
 
-Patterns in this section have been created by designers and developers at MOJ.
+Patterns in this section have been created by designers and developers at MoJ.
 
 
 


### PR DESCRIPTION
### Description

The Ministry of Justice acronym is MoJ but it has been implemented as MOJ across the public site. This change replaced MOJ with MoJ.