### PR TITLE
docs(archiving question pages pattern): question pages pattern archiv…

### DIFF
--- a/docs/_includes/layouts/patterns.njk
+++ b/docs/_includes/layouts/patterns.njk
@@ -43,10 +43,6 @@
             },
             items: [
               {
-                text: 'Question pages',
-                href: ('/patterns/question-pages' | url)
-              },
-              {
                 text: 'Task list pages',
                 href: ('/patterns/task-list' | url)
               },
@@ -59,13 +55,26 @@
         ]
       }) }}
 
+
+      <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+      {{ appSideNavigation({
+        items: [
+          {
+            text: 'Archived patterns',
+            href: ('/patterns/archived-patterns' | url)
+          }
+        ]
+      }) }}
+
+
       {% include "./partials/back-to-top.njk" %}
     </div>
 
     <div class="govuk-grid-column-two-thirds">
       <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
         <h1 class="govuk-heading-xl">
-          {% if subsection %}<span class="govuk-caption-xl">{{ subsection }}</span>{% endif %}
+          {% if not isIndex %}<span class="govuk-caption-xl">Patterns</span>{% endif %}
           {{ title }}
         </h1>
         {{ content | safe }}

--- a/docs/patterns/archived-patterns.md
+++ b/docs/patterns/archived-patterns.md
@@ -1,0 +1,16 @@
+---
+layout: layouts/patterns.njk
+title: Archived patterns
+---
+
+MoJ patterns are archived when similar patterns are published in the GOV.UK Design System, or when it is no longer practical to support them.
+
+### Contents
+
+- [Question pages](#question-pages)
+
+## Question pages
+
+[Question pages](../question-pages) was archived on 11 December 2023.
+
+This pattern has been archived as documentation on [question pages](https://design-system.service.gov.uk/patterns/question-pages/) is published in the GOV.UK Design System. Further information about [structuring forms](https://www.gov.uk/service-manual/design/form-structure) is also published in the GOV.UK Service Manual.

--- a/docs/patterns/question-pages.md
+++ b/docs/patterns/question-pages.md
@@ -3,12 +3,9 @@ layout: layouts/patterns.njk
 title: Question pages
 ---
 
-{% banner "The GOV.UK Design System has similar guidance" %}
+{% banner "This pattern is archived" %}
 
-- [Question pages](https://design-system.service.gov.uk/patterns/question-pages) is published in the GOV.UK Design System.
-- [Structuring forms](https://www.gov.uk/service-manual/design/form-structure) is published in the GOV.UK Service Manual.
-
-You should consider following the GOV.UK guidance if it fits your needs.
+This pattern has been archived as documentation on [question pages](https://design-system.service.gov.uk/patterns/question-pages/) is published in the GOV.UK Design System. Further information about [structuring forms](https://www.gov.uk/service-manual/design/form-structure) is also published in the GOV.UK Service Manual.
 {% endbanner %}
 
 ## Asking multiple questions per page
@@ -21,14 +18,14 @@ Before asking multiple questions per page, you should first:
 
 User research will tell you if it makes sense to group a number of related questions on the same page. For example, if you’re designing an internal service for government users who need to repeat and switch between tasks quickly.
 
-If user research tells you to group pages together, you should: 
+If user research tells you to group pages together, you should:
 
 - follow the guidance on [asking multiple questions on a page](https://design-system.service.gov.uk/patterns/question-pages/#asking-multiple-questions-on-a-page) in the GOV.UK Design System.
 
-### Further reading 
+### Further reading
 
 - [Design principles for admin interfaces](https://designnotes.blog.gov.uk/2015/09/25/design-principles-for-admin-interfaces/) including more than one thing per page
 
-## Contribute 
+## Contribute
 
 [Discuss question pages on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/215)


### PR DESCRIPTION
### Description

- Question pages pattern no longer needed.
- Archive section created for patterns (based on archived components section)
- Question page link removed from navigation
- Banner updated on question page pattern to highlight it as an archived pattern