### PR TITLE
fix(date picker): minDate is now exclusive

### DIFF
--- a/src/moj/components/date-picker/date-picker.js
+++ b/src/moj/components/date-picker/date-picker.js
@@ -435,7 +435,7 @@ Datepicker.prototype.setWeekStartDay = function () {
  *
  */
 Datepicker.prototype.isExcludedDate = function (date) {
-  if (this.minDate && this.minDate > date) {
+  if (this.minDate && this.minDate >= date) {
     return true;
   }
 


### PR DESCRIPTION
This PR makes minDate behaviour match maxDate, and allows the date provided in the option to be selected.

BREAKING CHANGE: The date provided to the component via the minDate option is now selectable by users. If you are using the mindate functionality, you will need to adjust the dates you pass into the component to ensure the correct dates are included/excluded.

fix #923
