### PR TITLE
fix: include compiled css and js in the package

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,6 +17,12 @@
       "assets": [
         {"path": "dist/release.zip", "name": "release-${nextRelease.gitTag}.zip"}
       ]
-    }]
+    }],
+    ["semantic-release-plugin-update-version-in-files", {
+    "files": [
+      "package/moj/all.js"
+    ],
+    "placeholder": "0.0.0-development"
+  }]
   ]
 }

--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -9,6 +9,7 @@ gulp.task('build:javascript', () => {
       'src/moj/namespace.js',
       'src/moj/helpers.js',
       'src/moj/all.js',
+      'src/moj/version.js',
       'src/moj/components/**/!(*.spec).js'
     ])
     .pipe(concat('all.js'))

--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -1,6 +1,7 @@
-const gulp = require('gulp');
-const uglify = require("gulp-uglify");
 var concat = require('gulp-concat');
+const gulp = require('gulp');
+const rename = require("gulp-rename");
+const uglify = require("gulp-uglify");
 var umd = require('gulp-umd');
 
 gulp.task('build:javascript', () => {
@@ -22,24 +23,21 @@ gulp.task('build:javascript', () => {
     .pipe(gulp.dest('package/moj/'));
 });
 
-gulp.task('build:javascript-with-jquery', () => {
+gulp.task('build:javascript-minified', () => {
+  return gulp
+    .src("package/moj/all.js")
+    .pipe(uglify())
+    .pipe(rename("moj-frontend.min.js"))
+    .pipe(gulp.dest("package/moj"));
+})
+
+gulp.task('build:javascript-minified-with-jquery', () => {
   return gulp.src([
       'node_modules/jquery/dist/jquery.js',
       'gulp/jquery/scope.js',
-      'src/moj/namespace.js',
-      'src/moj/helpers.js',
-      'src/moj/all.js',
-      'src/moj/components/**/!(*.spec).js',
+      'package/moj/all.js',
     ])
     .pipe(concat('all.jquery.min.js'))
-    .pipe(umd({
-      exports: function() {
-        return 'MOJFrontend';
-      },
-      namespace: function() {
-        return 'MOJFrontend';
-      }
-    }))
     .pipe(uglify())
     .pipe(gulp.dest('package/moj/'));
 });

--- a/gulp/build-styles.js
+++ b/gulp/build-styles.js
@@ -1,0 +1,21 @@
+const autoprefixer = require("autoprefixer");
+const cssnano = require("cssnano");
+const gulp = require("gulp");
+const postcss = require("gulp-postcss");
+const rename = require("gulp-rename");
+const sass = require("gulp-sass")(require("sass"));
+
+gulp.task("build:css", () => {
+  return gulp
+    .src("gulp/dist-scss/*.scss")
+    .pipe(sass())
+    .pipe(postcss([autoprefixer, cssnano]))
+    .pipe(
+      rename((path) => ({
+        dirname: path.dirname,
+        basename: path.basename.replace("all", "moj-frontend"),
+        extname: ".min.css",
+      }))
+    )
+    .pipe(gulp.dest("package/moj"));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,9 @@ gulp.task(
     "build:clean",
     "build:copy-files",
     "build:javascript",
-    "build:javascript-with-jquery",
+    "build:javascript-minified",
+    "build:javascript-minified-with-jquery",
+    "build:css",
     "build:compress-images",
   )
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "moment": "^2.29.4",
         "nunjucks": "^3.2.3",
         "require-dir": "^1.2.0",
-        "sass": "^1.79.3"
+        "sass": "^1.79.3",
+        "semantic-release-plugin-update-version-in-files": "^1.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -27422,6 +27423,15 @@
         "node": ">=20.8.1"
       }
     },
+    "node_modules/semantic-release-plugin-update-version-in-files": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release-plugin-update-version-in-files/-/semantic-release-plugin-update-version-in-files-1.1.0.tgz",
+      "integrity": "sha512-OWBrved3Rr0w3YP4iID81MhG9qhGrG+XtxdO9VMhKJ9qte3yBdMz5cSxDiPE/uhnGJQF00fqQetY3yhHFGabWw==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "glob": "^7.1.3"
+      }
+    },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
@@ -30928,7 +30938,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "3.1.0",
+      "version": "3.2.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "moment": "^2.29.4",
     "nunjucks": "^3.2.3",
     "require-dir": "^1.2.0",
-    "sass": "^1.79.3"
+    "sass": "^1.79.3",
+    "semantic-release-plugin-update-version-in-files": "^1.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/moj/version.js
+++ b/src/moj/version.js
@@ -1,0 +1,1 @@
+MOJFrontend.version = '0.0.0-development'


### PR DESCRIPTION
This PR adjusts the build:package task to also output a compiled minified js and css file. It also fixes the compiled output including jQuery, which didn't  work due to jQuery ending up bundled by the umd.

It also adds in a version string onto the MOJFrontend object, that should get updated by semantic release
