### PR TITLE
fix(scss): amend sass loadpaths to include node_modules directory

### DIFF
--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -27,7 +27,9 @@ gulp.task("dist:javascript", () => {
 gulp.task("dist:css", () => {
   return gulp
     .src("gulp/dist-scss/*.scss")
-    .pipe(sass())
+    .pipe(sass({
+      includePaths: ["node_modules"]
+    }))
     .pipe(postcss([autoprefixer, cssnano]))
     .pipe(
       rename((path) => ({

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -42,7 +42,9 @@ gulp.task(
   "docs:styles", () => {
     return gulp
       .src("docs/assets/stylesheets/application.scss")
-      .pipe(sass())
+      .pipe(sass({
+        includePaths: ["node_modules"]
+      }))
       .pipe(rename({
         suffix: `-${VERSION}`
       }))

--- a/src/moj/all.scss
+++ b/src/moj/all.scss
@@ -1,4 +1,4 @@
-@import "node_modules/govuk-frontend/dist/govuk/base";
+@import "govuk-frontend/dist/govuk/base";
 
 @import "settings/all";
 @import "helpers/all";


### PR DESCRIPTION
This allows us to remove the node modules prefix from the govuk scss import in all.scss. Which would resolve loading issues for users.

BREAKING CHANGE: This PR changes the loadpath for govuk frontend.  You will now need to ensure your project SASS configuration includes node_modules within its loadpaths in order to compile, however this is often default behaviour in many build tools.

fix #927



