### PR TITLE
build(deployment): increase replicas and set pod disruption policy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -85,6 +85,8 @@ jobs:
 
   push-to-production:
     runs-on: ubuntu-latest
+    needs: [build, test]
+    if: github.event_name == 'push'
     permissions:
       id-token: write
       contents: read

--- a/kubernetes-deploy-production.tpl
+++ b/kubernetes-deploy-production.tpl
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: moj-frontend-${BRANCH}
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: moj-frontend-${BRANCH}
@@ -68,3 +68,14 @@ spec:
             name: moj-frontend-service-${BRANCH}
             port:
               number: 3000
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: moj-frontend-disruption-policy
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: moj-frontend-${BRANCH}
+


### PR DESCRIPTION
This PR adds increases the number of pods, and also specifies a pod disruption policy that ensures at least one pod is always available.
