### PR TITLE
fix(button menu): small tweak to fix alignment within an moj-button-group

### DIFF
--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -6,7 +6,9 @@ $moj-datepicker-mid-grey: #949494;
   position: relative;
 
   > .govuk-button {
+    // required for no-js alignment within moj-button-group
     margin-bottom: 0;
+    vertical-align: baseline;
   }
 }
 

--- a/src/moj/objects/_button-group.scss
+++ b/src/moj/objects/_button-group.scss
@@ -1,4 +1,3 @@
-
 .moj-button-group {
   $horizontal-gap: govuk-spacing(3);
   $vertical-gap: govuk-spacing(3);
@@ -6,32 +5,27 @@
 
   @extend .govuk-button-group;
 
-
   &--inline {
-  flex-direction: row;
-  flex-wrap: wrap;
-  align-items: baseline;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: baseline;
     gap: $horizontal-gap;
     margin-right: 0;
 
-  .moj-button-menu {
+    .moj-button-menu {
       margin-bottom: $vertical-gap + $button-shadow-size;
     }
 
-  .moj-button-menu .moj-button-menu__toggle-button {
+    .moj-button-menu .moj-button-menu__toggle-button {
       vertical-align: baseline;
     }
 
-  .moj-button-menu,
-  .govuk-button,
-  .govuk-link {
-    width: auto;
-    margin-right: 0;
+    > .moj-button-menu,
+    > .govuk-button,
+    > .govuk-link {
+      width: auto;
+      margin-right: 0;
       margin-bottom: 0;
     }
-
-  /* :is(.govuk, .moj-button-menu, .govuk-link) + :is(.govuk, .moj-button-menu, .govuk-link) { */
-  /*     margin-top: $horizontal-gap; */
-  /*   } */
   }
 }


### PR DESCRIPTION
without js the alignment of the button menu items in a button group was not right.

Before:
![image](https://github.com/user-attachments/assets/6fc6e6f0-d277-4ee9-a31d-8c73a884d25f)

After:
![image](https://github.com/user-attachments/assets/603d8f32-1617-44df-b384-a2fb173cd695)

