### PR TITLE
ci: update the commit status with result of tests

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,6 +44,12 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x]
 
     steps:
+    - name: Set commit status as pending
+      uses: myrotvorets/set-commit-status-action@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: pending
+        context: deploy tests
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -59,6 +65,13 @@ jobs:
         path: package
     - name: Test that sass can be compiled
       run: npm run test:sass
+    - name: Set final commit status
+      uses: myrotvorets/set-commit-status-action@master
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: ${{ job.status }}
+        context: deploy tests
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
-        context: deploy tests
+        context: Tests
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -65,17 +65,22 @@ jobs:
         path: package
     - name: Test that sass can be compiled
       run: npm run test:sass
+
+  result:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
     - name: Set final commit status
       uses: myrotvorets/set-commit-status-action@master
-      if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ job.status }}
-        context: deploy tests
+        status: ${{ needs.test.result }}
+        context: Tests
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build, test]
+    needs: [result]
     if: github.event_name == 'push'
     permissions:
       id-token: write

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         status: pending
-        context: publish tests
+        context: Tests
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -60,17 +60,23 @@ jobs:
         path: package
     - name: Test that sass can be compiled
       run: npm run test:sass
+
+  result:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always()
+    steps:
     - name: Set final commit status
       uses: myrotvorets/set-commit-status-action@master
-      if: always()
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        status: ${{ job.status }}
-        context: publish tests
+        status: ${{ needs.test.result }}
+        context: Tests
+
 
   publish:
     runs-on: ubuntu-latest
-    needs: [build, test]
+    needs: [result]
     if: github.event_name == 'push'
 
     steps:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -39,6 +39,12 @@ jobs:
         node-version: [14.x, 16.x, 18.x, 20.x, 21.x, 22.x]
 
     steps:
+    - name: Set commit status as pending
+      uses: myrotvorets/set-commit-status-action@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: pending
+        context: publish tests
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
@@ -54,6 +60,13 @@ jobs:
         path: package
     - name: Test that sass can be compiled
       run: npm run test:sass
+    - name: Set final commit status
+      uses: myrotvorets/set-commit-status-action@master
+      if: always()
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: ${{ job.status }}
+        context: publish tests
 
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates the deploy and publish github actions to update the commit status based on the pass/fail status of the tests.

This should then allow us to update the branch rules to prevent merging if the tests are failing.
