### PR TITLE
fix(package): Rename compiled js with jquery

### DIFF
--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -37,7 +37,7 @@ gulp.task('build:javascript-minified-with-jquery', () => {
       'gulp/jquery/scope.js',
       'package/moj/all.js',
     ])
-    .pipe(concat('all.jquery.min.js'))
+    .pipe(concat('moj-frontend.jquery.min.js'))
     .pipe(uglify())
     .pipe(gulp.dest('package/moj/'));
 });

--- a/gulp/build-javascript.js
+++ b/gulp/build-javascript.js
@@ -1,6 +1,7 @@
-const gulp = require('gulp');
-const uglify = require("gulp-uglify");
 var concat = require('gulp-concat');
+const gulp = require('gulp');
+const rename = require("gulp-rename");
+const uglify = require("gulp-uglify");
 var umd = require('gulp-umd');
 
 gulp.task('build:javascript', () => {
@@ -22,24 +23,21 @@ gulp.task('build:javascript', () => {
     .pipe(gulp.dest('package/moj/'));
 });
 
-gulp.task('build:javascript-with-jquery', () => {
+gulp.task('build:javascript-minified', () => {
+  return gulp
+    .src("package/moj/all.js")
+    .pipe(uglify())
+    .pipe(rename("moj-frontend.min.js"))
+    .pipe(gulp.dest("package/moj"));
+})
+
+gulp.task('build:javascript-minified-with-jquery', () => {
   return gulp.src([
       'node_modules/jquery/dist/jquery.js',
       'gulp/jquery/scope.js',
-      'src/moj/namespace.js',
-      'src/moj/helpers.js',
-      'src/moj/all.js',
-      'src/moj/components/**/!(*.spec).js',
+      'package/moj/all.js',
     ])
     .pipe(concat('all.jquery.min.js'))
-    .pipe(umd({
-      exports: function() {
-        return 'MOJFrontend';
-      },
-      namespace: function() {
-        return 'MOJFrontend';
-      }
-    }))
     .pipe(uglify())
     .pipe(gulp.dest('package/moj/'));
 });

--- a/gulp/build-styles.js
+++ b/gulp/build-styles.js
@@ -1,0 +1,21 @@
+const autoprefixer = require("autoprefixer");
+const cssnano = require("cssnano");
+const gulp = require("gulp");
+const postcss = require("gulp-postcss");
+const rename = require("gulp-rename");
+const sass = require("gulp-sass")(require("sass"));
+
+gulp.task("build:css", () => {
+  return gulp
+    .src("gulp/dist-scss/*.scss")
+    .pipe(sass())
+    .pipe(postcss([autoprefixer, cssnano]))
+    .pipe(
+      rename((path) => ({
+        dirname: path.dirname,
+        basename: path.basename.replace("all", "moj-frontend"),
+        extname: ".min.css",
+      }))
+    )
+    .pipe(gulp.dest("package/moj"));
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,9 @@ gulp.task(
     "build:clean",
     "build:copy-files",
     "build:javascript",
-    "build:javascript-with-jquery",
+    "build:javascript-minified",
+    "build:javascript-minified-with-jquery",
+    "build:css",
     "build:compress-images",
   )
 );


### PR DESCRIPTION
This PR simply renames the compiled js file that includes jquery from 'all.jquery.min.js' to
'moj-frontend.jquery.min.js' for consistency with the other compiled files.

Fixes #1030 

BREAKING CHANGE: The compiled javscript output with bundled jQuery has been renamed from
`all.jquery.min.js` to `moj-frontend.jquery.min.js`.