### PR TITLE
docs: add link to Upload files pattern

### DIFF
--- a/docs/_includes/layouts/patterns.njk
+++ b/docs/_includes/layouts/patterns.njk
@@ -30,6 +30,10 @@
               {
                 text: 'Get help',
                 href: ('/patterns/get-help' | url)
+              },
+              {
+                text: 'Upload files',
+                href: ('/patterns/upload-files' | url)
               }
             ]
           }


### PR DESCRIPTION
Page was dropped from navigation a while ago but still exists, this adds the nav back in.
