### PR TITLE
fix(action bar): adjust alignment of filter toggle button when next to menu button

### DIFF
--- a/src/moj/components/action-bar/_action-bar.scss
+++ b/src/moj/components/action-bar/_action-bar.scss
@@ -25,4 +25,9 @@
     }
   }
 
+  > .govuk-button {
+    vertical-align: baseline;
+  }
 }
+
+


### PR DESCRIPTION
The updates to the button menu caused the alignment of the buttons in the action bar component for filtering to be misaligned. This is a simple fix to ensure the buttons are aligned.

