### PR TITLE
docs(service patterns intro): an orphan page created to introduce ser…

### DIFF
--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -31,8 +31,6 @@
 
         {% include "./partials/navigation.njk" %}
 
-        {% include "./partials/feedback-banner.njk" %}
-
         {% block content %}
           <main class="app-prose-scope" role="main">
             {{ content | safe }}

--- a/docs/_includes/layouts/service-patterns.njk
+++ b/docs/_includes/layouts/service-patterns.njk
@@ -1,0 +1,33 @@
+{% extends "./base.njk" %}
+
+{% block content %}
+  <div class="govuk-width-container">
+
+    <div class="govuk-phase-banner">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          Beta
+        </strong>
+
+        <span class="govuk-phase-banner__text">
+          This is new – your <a class="govuk-link" href="mailto:design-system@digital.justice.gov.uk">feedback</a> will help us to improve it.
+        </span>
+
+      </p>
+    </div>
+
+    <main id="main-content" class="govuk-main-wrapper app-prose-scope" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <h1 class="govuk-heading-xl">
+            {{ title }}
+          </h1>
+
+        {{ content | safe }}
+
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock %}

--- a/docs/service-patterns.md
+++ b/docs/service-patterns.md
@@ -1,0 +1,53 @@
+---
+layout: layouts/service-patterns.njk
+title: Adding service patterns to the MoJ design system
+---
+
+Service patterns help you to determine the steps and tasks necessary to design your service. You can also use service patterns to scope your work or identify levels of complexity.
+
+Any action or activity a user completes is a potential service pattern, like booking appointments, making referrals, or tracking progress.
+
+## What MoJ service patterns might look like
+
+We think service patterns should be:
+
+- based on common tasks that users complete as part of a service
+- reusable to encourage consistent experiences
+- modular so that they can be combined to create complete services
+- designed for multiple channels like offline services
+
+Each service pattern entry will contain guidance on how to implement the service pattern in a consistent way across our services.
+
+Service pattern information might include things like:
+
+- examples of implementation
+- customer journey maps
+- scenario mapping
+- supporting research
+- accessibility considerations
+- relevant components and patterns
+
+Service patterns will not replace design. Instead, service patterns will be a starting point to accelerate design and encourage consistent experiences.
+
+Each pattern must be unique and useful so that multiple products can use it.
+
+## Suggested MoJ service patterns
+
+We are developing our first service pattern right now.
+
+MoJ designers have already identified around 25 potential service patterns, such as:
+
+- book, view, and manage appointments
+- apply for something and track progress
+- order and pay for something
+- assign and complete activities
+
+This is not a complete list, and we may have missed something, but it's a good starting point.
+
+## Contributing to MoJ service patterns
+
+You will likely design multiple instances of potential service patterns when you develop new products or services.
+
+Speak to <a href="mailto:martin.ford-downes@digital.justice.gov.uk">Martin Ford-Downes</a> if you have a potential service pattern idea or want to help us work on others.
+
+We welcome feedback from everyone, including from people outside of the Ministry of Justice.


### PR DESCRIPTION
### Description of the change

To support the introduction of service patterns into the MoJ Design System, an orphaned page has been created to include an introduction to service patterns. This page will be used to support the internal promotion and awareness of service patterns.