### PR TITLE
fix(interruption card): fix body text color when govuk-global-styles is true

### DIFF
--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -14,6 +14,13 @@
   color: govuk-colour("white");
 }
 
+// If $govuk-global-styles is true, we need to override the color and size on elements
+// within the body class directly
+.moj-interruption-card__body > * {
+  @include govuk-font-size($size: 24);
+  color: govuk-colour("white");
+}
+
 .moj-interruption-card__body:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
If the component is used when govuk global styles is set to true, the specificity isn't high enough to override the text color to white. 

This PR adds extra css to ensure elements within the interruption card body are given the correct text size and color.

