### PR TITLE
docs(side nav): fix duplicate id issue on collapsible navs

### DIFF
--- a/docs/_includes/layouts/partials/side-navigation.njk
+++ b/docs/_includes/layouts/partials/side-navigation.njk
@@ -3,7 +3,7 @@
 {% set usingPages = collections.all | eleventyNavigation("Using the design system") %}
 {% from "./../macros/nav-list-item.njk" import verticalNavListItem %}
 
-<moj-collapsible-nav open-class="app-vertical-nav__item--open">
+<moj-collapsible-nav open-class="app-vertical-nav__item--open" id="building-nav">
 <nav class="app-vertical-nav" aria-labelledby="building-nav-title">
     <h2 class="app-vertical-nav__header" id="building-nav-title">Building blocks</h2>
     <ul class="app-vertical-nav__list">
@@ -19,7 +19,7 @@
 </nav>
 </moj-collapsible-nav>
 
-<moj-collapsible-nav open-class="app-vertical-nav__item--open">
+<moj-collapsible-nav open-class="app-vertical-nav__item--open" id="standards-nav">
 <nav class="app-vertical-nav" aria-labelledby="standards-nav-title">
     <h2 class="app-vertical-nav__header" id="standards-nav-title">Standards and principles</h2>
     <ul class="app-vertical-nav__list">
@@ -34,7 +34,7 @@
 </nav>
 </moj-collapsible-nav>
 
-<moj-collapsible-nav open-class="app-vertical-nav__item--open">
+<moj-collapsible-nav open-class="app-vertical-nav__item--open" id="using-nav">
 <nav class="app-vertical-nav" aria-labelledby="using-nav-title">
     <h2 class="app-vertical-nav__header" id="using-nav-title">Using the design system</h2>
     <ul class="app-vertical-nav__list">

--- a/docs/assets/javascript/collapsible-nav.js
+++ b/docs/assets/javascript/collapsible-nav.js
@@ -1,6 +1,9 @@
 export default class CollapsibleNav extends HTMLElement {
   constructor() {
     super();
+    if(!this.id) {
+     this.id = `nav-${Date.now()}`
+    }
 
     this.collapsibleItems = this.querySelectorAll("li:has(ul)");
 
@@ -9,8 +12,9 @@ export default class CollapsibleNav extends HTMLElement {
       const $list = $item.querySelector("ul");
       const $button = document.createElement("button");
 
+
       if (!$list.id) {
-        $list.id = `moj-collapsible-nav-${index}`;
+        $list.id = `${this.id}-collapsible-nav-${index}`;
       }
 
       $button.setAttribute("aria-controls", $list.id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -30590,7 +30590,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Our current sidenav custom element, applies incremental ids to each collapsible item within it starting with `collapsible-nav-0`

If there are multiple `<moj-collapsible-nav>` elements on a page, each starts applying ids from 0, which results in duplicate ids on the page.

This PR fixes this issue, by applying either a dynamic, timestamp-based id to each instance of the component, or by allowing the user to manually set an id on the custom element, and using this id as a prefix for the child collapsible nav elements.
