### PR TITLE
fix(inital): remove duplicate initialisation block in all.js

### DIFF
--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -61,13 +61,6 @@ MOJFrontend.initAll = function (options) {
     });
   });
 
-  var $sortableTables = scope.querySelectorAll('[data-module="moj-sortable-table"]');
-  MOJFrontend.nodeListForEach($sortableTables, function ($table) {
-    new MOJFrontend.SortableTable({
-      table: $table
-    });
-  });
-
   const $datepickers = document.querySelectorAll('[data-module="moj-date-picker"]')
   MOJFrontend.nodeListForEach($datepickers, function ($datepicker) {
     new MOJFrontend.DatePicker($datepicker, {}).init();


### PR DESCRIPTION
Removes the duplication of the code block to initialize sortable table components. 


