### PR TITLE
build(preview): add branch preview cleanup workflow

### DIFF
--- a/.github/workflows/branch-preview-cleanup.yml
+++ b/.github/workflows/branch-preview-cleanup.yml
@@ -1,0 +1,33 @@
+name: Cleanup branch preview
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ECR_NAME: ${{ secrets.ECR_NAME }}
+  KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+  KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
+
+jobs:
+  cleanup-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    if: contains(github.event.pull_request.labels.*.name, 'preview:request') || contains(github.event.pull_request.labels.*.name, 'preview:active')
+    steps:
+      - run: |
+          echo "${KUBE_CERT}" > ca.crt
+          kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
+          kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
+          kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
+          kubectl config use-context ${KUBE_CLUSTER}
+          kubectl delete deployment moj-frontend-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
+          kubectl delete service moj-frontend-service-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
+          kubectl delete ingress moj-frontend-ingress-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
+        env:
+          KUBE_CERT: ${{ secrets.KUBE_CERT }}
+          KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
+          KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}

--- a/.github/workflows/branch-preview-cleanup.yml
+++ b/.github/workflows/branch-preview-cleanup.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'preview:request') || contains(github.event.pull_request.labels.*.name, 'preview:active')
+    if: contains(github.event.pull_request.labels.*.name, 'preview:active')
     steps:
       - run: |
           echo "${KUBE_CERT}" > ca.crt
@@ -31,3 +31,8 @@ jobs:
           KUBE_CERT: ${{ secrets.KUBE_CERT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
+      - name: Remove preview:active label
+        run: |
+          gh pr edit $PRNUM --remove-label "preview:active"
+        env:
+          PRNUM: ${{ github.event.number }}


### PR DESCRIPTION
This PR creates a github action that runs when a PR is closed (or merged).  If the pull request has the label `preview:active` then this action will run.

It removes the kubernetes infrastructure for the preview site by issuing `kubectl delete` commands for the deployment, service and ingress that are created by the preview deploy action.

As a final step, it removes the `preview:active` label from the PR.