### PR TITLE
fix: text color in interruption card and initAll function

### DIFF
--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -61,7 +61,7 @@ MOJFrontend.initAll = function (options) {
     });
   });
 
-  const $datepickers = document.querySelectorAll('[data-module="moj-date-picker"]')
+  const $datepickers = scope.querySelectorAll('[data-module="moj-date-picker"]')
   MOJFrontend.nodeListForEach($datepickers, function ($datepicker) {
     new MOJFrontend.DatePicker($datepicker, {}).init();
   })

--- a/src/moj/all.js
+++ b/src/moj/all.js
@@ -61,13 +61,6 @@ MOJFrontend.initAll = function (options) {
     });
   });
 
-  var $sortableTables = scope.querySelectorAll('[data-module="moj-sortable-table"]');
-  MOJFrontend.nodeListForEach($sortableTables, function ($table) {
-    new MOJFrontend.SortableTable({
-      table: $table
-    });
-  });
-
   const $datepickers = document.querySelectorAll('[data-module="moj-date-picker"]')
   MOJFrontend.nodeListForEach($datepickers, function ($datepicker) {
     new MOJFrontend.DatePicker($datepicker, {}).init();

--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -14,6 +14,13 @@
   color: govuk-colour("white");
 }
 
+// If $govuk-global-styles is true, we need to override the color and size on elements
+// within the body class directly
+.moj-interruption-card__body > * {
+  @include govuk-font-size($size: 24);
+  color: govuk-colour("white");
+}
+
 .moj-interruption-card__body:last-child {
   margin-bottom: 0;
 }


### PR DESCRIPTION
Introduces the following fixes:
* #1059 
* #1060 
* #1061 