### PR TITLE
Changing pagination results number

### DIFF
--- a/docs/examples/pagination/index.njk
+++ b/docs/examples/pagination/index.njk
@@ -25,7 +25,7 @@ arguments: pagination
   }],
   results: {
     count: 30,
-    from: 10,
+    from: 11,
     to: 20,
     text: 'results'
   },

--- a/src/moj/components/pagination/template.njk
+++ b/src/moj/components/pagination/template.njk
@@ -12,9 +12,9 @@
         <li class="moj-pagination__item moj-pagination__item--dots">…</li>
       {% else %}
         {%- if item.selected %}
-          <li class="moj-pagination__item moj-pagination__item--active" aria-label="Page {{ item.text }} of {{ params.results.count }}" aria-current="page">{{ item.text }}</li>
+          <li class="moj-pagination__item moj-pagination__item--active" aria-label="Page {{ item.text }} of {{ params.items | length }}" aria-current="page">{{ item.text }}</li>
         {% else %}
-          <li class="moj-pagination__item"><a class="moj-pagination__link" href="{{ item.href }}" aria-label="Page {{ item.text }} of {{ params.results.count }}">{{ item.text }}</a></li>
+          <li class="moj-pagination__item"><a class="moj-pagination__link" href="{{ item.href }}" aria-label="Page {{ item.text }} of {{ params.items | length }}">{{ item.text }}</a></li>
         {% endif -%}
       {% endif -%}
     {% endfor -%}


### PR DESCRIPTION
* Changes pagination example results string starting point from 10 to 11.
* Fixes aria-label attribute end number to be total number of pages instead of total results.