### PR TITLE
fix: (multi-select)  allow multiple multi-selects on same page

### DIFF
--- a/docs/examples/multi-select/index.njk
+++ b/docs/examples/multi-select/index.njk
@@ -4,7 +4,7 @@ title: Multi select (example)
 figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type=design&node-id=841-220&mode=design
 ---
 
-<table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
+<table class="govuk-table" data-module="moj-multi-select" data-multi-select-checkbox="#select-all" data-multi-select-idprefix="mountains-">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header" scope="col" id="select-all"></th>

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -15,7 +15,8 @@ MOJFrontend.initAll = function (options) {
   MOJFrontend.nodeListForEach($multiSelects, function ($multiSelect) {
     new MOJFrontend.MultiSelect({
       container: $multiSelect.querySelector($multiSelect.getAttribute('data-multi-select-checkbox')),
-      checkboxes: $multiSelect.querySelectorAll('tbody .govuk-checkboxes__input')
+      checkboxes: $multiSelect.querySelectorAll('tbody .govuk-checkboxes__input'),
+      id_prefix: $multiSelect.getAttribute('data-multi-select-idprefix'),
     });
   });
 

--- a/src/moj/components/multi-select/README.md
+++ b/src/moj/components/multi-select/README.md
@@ -1,3 +1,3 @@
 # Table multi-select
 
-- [Guidance](https://design-patterns.service.justice.gov.uk/components/table-multi-select)
+- [Guidance](https://design-patterns.service.justice.gov.uk/components/multi-select/)

--- a/src/moj/components/multi-select/multi-select.js
+++ b/src/moj/components/multi-select/multi-select.js
@@ -7,7 +7,13 @@ MOJFrontend.MultiSelect = function(options) {
 
   this.container.data('moj-multi-select-initialised', true);
 
-  this.toggle = $(this.getToggleHtml());
+  const idPrefix = options.id_prefix;
+  let allId = 'checkboxes-all';
+  if (typeof idPrefix !== 'undefined') {
+    allId = idPrefix + 'checkboxes-all';
+  }
+
+  this.toggle = $(this.getToggleHtml(allId));
   this.toggleButton = this.toggle.find('input');
   this.toggleButton.on('click', $.proxy(this, 'onButtonClick'));
   this.container.append(this.toggle);
@@ -16,11 +22,11 @@ MOJFrontend.MultiSelect = function(options) {
   this.checked = options.checked || false;
 };
 
-MOJFrontend.MultiSelect.prototype.getToggleHtml = function() {
-  var html = '';
+MOJFrontend.MultiSelect.prototype.getToggleHtml = function (allId) {
+  let html = '';
   html += '<div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox">';
-  html += '  <input type="checkbox" class="govuk-checkboxes__input" id="checkboxes-all">';
-  html += '  <label class="govuk-label govuk-checkboxes__label moj-multi-select__toggle-label" for="checkboxes-all">';
+  html += `  <input type="checkbox" class="govuk-checkboxes__input" id="${allId}">`;
+  html += `  <label class="govuk-label govuk-checkboxes__label moj-multi-select__toggle-label" for="${allId}">`;
   html += '    <span class="govuk-visually-hidden">Select all</span>';
   html += '  </label>';
   html += '</div>';


### PR DESCRIPTION
### Identify the bug

https://github.com/ministryofjustice/moj-frontend/issues/914

### Description of the change

Add a optional 'idprefix' option to the multi-select component, so that the 'all' checkbox can have a unique id. Without this, multiple multi-selects on the same page don't work properly (selecting the second one 'all-selects' the first in Chrome, but YMMV)

### Alternative designs

None 

### Possible drawbacks

None - I have tried to ensure that the default id of the 'all' checkbox remains the same if the option is not provided.

### Verification process

This change is to support a feature in https://github.com/DFE-Digital/teaching-vacancies, where multiple tabs each have their own set of check-boxes. This change makes those check-boxes behave correctly and independently.

### Release notes

Fixed issue with multiple multi-selects appearing on the same page using new optional data-multi-select-idprefix.

