### PR TITLE
docs: adding figma link for header component

### DIFF
--- a/docs/examples/header/index.njk
+++ b/docs/examples/header/index.njk
@@ -2,6 +2,7 @@
 layout: layouts/example.njk
 title: Header (example)
 arguments: header
+figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=682-344&mode=design
 ---
 
 {%- from "moj/components/header/macro.njk" import mojHeader -%}


### PR DESCRIPTION
### Description

Version of the Header component created in Figma. Link to Figma included on the Header component page.