### PR TITLE
test(datepicker): remove test for length of excluded dates

### DIFF
--- a/src/moj/components/date-picker/date-picker.spec.js
+++ b/src/moj/components/date-picker/date-picker.spec.js
@@ -754,7 +754,7 @@ describe("button menu JS API", () => {
         }
         datesToExclude = datesToExclude.map((date) => date.startOf("day"));
         config = {
-          excludedDates: `${datesToExclude[0].format("D/M/YYYY")}-${datesToExclude[2].format("D/M/YYYY")} ${datesToExclude[3].format("D/M/YYYY")} ${datesToExclude[4].format("D/M/YYYY")} `,
+          excludedDates: `${datesToExclude[0].format("D/M/YYYY")}-${datesToExclude[2].format("D/M/YYYY")} ${datesToExclude[3].format("D/M/YYYY")} ${datesToExclude[4].format("D/M/YYYY")}`,
         };
         const datePicker = new MOJFrontend.DatePicker(component, config);
         datePicker.init();

--- a/src/moj/components/date-picker/date-picker.spec.js
+++ b/src/moj/components/date-picker/date-picker.spec.js
@@ -102,19 +102,6 @@ const getDateInCurrentMonth = (excluding = []) => {
   return days[Math.floor(Math.random() * days.length)];
 };
 
-const getDateRangeInCurrentMonth = (startDay, endDay) => {
-  let date = dayjs().date(startDay); // Convert the start date to a Day.js object
-  const endDate = dayjs().date(endDay + 1);
-  const dates = [];
-
-  while (date.isBefore(endDate)) {
-    dates.push(date);
-    date = date.add(1, "day");
-  }
-
-  return dates;
-};
-
 const range = (start, end) => {
   return [...Array(end - start + 1).keys()].map((x) => x + start);
 };
@@ -767,7 +754,6 @@ describe("button menu JS API", () => {
         const datePicker = new MOJFrontend.DatePicker(component, config);
         datePicker.init();
 
-        // expect(datePicker.excludedDates.length).toEqual(5);
         expect(datePicker.excludedDates).toStrictEqual(
           datesToExclude.map((date) => date.toDate()),
         );
@@ -880,11 +866,15 @@ describe("button menu JS API", () => {
       });
 
       test("excluding a range of days", async () => {
-        let datesToExclude;
+        let datesToExclude = [];
         if (dayjs().date() < 15) {
-          datesToExclude = getDateRangeInCurrentMonth(18, 20);
+          datesToExclude.push(dayjs().date(18));
+          datesToExclude.push(dayjs().date(19));
+          datesToExclude.push(dayjs().date(20));
         } else {
-          datesToExclude = getDateRangeInCurrentMonth(3, 5);
+          datesToExclude.push(dayjs().date(3));
+          datesToExclude.push(dayjs().date(4));
+          datesToExclude.push(dayjs().date(5));
         }
         datesToExclude = datesToExclude.map((date) => date.startOf("day"));
         let daysToExclude = datesToExclude.map((date) => date.date());
@@ -1072,11 +1062,15 @@ describe("Datepicker data-attributes API", () => {
     });
 
     test("excluding a range of days", async () => {
-      let datesToExclude;
+      let datesToExclude = [];
       if (dayjs().date() < 15) {
-        datesToExclude = getDateRangeInCurrentMonth(18, 20);
-      } else {
-        datesToExclude = getDateRangeInCurrentMonth(3, 5);
+          datesToExclude.push(dayjs().date(18));
+          datesToExclude.push(dayjs().date(19));
+          datesToExclude.push(dayjs().date(20));
+        } else {
+          datesToExclude.push(dayjs().date(3));
+          datesToExclude.push(dayjs().date(4));
+          datesToExclude.push(dayjs().date(5));
       }
       datesToExclude = datesToExclude.map((date) => date.startOf("day"));
       let daysToExclude = datesToExclude.map((date) => date.date());

--- a/src/moj/components/date-picker/date-picker.spec.js
+++ b/src/moj/components/date-picker/date-picker.spec.js
@@ -720,11 +720,15 @@ describe("button menu JS API", () => {
       });
 
       test("excluding a range of days", () => {
-        let datesToExclude;
+        let datesToExclude = [];
         if (dayjs().date() < 15) {
-          datesToExclude = getDateRangeInCurrentMonth(18, 20);
+          datesToExclude.push(dayjs().date(18));
+          datesToExclude.push(dayjs().date(19));
+          datesToExclude.push(dayjs().date(20));
         } else {
-          datesToExclude = getDateRangeInCurrentMonth(3, 5);
+          datesToExclude.push(dayjs().date(3));
+          datesToExclude.push(dayjs().date(4));
+          datesToExclude.push(dayjs().date(5));
         }
         datesToExclude = datesToExclude.map((date) => date.startOf("day"));
 
@@ -742,13 +746,17 @@ describe("button menu JS API", () => {
       });
 
       test("excluding individual dates and a range of days", () => {
-        let datesToExclude;
+        let datesToExclude = [];
         if (dayjs().date() < 15) {
-          datesToExclude = getDateRangeInCurrentMonth(18, 20);
+          datesToExclude.push(dayjs().date(18));
+          datesToExclude.push(dayjs().date(19));
+          datesToExclude.push(dayjs().date(20));
           datesToExclude.push(dayjs().date(22));
           datesToExclude.push(dayjs().date(25));
         } else {
-          datesToExclude = getDateRangeInCurrentMonth(3, 5);
+          datesToExclude.push(dayjs().date(3));
+          datesToExclude.push(dayjs().date(4));
+          datesToExclude.push(dayjs().date(5));
           datesToExclude.push(dayjs().date(7));
           datesToExclude.push(dayjs().date(11));
         }

--- a/src/moj/components/date-picker/date-picker.spec.js
+++ b/src/moj/components/date-picker/date-picker.spec.js
@@ -727,13 +727,15 @@ describe("button menu JS API", () => {
           datesToExclude = getDateRangeInCurrentMonth(3, 5);
         }
         datesToExclude = datesToExclude.map((date) => date.startOf("day"));
+
         config = {
           excludedDates: `${datesToExclude[0].format("D/M/YYYY")}-${datesToExclude[datesToExclude.length - 1].format("D/M/YYYY")}`,
         };
+
         const datePicker = new MOJFrontend.DatePicker(component, config);
         datePicker.init();
 
-        expect(datePicker.excludedDates.length).toEqual(3);
+        // expect(datePicker.excludedDates.length).toEqual(3);
         expect(datePicker.excludedDates).toStrictEqual(
           datesToExclude.map((date) => date.toDate()),
         );
@@ -757,7 +759,7 @@ describe("button menu JS API", () => {
         const datePicker = new MOJFrontend.DatePicker(component, config);
         datePicker.init();
 
-        expect(datePicker.excludedDates.length).toEqual(5);
+        // expect(datePicker.excludedDates.length).toEqual(5);
         expect(datePicker.excludedDates).toStrictEqual(
           datesToExclude.map((date) => date.toDate()),
         );


### PR DESCRIPTION
The cause of the flaky test seems to be the `getDateRangeInCurrentMonth` function within the tests. This was implemented before the addition of the `dayjs` library.

Now we have the date library to easily generate dates, we can remove the custom function and just manually add dayjs dates to an array.