### PR TITLE
Updating suggest a change content

### DIFF
--- a/docs/_includes/layouts/partials/get-help-and-contribute.njk
+++ b/docs/_includes/layouts/partials/get-help-and-contribute.njk
@@ -17,7 +17,7 @@
 </p>
 
 <p class="govuk-body">
-  Add these comments to the <a class="govuk-link" href= {{githuburl}} >{{ title|lower }} discussion on Github</a>.
+  Add these comments to the <a class="govuk-link" href= {{githuburl}} >{{ title|lower }} discussion on GitHub</a>.
 </p>
 
 {% if contributors %}

--- a/docs/get-involved/suggest-a-change.md
+++ b/docs/get-involved/suggest-a-change.md
@@ -10,19 +10,13 @@ eleventyNavigation:
   excerpt: "Help improve the MoJ Design System by suggesting changes to building blocks."
 ---
 
-To help improve the MoJ Design System, you can suggest changes to components and patterns.
+Help improve the MoJ Design System by suggesting a change to a building block.
 
-Useful suggestions may look like:
+We want to hear suggestions that may include:
 
-- new research or testing that can help improve an existing component or pattern
-- reporting bugs where you've used a component or pattern in a live service and noticed an issue
+- how you have used building blocks in your service
+- research or testing that can help improve an existing building block
+- reporting bugs where you've used building blocks in a live service and noticed an issue
+- any feedback you have about usage, for example accessibility or ideas for improvements
 
-## Tell us your suggestion
-
-Tell us about the change you're proposing by using the [suggest a change form](https://forms.gle/FpDpbgttwmfmcz8o7). The MoJ Design System Group will be notified of your suggestion and will review it.
-
-Once reviewed, the group will either:
-
-- accept your suggestion and work to apply your change
-- accept your suggestion but work with you to tweak the changes before going ahead
-- not accept your suggestion and explain why
+Add these comments and take part in the [discussions on GitHub](https://github.com/ministryofjustice/moj-frontend/discussions/categories/released-components-pages-and-patterns).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30912,7 +30912,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- [Suggest a change page](https://design-patterns.service.justice.gov.uk/get-involved/suggest-a-change/) updated to more accurately reflect the process for users to suggest a change to a building block in the design system