### PR TITLE
fix(filter toggle button): ensure button appears

### DIFF
--- a/src/moj/components/filter-toggle-button/filter-toggle-button.js
+++ b/src/moj/components/filter-toggle-button/filter-toggle-button.js
@@ -20,7 +20,7 @@ MOJFrontend.FilterToggleButton.prototype.setupResponsiveChecks = function() {
 MOJFrontend.FilterToggleButton.prototype.createToggleButton = function() {
   this.menuButton = $('<button class="govuk-button '+this.options.toggleButton.classes+'" type="button" aria-haspopup="true" aria-expanded="false">'+this.options.toggleButton.showText+'</button>');
   this.menuButton.on('click', $.proxy(this, 'onMenuButtonClick'));
-  this.options.toggleButton.container.append(this.menuButton);
+  this.container.append(this.menuButton);
 };
 
 MOJFrontend.FilterToggleButton.prototype.checkMode = function(mq) {


### PR DESCRIPTION
The container wasn't being wrapped in a jQuery tag, meaning the button wasn't properly appended to the DOM.

Use the jQuery-wrapped container instead.
