### PR TITLE
fix(initall): ensure datepickers respect scope when initialised

### DIFF
--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -61,7 +61,7 @@ MOJFrontend.initAll = function (options) {
     });
   });
 
-  const $datepickers = document.querySelectorAll('[data-module="moj-date-picker"]')
+  const $datepickers = scope.querySelectorAll('[data-module="moj-date-picker"]')
   MOJFrontend.nodeListForEach($datepickers, function ($datepicker) {
     new MOJFrontend.DatePicker($datepicker, {}).init();
   })


### PR DESCRIPTION
Datepickers now respect scope passed to initAll function rather than always being initialised within the document scope

