### PR TITLE
docs(figma links to components): adding Figma links to components in …

### DIFF
--- a/docs/examples/banner-information/index.njk
+++ b/docs/examples/banner-information/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Information banner (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5802&mode=design
 ---
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 

--- a/docs/examples/banner-success/index.njk
+++ b/docs/examples/banner-success/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Success banner (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5802&mode=design
 ---
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 

--- a/docs/examples/banner-warning/index.njk
+++ b/docs/examples/banner-warning/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Warning banner (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5802&mode=design
 ---
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 

--- a/docs/examples/banner/index.njk
+++ b/docs/examples/banner/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Banner (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5802&mode=design
 ---
 {%- from "moj/components/banner/macro.njk" import mojBanner -%}
 

--- a/docs/examples/button-menu-collapsible-alternative/index.njk
+++ b/docs/examples/button-menu-collapsible-alternative/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Button menu (example)
 arguments: button-menu
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5816&mode=design
 ---
 
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}

--- a/docs/examples/button-menu-collapsible/index.njk
+++ b/docs/examples/button-menu-collapsible/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Button menu (example)
 arguments: button-menu
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5816&mode=design
 ---
 
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}

--- a/docs/examples/button-menu/index.njk
+++ b/docs/examples/button-menu/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Button menu (example)
 arguments: button-menu
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5816&mode=design
 ---
 
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}

--- a/docs/examples/notification-badge/index.njk
+++ b/docs/examples/notification-badge/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Notification badge (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=61-3019&mode=design
 ---
 
 {%- from "moj/components/notification-badge/macro.njk" import mojNotificationBadge -%}

--- a/docs/examples/organisation-switcher/index.njk
+++ b/docs/examples/organisation-switcher/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Organisation switcher (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5984&mode=design
 ---
 
 {%- from "moj/components/organisation-switcher/macro.njk" import mojOrganisationSwitcher -%}

--- a/docs/examples/page-header-actions/index.njk
+++ b/docs/examples/page-header-actions/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Page header actions (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-5998&mode=design
 ---
 
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}

--- a/docs/examples/password-reveal/index.njk
+++ b/docs/examples/password-reveal/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Password reveal (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=66-6026&mode=design
 ---
 
 {%- from "govuk/components/input/macro.njk" import govukInput -%}

--- a/docs/examples/primary-navigation/index.njk
+++ b/docs/examples/primary-navigation/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Primary navigation (example)
 arguments: primary-navigation
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=61-3383&mode=design
 ---
 
 {%- from "moj/components/primary-navigation/macro.njk" import mojPrimaryNavigation -%}

--- a/docs/examples/search/index.njk
+++ b/docs/examples/search/index.njk
@@ -1,6 +1,7 @@
 ---
 layout: layouts/example.njk
 title: Search (example)
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=61-3747&mode=design
 ---
 
 {%- from "moj/components/search/macro.njk" import mojSearch -%}

--- a/docs/examples/side-navigation/index.njk
+++ b/docs/examples/side-navigation/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Side navigation (example)
 arguments: side-navigation
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=352-1027&mode=design
 ---
 
 {%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}

--- a/docs/examples/sub-navigation/index.njk
+++ b/docs/examples/sub-navigation/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Sub navigation (example)
 arguments: sub-navigation
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=61-4111&mode=design
 ---
 
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}


### PR DESCRIPTION
### Description

Adding Figma links to components. The following components have been updated with links to Figma in January 2024:

- Banner
- Button menu
- Notification badge
- Organisation switcher
- Page header actions
- Password reveal
- Primary navigation
- Search
- Side navigation
- Sub navigation