### PR TITLE
docs(removing inactive pages): removing community pages that are inac…

### DIFF
--- a/docs/_includes/layouts/community.njk
+++ b/docs/_includes/layouts/community.njk
@@ -16,25 +16,6 @@
         sections: [
           {
             heading: {
-              text: "What's new"
-            },
-            items: [
-            {
-              text: 'Latest updates',
-              href: ('/community/updates' | url)
-            },
-            {
-                text: 'Our roadmap',
-                href: ('/community/roadmap' | url)
-            },
-            {
-                text: 'Data and research',
-                href: ('/community/users-and-data' | url)
-              }
-            ]
-          },
-          {
-            heading: {
               text: "Contributing"
             },
             items: [

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -4,7 +4,3 @@ title: Community
 ---
 
 The MoJ Design System supports the design, build, and delivery of accessible and consistent services. It does this by helping people, teams, professions, and communities across the Ministry of Justice to learn from the experiences of each other, contribute and share knowledge, and reuse as much as possible.
-
-## What's new
-
-View our [latest updates](/community/updates) to see what has been happening with the MoJ Design System, and [our roadmap](/community/roadmap) for the future plans.

--- a/docs/community/roadmap.md
+++ b/docs/community/roadmap.md
@@ -4,6 +4,17 @@ subsection: What's new
 title: Roadmap
 ---
 
+<div class="moj-banner moj-banner--warning" role="region" aria-label="Warning">
+
+  <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
+  </svg>
+
+  <div class="moj-banner__message"><strong>Due to inactivity, this page will shortly be removed.</strong></div>
+
+</div>
+
+
 This is the roadmap for the MoJ Design System. It shows what we’re working on now, and whilst some things on the roadmap might change, it gives a guide for what we’re planning to do in the future.
 
 This roadmap was last updated in **December 2023**.

--- a/docs/community/updates.md
+++ b/docs/community/updates.md
@@ -4,6 +4,16 @@ subsection: What's new
 title: Latest updates
 ---
 
+<div class="moj-banner moj-banner--warning" role="region" aria-label="Warning">
+
+  <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
+  </svg>
+
+  <div class="moj-banner__message"><strong>Due to inactivity, this page will shortly be removed.</strong></div>
+
+</div>
+
 ### December 2023
 
 - Interruption Card component proposed, reviewed, and declined.

--- a/docs/community/users-and-data.md
+++ b/docs/community/users-and-data.md
@@ -4,6 +4,16 @@ subsection: What's new
 title: Led by users, driven by data
 ---
 
+<div class="moj-banner moj-banner--warning" role="region" aria-label="Warning">
+
+  <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z" />
+  </svg>
+
+  <div class="moj-banner__message"><strong>Due to inactivity, this page will shortly be removed.</strong></div>
+
+</div>
+
 We aim to continuously improve our design system around the people that use it, reducing complexity and focus on what matters. We also aim to make the best possible use of our data to ensure that the direction of the design system is based on sound insight.
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,3 @@ title: Design, build, and deliver accessible and consistent services
 Anyone can contribute to the MoJ Design System by proposing a new style, component, or pattern.
 
 [Propose a contribution](./community/contribute)
-
----
-
-## Roadmap and latest updates
-
-Find out what the plans are for the MoJ Design System over the coming months, as well as updates on the latest changes and improvements.
-
-[View the roadmap](./community/roadmap)


### PR DESCRIPTION
### Description

- Removal of [latest updates](https://design-patterns.service.justice.gov.uk/community/updates), [roadmap](https://design-patterns.service.justice.gov.uk/community/roadmap), and [data and research](https://design-patterns.service.justice.gov.uk/community/users-and-data) from the community side navigation
- Banner included on each page to notify any visitors that the pages will soon be removed
- Date set for a final review of analytics (10 June 2024)
- After final review of analytics, if pages are still inactive, pages will be permanently removed