### PR TITLE
docs(cookie banner): align cookie banner content left

### DIFF
--- a/docs/_includes/layouts/partials/header.njk
+++ b/docs/_includes/layouts/partials/header.njk
@@ -30,6 +30,8 @@
   attributes: {
     "data-module": "app-cookies"
   },
+  classes: "govuk-cookie-banner--align-left",
+  hidden: true,
   messages: [
     {
       headingText: "Cookies on MoJ Design System",

--- a/docs/assets/javascript/cookies.js
+++ b/docs/assets/javascript/cookies.js
@@ -17,8 +17,10 @@ Cookies.prototype.init = function () {
   const configEncoded = localStorage.getItem("mojpl-cookies");
   if (configEncoded) {
     const config = JSON.parse(configEncoded);
-
     this.load(config);
+  } else {
+    // If there is no config, show the cookie banner
+    this.$module.hidden = false;
   }
 };
 

--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-assets-path: "../" !default;
 
 // Custom documentation components
 @import "./components/back-to-top";
+@import "./components/cookie-banner";
 @import "./components/copy-button";
 @import "./components/example";
 @import "./components/layout";

--- a/docs/assets/stylesheets/components/_cookie-banner.scss
+++ b/docs/assets/stylesheets/components/_cookie-banner.scss
@@ -1,0 +1,7 @@
+// Override cookie banner to be left aligned
+.govuk-cookie-banner--align-left {
+  .govuk-cookie-banner__message {
+    margin-left: 20px;
+    margin-right: 20px;
+  }
+}

--- a/docs/assets/stylesheets/components/_cookie-banner.scss
+++ b/docs/assets/stylesheets/components/_cookie-banner.scss
@@ -4,4 +4,7 @@
     margin-left: 20px;
     margin-right: 20px;
   }
+  .govuk-cookie-banner__content {
+    text-wrap: pretty;
+  }
 }


### PR DESCRIPTION
This PR overrides the govuk cookie banner styles to left align the content to match the rest of the site.

It also makes a small adjustment to add the `hidden` attribute to the banner by default. This ensures the banner stays hidden and is only revealed by the JS if the user needs to accept or reject. This will prevent the "flash of cookie banner" sometimes visible on the site currently, where the banner displays, and is then hidden by the JS when it realises it's not needed.

Before:
![image](https://github.com/user-attachments/assets/71708416-20dd-4ee1-a556-08f1ea76b7c9)



After:
![image](https://github.com/user-attachments/assets/7645af11-0045-4abb-995f-ac66c354ac26)

