### PR TITLE
build(preveiw): add a workflow to push a pr to branch preview

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -47,7 +47,7 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
-          echo -e "🚀 Deployed to preview environment!\n\n**URL:** https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
+          echo -e "🚀 Deployed to preview environment! If this is the first deploy, you may have to wait a few minutes for your preview site to be ready on the following URL:\n\n https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
           gh pr comment $PRNUM --body-file comment.txt
           gh pr edit $PRNUM --remove-label "preview:request"
           gh pr edit $PRNUM --add-label "preview:active"

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -1,0 +1,55 @@
+name: Deploy a tagged PR for preview
+on:
+  pull_request:
+    types: [labeled]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ECR_NAME: ${{ secrets.ECR_NAME }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+
+jobs:
+  push-to-staging:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    if: ${{ github.event.label.name == 'preview:request' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+      - uses: aws-actions/amazon-ecr-login@v2
+        id: login-ecr
+      - run: |
+          docker build --target=preview -t $REGISTRY/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REPOSITORY:$IMAGE_TAG
+          cat kubernetes-deploy-preview.tpl | envsubst > kubernetes-deploy-preview.yaml
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ github.sha }}
+          BRANCH: ${{ github.head_ref }}
+      - run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+          kubectl -n ${KUBE_NAMESPACE} apply -f kubernetes-deploy-preview.yaml
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+      - name: Update PR with success
+        run: |
+          echo -e "🚀 Deploying to [staging environment](https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
+          gh pr comment $PRNUM --body-file comment.txt
+          gh pr edit $PRNUM --remove-label "preview:request"
+          gh pr edit $PRNUM --add-label "preview:active"
+        env:
+          PRNUM: ${{ github.event.number }}

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -47,7 +47,7 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
-          echo -e "🚀 Deployed to [preview environment](https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
+          echo -e "🚀 Deployed to preview environment!\n\n**URL:** https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
           gh pr comment $PRNUM --body-file comment.txt
           gh pr edit $PRNUM --remove-label "preview:request"
           gh pr edit $PRNUM --add-label "preview:active"

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -1,7 +1,7 @@
 name: Deploy a tagged PR for preview
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, reopened, synchronize, labeled]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -10,13 +10,13 @@ env:
   KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
 
 jobs:
-  push-to-staging:
+  push-to-preview:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
       pull-requests: write
-    if: ${{ github.event.label.name == 'preview:request' }}
+    if: contains(github.event.pull_request.labels.*.name, 'preview:request') || contains(github.event.pull_request.labels.*.name, 'preview:active')
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -47,7 +47,7 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
-          echo -e "🚀 Deploying to [staging environment](https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
+          echo -e "🚀 Deployed to [preview environment](https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
           gh pr comment $PRNUM --body-file comment.txt
           gh pr edit $PRNUM --remove-label "preview:request"
           gh pr edit $PRNUM --add-label "preview:active"

--- a/docker/htpasswd-preview
+++ b/docker/htpasswd-preview
@@ -1,0 +1,1 @@
+preview:$1$YxM5kE7x$W.1KlD6SSzO7w0lqkhLEV1

--- a/docker/nginx-preview.conf
+++ b/docker/nginx-preview.conf
@@ -12,7 +12,7 @@ server {
     location / {
         index  index.html index.htm;
         
-        auth_basic "Staging site";
+        auth_basic "Preview site";
         auth_basic_user_file /etc/nginx/.htpasswd;
 
         etag off;

--- a/kubernetes-deploy-preview.tpl
+++ b/kubernetes-deploy-preview.tpl
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moj-frontend-${BRANCH}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moj-frontend-${BRANCH}
+  template:
+    metadata:
+      labels:
+        app: moj-frontend-${BRANCH}
+    spec:
+      containers:
+      - name: moj-frontend
+        image: ${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
+        env:
+          - name: USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: username
+          - name: PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: basic-auth
+                key: password
+        ports:
+        - containerPort: 3000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: moj-frontend-service-${BRANCH}
+  labels:
+    app: moj-frontend-service-${BRANCH}
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: moj-frontend-${BRANCH}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: moj-frontend-ingress-${BRANCH}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: moj-frontend-ingress-${BRANCH}-${KUBE_NAMESPACE}-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+spec:
+  ingressClassName: default
+  tls:
+  - hosts:
+    - ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: ${KUBE_NAMESPACE}-${BRANCH}.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: moj-frontend-service-${BRANCH}
+            port:
+              number: 3000


### PR DESCRIPTION
This PR adds a workflow to deploy a PR to a preview site when the label `preview:request` is added to the pull request.

Once successfully deployed, the label will be changed to `preview:active`.

Any subsequent pushes to the PR while the label remains applied will be automatically deployed out to the preview site.

On first deploy there may be a few minute delay before the site is available due to DNS rollout within the cluster.

The preview site is protected with httpauth like the staging site - username "preview" and password "moj" for all preview sites.