### PR TITLE
fix(datepicker): prevent double initialization on datepicker components

### DIFF
--- a/src/moj/components/date-picker/date-picker.js
+++ b/src/moj/components/date-picker/date-picker.js
@@ -88,9 +88,13 @@ Datepicker.prototype.init = function () {
   if (!this.$input) {
     return;
   }
+  if (this.$module.dataset.initialized) {
+    return;
+  }
 
   this.setOptions();
   this.initControls();
+  this.$module.setAttribute('data-initialized', 'true')
 };
 
 Datepicker.prototype.initControls = function () {


### PR DESCRIPTION
fix #751

Prevent double-initialization of the component by adding a `data-initialized` attribute onto the `$module` after the `init()` method has run.  The `init()` method then checks for the presence of the attribute and aborts if it is present.
