### PR TITLE
test: use sass instead of deprecated node-sass

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "moment": "^2.29.4",
         "nunjucks": "^3.2.3",
         "require-dir": "^1.2.0",
-        "sass": "^1.50.1"
+        "sass": "^1.77.8"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -20799,9 +20799,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.0.tgz",
-      "integrity": "sha512-HKKIKf49Vkxlrav3F/w6qRuPcmImGVbIXJ2I3Kg0VMA+3Bav+8yE9G5XmP5lMj6nl4OlqbPftGAscNaNu28b8w==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -23979,7 +23979,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "2.1.3",
+      "version": "2.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -38860,9 +38860,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.71.0.tgz",
-      "integrity": "sha512-HKKIKf49Vkxlrav3F/w6qRuPcmImGVbIXJ2I3Kg0VMA+3Bav+8yE9G5XmP5lMj6nl4OlqbPftGAscNaNu28b8w==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ci:dryrun": "HUSKY=0 CI=true semantic-release --dry-run",
     "start": "npm-run-all --parallel watch:*",
     "test": "npm-run-all --parallel test:*",
-    "test:sass": "npm install node-sass && node-sass -q gulp/dist-scss/all.scss >/dev/null && echo 'ok'",
+    "test:sass": "npm install sass && sass -q -I . gulp/dist-scss/all.scss >/dev/null && echo 'ok'",
     "test:docs": "npm run build:docs",
     "watch:11ty": "ENV='dev' eleventy --input=./docs --output=public --serve",
     "watch:package": "gulp watch:dev"
@@ -50,7 +50,7 @@
     "moment": "^2.29.4",
     "nunjucks": "^3.2.3",
     "require-dir": "^1.2.0",
-    "sass": "^1.50.1"
+    "sass": "^1.77.8"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",


### PR DESCRIPTION
### Description of the change

Cloning the repository and attempting to run all tests (`npm test`) produces errors linked to `gyp` and `node-sass`. 
Given the [`node-sass` library is deprecated](https://www.npmjs.com/package/node-sass), the official recommendation is to use the `sass` library instead. 

This change fixes issues with running all tests.

### Quantitative performance benefits

This should enable contributing developers to run tests locally.
