### PR TITLE
fix(datepicker): fix issues with leadingZeros config option

### DIFF
--- a/docs/examples/date-picker-leading-zeros/index.njk
+++ b/docs/examples/date-picker-leading-zeros/index.njk
@@ -1,0 +1,20 @@
+---
+layout: layouts/example.njk
+title: Date Picker (example)
+arguments: date-picker
+figma_link: https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?node-id=792-861&t=6DfPOX7RAnjrVE0j-0
+---
+
+{%- from "moj/components/date-picker/macro.njk" import mojDatePicker -%}
+
+{{ mojDatePicker({
+  id: "date",
+  name: "date",
+  label: {
+      text: "Date"
+  },
+  hint: {
+    text: "For example, 17/5/2024."
+  },
+  leadingZeros: "true"
+}) }}

--- a/src/moj/components/date-picker/date-picker.js
+++ b/src/moj/components/date-picker/date-picker.js
@@ -411,9 +411,11 @@ Datepicker.prototype.setLeadingZeros = function () {
   if (typeof this.config.leadingZeros !== "boolean") {
     if (this.config.leadingZeros.toLowerCase() === "true") {
       this.config.leadingZeros = true;
+      return;
     }
     if (this.config.leadingZeros.toLowerCase() === "false") {
       this.config.leadingZeros = false;
+      return;
     }
   }
 };


### PR DESCRIPTION
added `return` statements to `setLeadingZeros` method to prevent calling `toLowerCase` on a boolean value.

fix #753
