### PR TITLE
feat(version): add version variable to bundle js

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,6 +17,12 @@
       "assets": [
         {"path": "dist/release.zip", "name": "release-${nextRelease.gitTag}.zip"}
       ]
-    }]
+    }],
+    ["semantic-release-plugin-update-version-in-files", {
+    "files": [
+      "package/moj/all.js"
+    ],
+    "placeholder": "0.0.0-development"
+  }]
   ]
 }

--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -8,6 +8,7 @@ gulp.task('build:javascript', () => {
       'src/moj/namespace.js',
       'src/moj/helpers.js',
       'src/moj/all.js',
+      'src/moj/version.js',
       'src/moj/components/**/!(*.spec).js'
     ])
     .pipe(concat('all.js'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "moment": "^2.29.4",
         "nunjucks": "^3.2.3",
         "require-dir": "^1.2.0",
-        "sass": "^1.79.3"
+        "sass": "^1.79.3",
+        "semantic-release-plugin-update-version-in-files": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -27422,6 +27423,15 @@
         "node": ">=20.8.1"
       }
     },
+    "node_modules/semantic-release-plugin-update-version-in-files": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+      "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.3"
+      }
+    },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -30928,7 +30938,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "3.1.0",
+      "version": "3.2.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "moment": "^2.29.4",
     "nunjucks": "^3.2.3",
     "require-dir": "^1.2.0",
-    "sass": "^1.79.3"
+    "sass": "^1.79.3",
+    "semantic-release-plugin-update-version-in-files": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/moj/version.js
+++ b/src/moj/version.js
@@ -1,0 +1,1 @@
+MOJFrontend.version = '0.0.0-development'


### PR DESCRIPTION
This PR should include the semantic release version number within the exported bundle js.

It does this by including a version.js file which contains a placeholder version string assigned to `MOJFrontend.version` 

There is then a plugin for semantic release which should be able to find and replace this string within the compiled js output 🤞 
