### PR TITLE
docs: update govuk-frontend to 5.8.0

### DIFF
--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -4,7 +4,7 @@ $moj-assets-path: "../" !default;
 $govuk-assets-path: "../" !default;
 
 // GOV.UK Frontend
-@import "node_modules/govuk-frontend/dist/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/index";
 
 // MOJ Frontend
 @import "src/moj/all";

--- a/package-lock.json
+++ b/package-lock.json
@@ -13114,10 +13114,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
-      "license": "MIT",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
+      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -30937,7 +30936,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "3.2.2",
+      "version": "3.3.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This PR updates the docs site to use govuk-frontend 5.8.0

The only change required is to import `index.scss` instead of `all.scss` 

This is listed as a docs only change, as while the published bundle does draw in from the installed version of govuk frontend, it only requires `base.scss` and as such there will be no changes to the package, so we do not need to publish a new version.