### PR TITLE
docs(password-reveal): note GOV.UK Password input component on Password reveal page

### DIFF
--- a/docs/components/password-reveal.md
+++ b/docs/components/password-reveal.md
@@ -3,6 +3,12 @@ layout: layouts/component.njk
 title: Password reveal
 ---
 
+{% banner "The GOV.UK Design System has a similar component" %}
+The [Password input component](https://design-system.service.gov.uk/components/password-input/) in the GOV.UK Design System has a similar function and visual design to this component.
+
+You should consider using the GOV.UK version if it fits your needs.
+{% endbanner %}
+
 {% lastUpdated "password-reveal" %}
 
 {% example "/examples/password-reveal", 175 %}


### PR DESCRIPTION
To encourage people to use the standardised component
