### PR TITLE
docs(examples): add padding so that copy code button does not obscure the code

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -68,7 +68,7 @@
 {% endif %}
 
 {% if figmaLink %}
-  <div class="app-tabs__panel govuk-!-padding-2 app-tabs__panel--hidden" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">
+  <div class="app-tabs__panel govuk-!-padding-3 app-tabs__panel--hidden" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">
 
 This component is in the ‘Assets’ tab in the MoJ Figma Kit.
 

--- a/docs/assets/stylesheets/components/_example.scss
+++ b/docs/assets/stylesheets/components/_example.scss
@@ -27,11 +27,12 @@
     @include govuk-font($size: 16);
     border: 1px solid $govuk-border-colour;
     position: absolute; top: -1px; left: -1px;
+    background-color: white;
+
 
     a,
     a:link,
     a:visited {
-      background-color: white;
       color: govuk-colour("blue");
       display: block;
       margin: 8px;

--- a/docs/assets/stylesheets/components/_tabs.scss
+++ b/docs/assets/stylesheets/components/_tabs.scss
@@ -102,4 +102,8 @@
   p {
     max-width: 100% !important;
   }
+
+  pre {
+    padding-top: govuk-spacing(9);
+  }
 }


### PR DESCRIPTION
This PR makes a couple of minor tweaks to the coded examples:
* Adds top padding to the `<pre>` element, so that the 'copy code' button does not obscure long lines of code.
* Adds a white backgorund to the whole of the box around 'Open this example in a new tab'
* Updates the padding around the Figma tab content to match the other tabs.

**Before:**
<img width="895" alt="image" src="https://github.com/user-attachments/assets/ee9a79dc-d7eb-4882-b1a8-95c87ecc6068">
<img width="909" alt="image" src="https://github.com/user-attachments/assets/1494f155-014e-468e-a3f5-45c7418e2a39">


**After:**
<img width="883" alt="image" src="https://github.com/user-attachments/assets/1aba3bfb-9dd6-440d-9a8a-e36ac6176913">
<img width="894" alt="image" src="https://github.com/user-attachments/assets/125a5add-2097-4011-b0be-672ead73b2d8">

