### PR TITLE
Add stylelint config and lint all scss files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,27 @@
-.DS_Store
-.env
-.port.tmp
-.tmp
-.vscode/
-node_modules
-npm-debug.log
-public/
-sass-cache
-settings.json
-tmp-uploads
-dist
+# Temporary only
+.cache/
+.tmp/
 
+# Node.js modules
+node_modules/
+
+# Build output
+dist/
+public/
 # ignore everything in the package directory, but not govuk-prototype-kit.config.json, package.json and README.md
 package/*
 !package/govuk-prototype-kit.config.json
 !package/package.json
 !package/README.md
+
+# Other
+.DS_Store
+.env
+.port.tmp
+.vscode/
+npm-debug.log
+sass-cache
+settings.json
+tmp-uploads
+
+

--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -10,7 +10,7 @@ $govuk-assets-path: "../" !default;
 @import "src/moj/all";
 
 // highlight.js
-@import "node_modules/highlight.js/scss/github.scss";
+@import "node_modules/highlight.js/scss/github";
 
 // Custom documentation components
 @import "./components/accordions";

--- a/docs/assets/stylesheets/components/_accordions.scss
+++ b/docs/assets/stylesheets/components/_accordions.scss
@@ -3,15 +3,20 @@
    ========================================================================== */
 
    .govuk-accordion__section-button:hover {
+    // stylelint-disable-next-line declaration-no-important
     background: #ebebeb !important;
   }
 
   .govuk-accordion__show-all:hover {
+   // stylelint-disable-next-line declaration-no-important
    background: #ebebeb !important;
+   // stylelint-disable-next-line declaration-no-important
    box-shadow: 0 -2px #ebebeb, 0 4px #ebebeb !important;
  }
 
   .govuk-accordion__show-all:focus {
+    // stylelint-disable-next-line declaration-no-important
     background: $govuk-focus-colour !important;
+    // stylelint-disable-next-line declaration-no-important
     box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-text-colour !important;
   }

--- a/docs/assets/stylesheets/components/_cookie-banner.scss
+++ b/docs/assets/stylesheets/components/_cookie-banner.scss
@@ -1,9 +1,10 @@
 // Override cookie banner to be left aligned
 .govuk-cookie-banner--align-left {
   .govuk-cookie-banner__message {
-    margin-left: 20px;
     margin-right: 20px;
+    margin-left: 20px;
   }
+
   .govuk-cookie-banner__content {
     text-wrap: pretty;
   }

--- a/docs/assets/stylesheets/components/_copy-button.scss
+++ b/docs/assets/stylesheets/components/_copy-button.scss
@@ -7,7 +7,7 @@
   top: govuk-spacing(3);
   right: govuk-spacing(3);
   min-width: 110px;
-  padding: 4px 10px 2px 10px;
+  padding: 4px 10px 2px;
   border: 1px solid $copy-button-colour;
   color: $copy-button-colour;
   background-color: govuk-colour("white");

--- a/docs/assets/stylesheets/components/_documentation_tabs.scss
+++ b/docs/assets/stylesheets/components/_documentation_tabs.scss
@@ -1,3 +1,4 @@
+// stylelint-disable
 .js-enabled {
   .app-navigation {
     &__list {
@@ -209,7 +210,6 @@
       padding-left: unset;
 
       a:not(:focus)::before {
-        // stylelint-disable-next-line declaration-no-important
         background-color: unset !important;
       }
     }
@@ -338,3 +338,4 @@ body:not(.js-enabled) {
 .govuk-tabs__list-item {
   background-color: unset;
 }
+// stylelint-enable

--- a/docs/assets/stylesheets/components/_documentation_tabs.scss
+++ b/docs/assets/stylesheets/components/_documentation_tabs.scss
@@ -200,6 +200,7 @@
       }
       padding-left: unset;
       a:not(:focus):before {
+        // stylelint-disable-next-line declaration-no-important
         background-color: unset !important;
       }
     }

--- a/docs/assets/stylesheets/components/_documentation_tabs.scss
+++ b/docs/assets/stylesheets/components/_documentation_tabs.scss
@@ -2,17 +2,17 @@
   .app-navigation {
     &__list {
       @include govuk-media-query($from: tablet) {
-        box-shadow: inset 0 -1px 0 $govuk-border-colour;
         width: 100%;
+        box-shadow: inset 0 -1px 0 $govuk-border-colour;
       }
     }
 
     &__item {
       @include govuk-media-query($from: tablet) {
-        box-shadow: none;
         display: inline-block;
-        margin-right: govuk-spacing(4);
         margin-top: 0;
+        margin-right: govuk-spacing(4);
+        box-shadow: none;
       }
     }
 
@@ -22,30 +22,33 @@
       }
 
 
-      &:focus:before {
+      &:focus::before {
         @include govuk-media-query($from: tablet) {
-          height: 5px;
           width: 100%;
+          height: 5px;
         }
       }
     }
+
     &__link[aria-current="page"] {
-      &:before {
+      &::before {
         @include govuk-media-query($from: tablet) {
-          height: 5px;
           width: 100%;
+          height: 5px;
         }
       }
     }
+
     .govuk-tabs__list-item--selected {
       a {
         @include govuk-media-query($from: tablet) {
           padding-left: 0;
         }
-        &:focus:before {
+
+        &:focus::before {
           @include govuk-media-query($from: tablet) {
-            height: 5px;
             width: 100%;
+            height: 5px;
           }
         }
 
@@ -58,17 +61,17 @@
   margin-bottom: govuk-spacing(7);
 
   &__list {
-    font-size: 0; // Removes white space when using inline-block on child element.
-    list-style: none;
     margin: 0;
     padding: 0;
+    font-size: 0; // Removes white space when using inline-block on child element.
+    list-style: none;
   }
 
   &__item {
     @include govuk-font(19);
-    box-shadow: inset 0 -1px 0 $govuk-border-colour;
     display: block;
     margin-top: -1px;
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
 
     &:last-child {
       box-shadow: none;
@@ -77,11 +80,11 @@
 
   &__link {
     display: block;
+    position: relative;
     padding-top: 12px;
     padding-bottom: 12px;
     padding-left: govuk-spacing(3);
     text-decoration: none;
-    position: relative;
 
     &:link,
     &:visited {
@@ -93,44 +96,44 @@
     }
 
     &:focus {
-      color: govuk-colour("black");
       position: relative;
+      color: govuk-colour("black");
       box-shadow: none;
     }
 
-    &:focus:before {
-      background-color: govuk-colour("black");
+    &:focus::before {
       content: "";
       display: block;
-      height: 100%;
       position: absolute;
       bottom: 0;
       left: 0;
       width: 5px;
+      height: 100%;
+      background-color: govuk-colour("black");
     }
   }
 
   &__link[aria-current="page"] {
-    color: $govuk-link-active-colour;
     position: relative;
+    color: $govuk-link-active-colour;
     text-decoration: none;
 
-    &:before {
-      background-color: $govuk-link-colour;
+    &::before {
       content: "";
       display: block;
-      height: 100%;
       position: absolute;
       bottom: 0;
       left: 0;
       width: 5px;
+      height: 100%;
+      background-color: $govuk-link-colour;
     }
 
     &:hover {
       color: $govuk-link-hover-colour;
     }
 
-    &:focus:before {
+    &:focus::before {
       background-color: govuk-colour("black");
     }
   }
@@ -143,31 +146,37 @@
     }
 
     .app-navigation__item {
-      margin-left: 0;
       margin-right: 20px;
-      &:before {
+      margin-left: 0;
+
+      &::before {
         content: unset;
         margin-left: unset;
         padding-left: unset;
       }
+
       a.app-navigation__link {
         margin-bottom: 0;
         text-decoration: none;
+
         &:focus {
           border: none;
           box-shadow: none;
         }
       }
     }
+
     .govuk-tabs__list-item--selected {
       margin-right: 20px;
+
       a {
         display: block;
+        position: relative;
         padding-top: 12px;
         padding-bottom: 12px;
         padding-left: govuk-spacing(3);
         text-decoration: none;
-        position: relative;
+        text-decoration: underline;
 
         &:link,
         &:visited {
@@ -179,31 +188,32 @@
         }
 
         &:focus {
-          color: govuk-colour("black");
           position: relative;
+          color: govuk-colour("black");
           box-shadow: none;
         }
 
-        &:focus:before {
-          background-color: govuk-colour("black");
+        &:focus::before {
           content: "";
           display: block;
-          height: 100%;
           position: absolute;
           bottom: 0;
           left: 0;
           width: 5px;
+          height: 100%;
+          background-color: govuk-colour("black");
 
 
         }
-        text-decoration: underline;
       }
       padding-left: unset;
-      a:not(:focus):before {
+
+      a:not(:focus)::before {
         // stylelint-disable-next-line declaration-no-important
         background-color: unset !important;
       }
     }
+
     .app-navigation__list {
       padding-left: 0;
     }
@@ -216,6 +226,7 @@
 
 body:not(.js-enabled) {
   @include no-js-doc-tabs-styles;
+
   .govuk-tabs__list-item {
     text-align: left;
   }
@@ -227,21 +238,26 @@ body:not(.js-enabled) {
       margin-bottom: 20px;
       padding-left: unset;
       border-bottom: unset;
+
       .govuk-tabs__tab {
         &:link,
         &:visited {
           color: $govuk-link-colour;
         }
+
         &[aria-selected="true"] {
           color: govuk-colour("black");
         }
+
         &:hover {
           color: $govuk-link-hover-colour;
         }
         text-decoration: unset;
       }
+
       .app-navigation__item {
         margin-bottom: 0;
+
         .app-navigation__link {
           &:focus {
             box-shadow: none;
@@ -255,23 +271,25 @@ body:not(.js-enabled) {
 .js-enabled {
   .app-navigation {
     .govuk-tabs__list-item--selected a {
-      color: $govuk-link-active-colour;
       position: relative;
+      color: $govuk-link-active-colour;
       text-decoration: none;
 
-      &:before {
-        background-color: $govuk-link-colour;
+      text-decoration: unset;
+
+      &::before {
         content: "";
         display: block;
-        height: 100%;
         position: absolute;
         bottom: 0;
         left: 0;
         width: 5px;
+        height: 100%;
+        background-color: $govuk-link-colour;
 
         @include govuk-media-query($from: tablet) {
-          height: 5px;
           width: 100%;
+          height: 5px;
         }
       }
 
@@ -279,11 +297,9 @@ body:not(.js-enabled) {
         color: $govuk-link-hover-colour;
       }
 
-      &:focus:before {
+      &:focus::before {
         background-color: govuk-colour("black");
       }
-
-      text-decoration: unset;
     }
   }
 
@@ -297,21 +313,24 @@ body:not(.js-enabled) {
     margin-bottom: 40px;
     scroll-margin-top: 40px;
   }
+
   .govuk-tabs__list-item--selected,
   .govuk-tabs__panel {
-    border: unset;
     padding: unset;
+    border: unset;
   }
+
   .govuk-tabs__list-item {
-    background-color: unset;
-    float: unset;
     margin-right: 20px;
     padding: unset;
-  }
-  .govuk-tabs__list-item--selected {
     float: unset;
-    margin-top: unset;
+    background-color: unset;
+  }
+
+  .govuk-tabs__list-item--selected {
     position: unset;
+    margin-top: unset;
+    float: unset;
     background-color: unset;
   }
 }

--- a/docs/assets/stylesheets/components/_example.scss
+++ b/docs/assets/stylesheets/components/_example.scss
@@ -3,31 +3,31 @@
    ========================================================================== */
 
   .app-example {
-    background-color: govuk-colour("white");
-    border-left: 1px solid $govuk-border-colour;
-    border-right: 1px solid $govuk-border-colour;
     position: relative;
+    border-right: 1px solid $govuk-border-colour;
+    border-left: 1px solid $govuk-border-colour;
+    background-color: govuk-colour("white");
   }
 
   .app-example__frame {
-    background-color: govuk-colour("white");
-    border: 0;
     display: block;
     width: 100%;
+    border: 0;
+    background-color: govuk-colour("white");
   }
 
   .app-example-page {
+    position: relative;
     margin-bottom: -1px;
     padding: 30px;
     padding-top: 60px;
-    position: relative;
   }
 
   .app-example__new-window {
     @include govuk-font($size: 16);
+    padding: 8px;
     border: 1px solid $govuk-border-colour;
     background-color: govuk-colour("white");
-    padding: 8px;
 
     a,
     a:link,

--- a/docs/assets/stylesheets/components/_footer.scss
+++ b/docs/assets/stylesheets/components/_footer.scss
@@ -1,6 +1,6 @@
 .govuk-footer--docs {
   .govuk-width-container {
-    margin-left: govuk-spacing(4);
     margin-right: govuk-spacing(4);
+    margin-left: govuk-spacing(4);
   }
 }

--- a/docs/assets/stylesheets/components/_header.scss
+++ b/docs/assets/stylesheets/components/_header.scss
@@ -1,7 +1,7 @@
 .moj-header--docs {
-    background-color: #220051;
     padding-top: govuk-spacing(3);
     border-bottom: 10px solid govuk-colour("pink");
+    background-color: #220051;
 }
 
 .moj-header--docs .moj-header__container {

--- a/docs/assets/stylesheets/components/_layout.scss
+++ b/docs/assets/stylesheets/components/_layout.scss
@@ -2,8 +2,8 @@ $app-breakpoint: 800px;
 
 .app-layout {
     @include govuk-media-query($app-breakpoint) {
-      width: 100%;
       display: grid;
+      width: 100%;
       grid-template-columns: min(25%, 300px) auto;
     }
 }

--- a/docs/assets/stylesheets/components/_masthead.scss
+++ b/docs/assets/stylesheets/components/_masthead.scss
@@ -15,6 +15,7 @@ $brand-colour: #220051;
 }
 
 .app-masthead .govuk-button--start {
+  // stylelint-disable-next-line declaration-no-important
   color: $brand-colour !important;
   background-color: govuk-colour("white");
 }

--- a/docs/assets/stylesheets/components/_masthead.scss
+++ b/docs/assets/stylesheets/components/_masthead.scss
@@ -5,8 +5,8 @@
 $brand-colour: #220051;
 
 .app-masthead {
-  background-color: $brand-colour;
   color: govuk-colour("white");
+  background-color: $brand-colour;
 }
 
 .app-masthead p,

--- a/docs/assets/stylesheets/components/_menu-toggle.scss
+++ b/docs/assets/stylesheets/components/_menu-toggle.scss
@@ -5,21 +5,21 @@ moj-menu-toggle:not(:defined) {
 moj-menu-toggle > button {
   @extend .govuk-button;
 
-  background: none;
-  border: none;
-  box-shadow: none;
-  margin-bottom: 0;
-  color: govuk-colour('white');
-  font-weight: bold;
-
   display: flex;
+  margin-bottom: 0;
+  border: none;
+  color: govuk-colour('white');
+
+  background: none;
+  box-shadow: none;
+  font-weight: bold;
   align-items: center;
   gap: 6px;
 
   &:hover,
   &:active {
-    background-color: transparent;
     border-color: transparent;
+    background-color: transparent;
   }
 
   &:focus {

--- a/docs/assets/stylesheets/components/_panel.scss
+++ b/docs/assets/stylesheets/components/_panel.scss
@@ -6,8 +6,8 @@
   @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(6, "bottom");
   @include govuk-responsive-padding(3);
-  background-color: govuk-colour("blue");
   color: govuk-colour("white");
+  background-color: govuk-colour("blue");
 }
 
 .app-panel__heading,

--- a/docs/assets/stylesheets/components/_prose.scss
+++ b/docs/assets/stylesheets/components/_prose.scss
@@ -20,8 +20,8 @@
   }
 
   img {
-    border: 1px solid #b1b4b6;
     max-width: 100%;
+    border: 1px solid #b1b4b6;
   }
 
   code:not([class*="language-"]) {
@@ -69,23 +69,23 @@
     @include govuk-font($size: 19);
     @include govuk-text-colour;
     @include govuk-responsive-margin(6, "bottom");
+    width: 100%;
     border-spacing: 0;
     border-collapse: collapse;
-    width: 100%;
   }
 
   th {
     @include govuk-typography-weight-bold;
-    border-bottom: 1px solid $govuk-border-colour;
     padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px)
       govuk-em(govuk-spacing(2), 19px) 0;
+    border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
   }
 
   td {
-    border-bottom: 1px solid $govuk-border-colour;
     padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px)
       govuk-em(govuk-spacing(2), 19px) 0;
+    border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
   }
 
@@ -103,10 +103,10 @@
 
 pre {
   @include govuk-responsive-margin(6, "bottom");
-  background: #f7f7f7;
-  font-size: 16px;
+  position: relative;
   margin: govuk-spacing(6);
   padding: govuk-spacing(3);
-  position: relative;
   overflow: auto;
+  background: #f7f7f7;
+  font-size: 16px;
 }

--- a/docs/assets/stylesheets/components/_prose.scss
+++ b/docs/assets/stylesheets/components/_prose.scss
@@ -28,7 +28,7 @@
     padding: 0 1px;
     color: #c62950;
     background-color: #e9e9e9;
-    font-family: monospace, monospace;
+    font-family: monospace;
     font-size: 0.85em;
   }
 

--- a/docs/assets/stylesheets/components/_tabs.scss
+++ b/docs/assets/stylesheets/components/_tabs.scss
@@ -97,6 +97,7 @@
   }
 
   p {
+    // stylelint-disable-next-line declaration-no-important
     max-width: 100% !important;
   }
 

--- a/docs/assets/stylesheets/components/_tabs.scss
+++ b/docs/assets/stylesheets/components/_tabs.scss
@@ -3,29 +3,29 @@
    ========================================================================== */
 
 .app-tabs {
-  background: govuk-colour("white");
-  border-top: 0;
   margin-bottom: govuk-spacing(9);
+  border-top: 0;
+  background: govuk-colour("white");
 }
 
 .app-tabs__list {
-  border: 1px solid $govuk-border-colour;
-  list-style: none;
   margin: 0;
   padding: 0;
+  border: 1px solid $govuk-border-colour;
+  list-style: none;
 
   // A specific selector to override .app-prose-scope
   .app-prose-scope & {
-    font-size: 0; // Remove white space when using display: inline-block
     margin: 0;
     padding: 0;
+    font-size: 0; // Remove white space when using display: inline-block
   }
 }
 
 .app-tabs__list-item {
-  border-right: 1px solid $govuk-border-colour;
   display: inline-block;
   margin: 0;
+  border-right: 1px solid $govuk-border-colour;
 
   // A specific selector to override .app-prose-scope
   .app-prose-scope & {
@@ -35,18 +35,18 @@
 
 .app-tabs__tab {
   @include govuk-font($size: 19, $weight: bold);
-  background-color: govuk-colour("white");
-  color: govuk-colour("blue");
   display: block;
-  padding: 20px;
   position: relative;
+  padding: 20px;
+  color: govuk-colour("blue");
+  background-color: govuk-colour("white");
   text-decoration: none;
 
   &:link,
   &:active,
   &:visited {
-    background-color: govuk-colour("white");
     color: govuk-colour("blue");
+    background-color: govuk-colour("white");
 
     // A specific selector to override .app-prose-scope
     .app-prose-scope & {
@@ -64,18 +64,18 @@
     z-index: 2; // Focus state must sit above
 
     .app-prose-scope & {
+      border-color: $govuk-focus-text-colour;
       color: $govuk-focus-text-colour;
       background-color: $govuk-focus-colour;
       box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
-      border-color: $govuk-focus-text-colour;
     }
   }
 
   &[aria-selected="true"] {
-    background-color: govuk-colour("white");
-    color: govuk-colour("black");
     margin-bottom: -1px;
     padding-bottom: 21px;
+    color: govuk-colour("black");
+    background-color: govuk-colour("white");
 
     // A specific selector to override .app-prose-scope
     .app-prose-scope & {
@@ -86,11 +86,11 @@
 
 .app-tabs__panel {
   @include govuk-font($size: 16);
-  background-color: govuk-colour("white");
-  border: 1px solid $govuk-border-colour;
-  border-top: 0;
   position: relative;
   padding: govuk-spacing(3);
+  border: 1px solid $govuk-border-colour;
+  border-top: 0;
+  background-color: govuk-colour("white");
 
   &--hidden {
     display: none;

--- a/docs/assets/stylesheets/components/_vertical-nav.scss
+++ b/docs/assets/stylesheets/components/_vertical-nav.scss
@@ -6,12 +6,12 @@ $moj-button-hover-colour: #767676;
   @include govuk-responsive-padding(6, 'bottom');
   @include govuk-responsive-margin(6, 'bottom');
 
-  &:after {
+  &::after {
     content: "";
     position:absolute;
+    right: govuk-spacing(4);
     bottom: 0;
     left: govuk-spacing(4);
-    right: govuk-spacing(4);
     height: 1px;
     background-color: $govuk-border-colour;
   }
@@ -19,17 +19,17 @@ $moj-button-hover-colour: #767676;
 
 .app-vertical-nav__header {
   @include govuk-font($size: 24);
-  color: $govuk-secondary-text-colour;
-  padding-left: 19px;
-  padding-right: 19px;
   margin-bottom: govuk-spacing(2);
+  padding-right: 19px;
+  padding-left: 19px;
+  color: $govuk-secondary-text-colour;
 }
 
 .app-vertical-nav__list {
   @include govuk-font($size: 19);
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
 }
 
 .app-vertical-nav__item {
@@ -38,12 +38,12 @@ $moj-button-hover-colour: #767676;
 }
 
 .app-vertical-nav__indicator {
+  display: flex;
   position: absolute;
-  width: 24px;
-  height: 24px;
   top: 7px;
   right: 15px;
-  display: flex;
+  width: 24px;
+  height: 24px;
   justify-content: center;
   align-items: center;
 
@@ -53,27 +53,27 @@ $moj-button-hover-colour: #767676;
 }
 
 .app-vertical-nav__link {
-  color: $govuk-link-colour;
-  text-decoration: none;
   display: block;
   padding: 10px 38px 8px govuk-spacing(4);
   border-left: 4px solid transparent;
+  color: $govuk-link-colour;
+  text-decoration: none;
 
   &:visited {
     color: $govuk-link-colour;
   }
 
   &:hover {
-    background-color: $moj-button-hover-colour;
     color: govuk-colour("white");
+    background-color: $moj-button-hover-colour;
   }
 
   &:focus,
   &:focus-visible {
-    background-color: $govuk-focus-colour;
-    color: $govuk-text-colour;
-    outline: none;
     border-color: $govuk-text-colour;
+    outline: none;
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
   }
 
   &:focus:hover,
@@ -86,14 +86,14 @@ $moj-button-hover-colour: #767676;
 .app-vertical-nav__toggle {
   display: block;
   width: 100%;
-  border: none;
-  background-color: transparent;
   padding: 10px 38px 8px govuk-spacing(4);
+  border: none;
   border-left: 4px solid transparent;
-  @include govuk-font($size: 19);
   color: $govuk-link-colour;
-  text-decoration: none;
+  background-color: transparent;
   text-align: left;
+  text-decoration: none;
+  @include govuk-font($size: 19);
 
   &:visited {
     color: $govuk-link-colour;
@@ -109,10 +109,10 @@ $moj-button-hover-colour: #767676;
   }
 
   &:focus-visible {
-    background-color: $govuk-focus-colour;
-    color: $govuk-text-colour;
-    outline: none;
     border-color: $govuk-text-colour;
+    outline: none;
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
   }
 
   &:focus-visible:hover {
@@ -127,20 +127,20 @@ $moj-button-hover-colour: #767676;
 }
 
 .app-vertical-nav__item--active > .app-vertical-nav__link {
-    background-color: $govuk-link-colour;
     color: govuk-colour('white');
+    background-color: $govuk-link-colour;
 
     &:hover {
-    background-color: $moj-app-mid-grey;
     color: govuk-colour('white') ;
+    background-color: $moj-app-mid-grey;
   }
 
   &:focus,
   &:focus-visible {
-    background-color: $govuk-focus-colour;
-    color: $govuk-text-colour;
-    outline: none;
     border-color: $govuk-text-colour;
+    outline: none;
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
   }
 
   &:focus:hover,
@@ -152,6 +152,7 @@ $moj-button-hover-colour: #767676;
 .app-vertical-nav__item .app-vertical-nav__indicator {
   transform: rotate(180deg);
 }
+
 .app-vertical-nav__item--open .app-vertical-nav__indicator {
   transform: rotate(0deg);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -202,55 +202,6 @@
         "url": "https://opencollective.com/11ty"
       }
     },
-    "node_modules/@11ty/eleventy/node_modules/entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/@11ty/eleventy/node_modules/linkify-it": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
-      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^1.0.1"
-      }
-    },
-    "node_modules/@11ty/eleventy/node_modules/markdown-it": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
-      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "~3.0.1",
-        "linkify-it": "^4.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/@11ty/eleventy/node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "license": "MIT"
-    },
-    "node_modules/@11ty/eleventy/node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "license": "MIT"
-    },
     "node_modules/@11ty/lodash-custom": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/@11ty/lodash-custom/-/lodash-custom-4.17.21.tgz",
@@ -2708,6 +2659,81 @@
         "node": ">=16"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
@@ -2719,6 +2745,276 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -4172,6 +4468,44 @@
         "@parcel/watcher-win32-x64": "2.4.1"
       }
     },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
+      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
+      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
@@ -4183,6 +4517,177 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
+      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
+      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
+      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
+      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
+      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
+      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
+      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
+      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
+      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -4388,14 +4893,10 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -4461,13 +4962,12 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -4488,14 +4988,13 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/mime": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
-      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.6.tgz",
+      "integrity": "sha512-4rGt7rvQHBbaSOF9POGkk1ocRP16Md1x36Xma8sz8h8/vfCUI2OtEIeCqe4Ofes853x4xDoPiFLIT47J5fI/7A==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa"
       ],
-      "license": "MIT",
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -7208,11 +7707,10 @@
       }
     },
     "node_modules/bin-version/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -7856,16 +8354,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/cacheable-request/node_modules/lowercase-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-      "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/cacheable-request/node_modules/normalize-url": {
@@ -9077,10 +9565,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -9196,11 +9683,10 @@
       }
     },
     "node_modules/css-select/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -9516,10 +10002,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -12852,11 +13337,10 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -14553,6 +15037,81 @@
         "node": ">=16"
       }
     },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/gulp-esbuild/node_modules/@esbuild/darwin-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
@@ -14564,6 +15123,261 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -14669,10 +15483,9 @@
       }
     },
     "node_modules/gulp-imagemin/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "license": "MIT",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -14814,10 +15627,9 @@
       }
     },
     "node_modules/gulp-plugin-extras/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "license": "MIT",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -15031,11 +15843,10 @@
       }
     },
     "node_modules/gulp-zip/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -15326,11 +16137,10 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
-      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -15620,11 +16430,10 @@
       }
     },
     "node_modules/imagemin-gifsicle/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "devOptional": true,
-      "license": "MIT",
       "dependencies": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -20244,14 +21053,11 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dependencies": {
-        "uc.micro": "^2.0.0"
+        "uc.micro": "^1.0.1"
       }
     },
     "node_modules/liquidjs": {
@@ -20643,11 +21449,10 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
       "devOptional": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20778,22 +21583,18 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
+      "integrity": "sha512-FtwnEuuK+2yVU7goGn/MJ0WBZMM9ZPgU9spqlFs7/A/pDIUNSOQZhUgOqYCficIuR2QaFnrt8LHqBWsbTAoI5w==",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
+        "markdown-it": "bin/markdown-it.js"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -20805,6 +21606,17 @@
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/marked": {
@@ -20858,11 +21670,10 @@
       }
     },
     "node_modules/marked-terminal/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -21139,12 +21950,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -21217,11 +22025,10 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.53.0.tgz",
-      "integrity": "sha512-oHlN/w+3MQ3rba9rqFr6V/ypF10LSkdwUysQL7GkXoTgIWeV+tcXGA852TBxH+gsh8UWoyhR1hKcoMJTuWflpg==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "devOptional": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -21235,16 +22042,6 @@
       "dependencies": {
         "mime-db": "1.52.0"
       },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -25698,9 +26495,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
-      "integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -25883,11 +26680,10 @@
       "license": "MIT"
     },
     "node_modules/parse5": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.0.tgz",
-      "integrity": "sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "entities": "^4.5.0"
       },
@@ -27311,17 +28107,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -27483,11 +28268,10 @@
       }
     },
     "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -27535,11 +28319,10 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -27566,11 +28349,10 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
-      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+      "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
       },
@@ -28315,10 +29097,9 @@
       }
     },
     "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
-      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
-      "license": "MIT",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -28330,12 +29111,11 @@
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
-      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
-      "license": "MIT",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+      "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -28356,11 +29136,10 @@
       }
     },
     "node_modules/schema-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
-      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.0.tgz",
+      "integrity": "sha512-Gf9qqc58SpCA/xdziiHz35F4GNIWYWZrEshUc/G/r5BnLph6xpKuLeoJoQuj5WfBIx/eQLf+hmVPYHaxJu7V2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -28368,7 +29147,7 @@
         "ajv-keywords": "^5.1.0"
       },
       "engines": {
-        "node": ">= 12.13.0"
+        "node": ">= 10.13.0"
       },
       "funding": {
         "type": "opencollective",
@@ -28614,11 +29393,10 @@
       }
     },
     "node_modules/semantic-release/node_modules/execa": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.4.0.tgz",
-      "integrity": "sha512-yKHlle2YGxZE842MERVIplWwNH5VYmqqcPFgtnlU//K8gxuFFXu0pwd/CrfXTumFpeEiufsP7+opT/bPJa1yVw==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
+      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "cross-spawn": "^7.0.3",
@@ -29580,11 +30358,10 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.20.tgz",
-      "integrity": "sha512-jg25NiDV/1fLtSgEgyvVyDunvaNHbuwF9lfNV17gSmPFAlYzdfNBlLtLzXTevwkPj7DhGbmN9VnmJIgLnhvaBw==",
-      "devOptional": true,
-      "license": "CC0-1.0"
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
+      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg==",
+      "devOptional": true
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -31604,12 +32381,9 @@
       }
     },
     "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,10 @@
         "npm-run-all2": "^6.0.0",
         "postcss": "^8.4.31",
         "semantic-release": "^23.0.0",
-        "sinon": "^19.0.2"
+        "sinon": "^19.0.2",
+        "stylelint": "^16.13.2",
+        "stylelint-config-gds": "^2.0.0",
+        "stylelint-order": "^6.0.4"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2617,6 +2620,80 @@
         "node": ">=8"
       }
     },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
+      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
+      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.2.tgz",
+      "integrity": "sha512-EUos465uvVvMJehckATTlNqGj4UJWkTmdWuDMjqvSUkjGpmOyFZBVwb4knxCm/k2GMTXY+c/5RkdndzFYWeX5A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/@es-joy/jsdoccomment": {
       "version": "0.49.0",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.49.0.tgz",
@@ -2631,86 +2708,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-x64": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
@@ -2722,294 +2719,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -4196,6 +3905,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.2.tgz",
+      "integrity": "sha512-+E/LyaAeuABniD/RvUezWVXKpeuvwLEA9//nE9952zBaOdBd2mQ3pPoM8cUe2X6IcMByfuSLzmYqnYshG60+HQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keyv/serialize/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@ministryofjustice/frontend": {
       "resolved": "package",
       "link": true
@@ -4430,46 +4172,6 @@
         "@parcel/watcher-win32-x64": "2.4.1"
       }
     },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-darwin-x64": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
@@ -4481,186 +4183,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
-      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
-      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
-      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
-      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
-      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
-      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
-      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
-      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -5893,9 +5415,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -6778,6 +6300,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -6810,6 +6341,15 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/async-settle": {
       "version": "1.0.0",
@@ -8282,6 +7822,16 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/cacheable": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.8.8.tgz",
+      "integrity": "sha512-OE1/jlarWxROUIpd0qGBSKFLkNsotY8pt4GeiVErUYh/NUeTNrT+SBksUgllQv4m6a0W/VZsLuiHb88maavqEw==",
+      "dev": true,
+      "dependencies": {
+        "hookified": "^1.7.0",
+        "keyv": "^5.2.3"
+      }
+    },
     "node_modules/cacheable-request": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
@@ -8354,6 +7904,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.2.3.tgz",
+      "integrity": "sha512-AGKecUfzrowabUv0bH1RIR5Vf7w+l4S3xtQAypKaUpTdIR1EbrAcTxHCrpo9Q+IWeUlFE2palRtgIQcgm+PQJw==",
+      "dev": true,
+      "dependencies": {
+        "@keyv/serialize": "^1.0.2"
       }
     },
     "node_modules/cachedir": {
@@ -9571,6 +9130,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
+      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12 || >=16"
       }
     },
     "node_modules/css-mediaquery": {
@@ -12017,6 +11585,32 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -12062,11 +11656,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/eslint/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/eslint/node_modules/supports-color": {
       "version": "7.2.0",
@@ -12686,16 +12295,15 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "license": "MIT",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -12742,6 +12350,15 @@
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.9.1"
       }
     },
     "node_modules/fastq": {
@@ -12800,15 +12417,12 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.0.5.tgz",
+      "integrity": "sha512-umpQsJrBNsdMDgreSryMEXvJh66XeLtZUwA8Gj7rHGearGufUFv6rB/bcXRFsiGWw/VeSUgUofF4Rf2UKEOrTA==",
       "dev": true,
       "dependencies": {
-        "flat-cache": "^3.0.4"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "flat-cache": "^6.1.5"
       }
     },
     "node_modules/file-type": {
@@ -13091,32 +12705,14 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.5.tgz",
+      "integrity": "sha512-QR+2kN38f8nMfiIQ1LHYjuDEmZNZVjxuxY+HufbS3BW0EX01Q5OnH7iduOYRutmgiXb797HAKcXUeXrvRjjgSQ==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/flat-cache/node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
-    "node_modules/flat-cache/node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "dependencies": {
-        "json-buffer": "3.0.1"
+        "cacheable": "^1.8.7",
+        "flatted": "^3.3.2",
+        "hookified": "^1.6.0"
       }
     },
     "node_modules/flatted": {
@@ -14328,6 +13924,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
     "node_modules/glogg": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.2.tgz",
@@ -14951,86 +14553,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/gulp-esbuild/node_modules/@esbuild/darwin-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
@@ -15042,278 +14564,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/gulp-esbuild/node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -16111,6 +15361,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hookified": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.7.0.tgz",
+      "integrity": "sha512-XQdMjqC1AyeOzfs+17cnIk7Wdfu1hh2JtcyNfBf5u9jHrT3iZUlGHxLTntFBuk5lwkqJ6l3+daeQdHK5yByHVA==",
+      "dev": true
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
@@ -16150,6 +15406,18 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
@@ -17052,11 +16320,12 @@
       "license": "MIT"
     },
     "node_modules/is-async-function": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.0.tgz",
-      "integrity": "sha512-GExz9MtyhlZyXYLxzlJRj5WUCE661zhDa1Yna52CN57AJsymh+DvXXjyveSioqSRdxvUrdKdvqB1b5cVKsNpWQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "dependencies": {
+        "async-function": "^1.0.0",
         "call-bound": "^1.0.3",
         "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
@@ -20674,6 +19943,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/known-css-properties": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.35.0.tgz",
+      "integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
+      "dev": true
+    },
     "node_modules/last-run": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -21237,6 +20512,12 @@
         "lodash._reinterpolate": "^3.0.0"
       }
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -21795,6 +21076,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/maximatch": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/maximatch/-/maximatch-0.1.0.tgz",
@@ -22232,9 +21523,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "dev": true,
       "funding": [
         {
@@ -22242,7 +21533,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -26772,11 +26062,10 @@
       "license": "MIT"
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
-      "devOptional": true,
-      "license": "ISC"
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "devOptional": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -27061,9 +26350,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
       "dev": true,
       "funding": [
         {
@@ -27079,10 +26368,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "nanoid": "^3.3.8",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -27233,6 +26521,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true
     },
     "node_modules/postcss-merge-longhand": {
       "version": "6.0.5",
@@ -27530,6 +26824,64 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+      "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-scss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.29"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -27542,6 +26894,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss-sorting": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-8.0.2.tgz",
+      "integrity": "sha512-M9dkSrmU00t/jK7rF6BZSZauA5MAaBW4i5EnJXspMwt4iqTh/L9j6fgMnbElEOfyRyfLfVbIHj/R52zHzAPe1Q==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.4.20"
       }
     },
     "node_modules/postcss-svgo": {
@@ -29910,6 +29271,56 @@
       "integrity": "sha512-Q9VME8WyGkc7pJf6QEkj3wE+2CnvZMI+XJhwdTPR8Z/kWQRXi7boAWLDibRPyHRTUTPx5FaU7MsyrjI3yLB4HA==",
       "dev": true
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/slugify": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
@@ -30656,6 +30067,454 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/stylelint": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.13.2.tgz",
+      "integrity": "sha512-wDlgh0mRO9RtSa3TdidqHd0nOG8MmUyVKl+dxA6C1j8aZRzpNeEgdhFmU5y4sZx4Fc6r46p0fI7p1vR5O2DZqA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "@csstools/media-query-list-parser": "^4.0.2",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.3.7",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^10.0.5",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.1",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.35.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.49",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.1.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint-config-gds": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-gds/-/stylelint-config-gds-2.0.0.tgz",
+      "integrity": "sha512-uloFaElSPR25oJ+tTCO0oLmuiq6qpFMPUwKRz90dGA9eEE+37ljd718P3GFwk5dNNtC3hr3KtNqW8kQOJvgugg==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-standard": "^36.0.0",
+        "stylelint-config-standard-scss": "^13.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.0.2"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+      "integrity": "sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.1.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.1.0.tgz",
+      "integrity": "sha512-bhaMhh1u5dQqSsf6ri2GVWWQW5iUjBYgcHkh7SgDDn92ijoItC/cfO/W+fpXshgTQWhwFkP1rVcewcv4jaftRg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-scss": "^4.0.9",
+        "stylelint-config-recommended": "^14.0.1",
+        "stylelint-scss": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3",
+        "stylelint": "^16.6.1"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "36.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+      "integrity": "sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "dependencies": {
+        "stylelint-config-recommended": "^14.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.1.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-13.1.0.tgz",
+      "integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended-scss": "^14.0.0",
+        "stylelint-config-standard": "^36.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3",
+        "stylelint": "^16.3.1"
+      },
+      "peerDependenciesMeta": {
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint-order": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-6.0.4.tgz",
+      "integrity": "sha512-0UuKo4+s1hgQ/uAxlYU4h0o0HS4NiQDud0NAUNI0aa8FJdmYHA5ZZTFHiV5FpmE3071e9pZx5j0QpVJW5zOCUA==",
+      "dev": true,
+      "dependencies": {
+        "postcss": "^8.4.32",
+        "postcss-sorting": "^8.0.2"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.0.0 || ^15.0.0 || ^16.0.1"
+      }
+    },
+    "node_modules/stylelint-scss": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.10.1.tgz",
+      "integrity": "sha512-CBqs0jecftIyhic6xba+4OvZUp4B0wNbX19w6Rq1fPo+lBDmTevk+olo8H7u/WQpTSDCDbBN4f3oocQurvXLTQ==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^3.0.1",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.35.0",
+        "mdn-data": "^2.14.0",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.0.2"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stylelint-scss/node_modules/css-tree/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true
+    },
+    "node_modules/stylelint-scss/node_modules/mdn-data": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.15.0.tgz",
+      "integrity": "sha512-KIrS0lFPOqA4DgeO16vI5fkAsy8p++WBlbXtB5P1EQs8ubBgguAInNd1DnrCeTRfGchY0kgThgDOOIPyOLH2dQ==",
+      "dev": true
+    },
+    "node_modules/stylelint-scss/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true
+    },
+    "node_modules/stylelint/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stylelint/node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/stylelint/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/globby/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true
+    },
+    "node_modules/stylelint/node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+      "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stylelint/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/super-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
@@ -30747,6 +30606,12 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "node_modules/svgo": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
@@ -30804,6 +30669,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,10 @@
     "npm-run-all2": "^6.0.0",
     "postcss": "^8.4.31",
     "semantic-release": "^23.0.0",
-    "sinon": "^19.0.2"
+    "sinon": "^19.0.2",
+    "stylelint": "^16.13.2",
+    "stylelint-config-gds": "^2.0.0",
+    "stylelint-order": "^6.0.4"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,13 @@
     "test:docs": "npm run build:docs",
     "test:js": "jest src/",
     "test:sass": "sass -q -I . gulp/dist-scss/all.scss >/dev/null && echo 'ok'",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:js": "npm run lint:js:cli -- \"**/*.{cjs,js,mjs}\"",
+    "lint:js:cli": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore --max-warnings 0",
+    "lint:prettier": "npm run lint:prettier:cli -- \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
+    "lint:prettier:cli": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check",
+    "lint:scss": "npm run lint:scss:cli -- \"**/*.scss\"",
+    "lint:scss:cli": "stylelint --cache --cache-location .cache/stylelint --cache-strategy content --color --ignore-path .gitignore --max-warnings 0",
     "watch:11ty": "ENV=dev eleventy --input=./docs --output=public --serve",
     "watch:package": "ENV=dev gulp watch:dev"
   },

--- a/src/moj/components/action-bar/_action-bar.scss
+++ b/src/moj/components/action-bar/_action-bar.scss
@@ -14,14 +14,14 @@
     margin-right: govuk-spacing(2);
     padding-right: govuk-spacing(2) + 2px; // Takes into account divider width
 
-    &:after {
+    &::after {
       content: "";
-      background-color: govuk-colour("light-grey");
-      height: 40px;
       position: absolute;
-      right: 0;
       top: 0;
+      right: 0;
       width: 2px;
+      height: 40px;
+      background-color: govuk-colour("light-grey");
     }
   }
 

--- a/src/moj/components/add-another/_add-another.scss
+++ b/src/moj/components/add-another/_add-another.scss
@@ -4,10 +4,10 @@
 
 .moj-add-another {
   &__item {
+    position: relative;
     margin: 0;
     margin-top: govuk-spacing(6);
     padding: 0;
-    position: relative;
 
     &:first-of-type {
       margin-top: 0;
@@ -15,9 +15,9 @@
   }
 
   &__title {
-    float: left;
-    padding: 4px 100px 4px 0;
     width: 100%;
+    padding: 4px 100px 4px 0;
+    float: left;
 
     & + .govuk-form-group {
       clear: left;
@@ -26,8 +26,8 @@
 
   &__remove-button {
     position: absolute;
-    right: 0;
     top: 0;
+    right: 0;
     width: auto;
   }
 
@@ -37,8 +37,8 @@
 }
 
 .moj-add-another__heading:focus {
-  background-color: $govuk-focus-colour;
-  color: $govuk-focus-text-colour;
-  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   outline: none;
+  color: $govuk-focus-text-colour;
+  background-color: $govuk-focus-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
 }

--- a/src/moj/components/badge/_badge.scss
+++ b/src/moj/components/badge/_badge.scss
@@ -4,14 +4,14 @@
 
 .moj-badge {
   @include govuk-font($size: 14, $weight: "bold");
-  padding: 0 govuk-spacing(1);
   display: inline-block;
+  padding: 0 govuk-spacing(1);
   border: 2px solid $govuk-brand-colour;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
   color: $govuk-brand-colour;
   text-transform: uppercase;
   vertical-align: middle;
-  outline: 2px solid transparent;
-  outline-offset: -2px;
 
   &--purple {
     border-color: govuk-colour("purple");

--- a/src/moj/components/banner/_banner.scss
+++ b/src/moj/components/banner/_banner.scss
@@ -3,25 +3,25 @@
    ========================================================================== */
 
 .moj-banner {
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(2);
   border: 5px solid $govuk-brand-colour;
   color: $govuk-brand-colour;
   font-size: 0; // Removes white space when using inline-block on child element.
-  margin-bottom: govuk-spacing(6);
-  padding: govuk-spacing(2);
 }
 
 
 .moj-banner__icon {
-  fill: currentColor;
-  float: left;
   margin-right: govuk-spacing(2);
+  float: left;
+  fill: currentcolor;
 }
 
 .moj-banner__message {
   @include govuk-font($size: 19);
-  color: govuk-colour("black");
   display: block;
   overflow: hidden;
+  color: govuk-colour("black");
 }
 
 .moj-banner__message h2 {

--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -34,7 +34,7 @@ $moj-datepicker-mid-grey: #949494;
 .moj-button-menu__wrapper {
   position: absolute;
   z-index: 10;
-  top: 43px; //38px button height, 2px shadow, 3px gap
+  top: 43px; // 38px button height, 2px shadow, 3px gap
   width: 200px;
   margin: 0;
   padding: 0;

--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -23,8 +23,8 @@ $moj-datepicker-mid-grey: #949494;
 }
 
 .moj-button-menu__toggle-button svg {
-  transform: rotate(180deg);
   margin-top: 2px;
+  transform: rotate(180deg);
 }
 
 .moj-button-menu__toggle-button[aria-expanded="true"] svg {
@@ -32,13 +32,13 @@ $moj-datepicker-mid-grey: #949494;
 }
 
 .moj-button-menu__wrapper {
-  list-style: none;
   position: absolute;
+  z-index: 10;
+  top: 43px; //38px button height, 2px shadow, 3px gap
+  width: 200px;
   margin: 0;
   padding: 0;
-  width: 200px;
-  top: 43px; //38px button height, 2px shadow, 3px gap
-  z-index: 10;
+  list-style: none;
 
   &--right {
     right: 0;
@@ -48,9 +48,10 @@ $moj-datepicker-mid-grey: #949494;
 /* Menu items with no JS */
 .moj-button-menu__item {
   display: inline-block;
+  width: auto; // Override GDS’s 100% width
   margin-right: govuk-spacing(2);
   margin-bottom: govuk-spacing(2);
-  width: auto; // Override GDS’s 100% width
+
   &:last-child {
     margin-right: 0;
   }
@@ -67,12 +68,12 @@ $moj-datepicker-mid-grey: #949494;
   width: 100%;
   margin-top: 0;
   margin-right: 0;
-  margin-left: 0;
   margin-bottom: 0;
+  margin-left: 0;
   padding: govuk-spacing(2);
   border: $govuk-border-width-form-element solid transparent;
-  border-radius: 0;
   border-bottom: 1px solid $moj-datepicker-mid-grey;
+  border-radius: 0;
   color: $govuk-text-colour;
   background-color: govuk-colour("light-grey");
   text-align: left;
@@ -105,10 +106,10 @@ $moj-datepicker-mid-grey: #949494;
   }
 
   &:focus {
+    z-index: 10;
     border-color: $govuk-focus-colour;
     outline: $govuk-focus-width solid transparent;
     box-shadow: inset 0 0 0 1px $govuk-focus-colour;
-    z-index: 10;
   }
 
   &:focus:not(:active):not(:hover) {

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -1,16 +1,16 @@
 @import "node_modules/govuk-frontend/dist/govuk/objects/width-container";
 
 .moj-cookie-banner {
-  display: none;
-  @include govuk-font(16);
 
   box-sizing: border-box;
+  display: none;
+  left: govuk-spacing(3);
 
   padding-top: govuk-spacing(3);
-  padding-bottom: govuk-spacing(3);
-  left: govuk-spacing(3);
   padding-right: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
   background-color: govuk-colour("white");
+  @include govuk-font(16);
 
   &--show {
     // stylelint-disable-next-line declaration-no-important

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -13,6 +13,7 @@
   background-color: govuk-colour("white");
 
   &--show {
+    // stylelint-disable-next-line declaration-no-important
     display: block !important;
   }
 
@@ -36,6 +37,7 @@
 
 @include govuk-media-query($media-type: print) {
   .moj-cookie-banner {
+    // stylelint-disable-next-line declaration-no-important
     display: none !important;
   }
 }

--- a/src/moj/components/currency-input/_currency-input.scss
+++ b/src/moj/components/currency-input/_currency-input.scss
@@ -4,17 +4,17 @@
 
 .moj-label__currency {
   @include govuk-font(19);
-  background-color: govuk-colour("light-grey");
   position: absolute;
   // stylelint-disable-next-line declaration-no-important
   margin: 2px 0 0 2px !important;
   padding: 5.5px 12px;
   border-right: 2px solid govuk-colour("black");
+  background-color: govuk-colour("light-grey");
 
   &--error {
-    background-color: $govuk-error-colour;
     border-right: 2px solid $govuk-error-colour;
     color: govuk-colour("white");
+    background-color: $govuk-error-colour;
   }
 
   @include govuk-media-query($until: tablet) {

--- a/src/moj/components/currency-input/_currency-input.scss
+++ b/src/moj/components/currency-input/_currency-input.scss
@@ -6,6 +6,7 @@
   @include govuk-font(19);
   background-color: govuk-colour("light-grey");
   position: absolute;
+  // stylelint-disable-next-line declaration-no-important
   margin: 2px 0 0 2px !important;
   padding: 5.5px 12px;
   border-right: 2px solid govuk-colour("black");
@@ -19,10 +20,10 @@
   @include govuk-media-query($until: tablet) {
     padding: 8px 12px;
   }
-
 }
 
 .moj-input__currency {
   margin: 0;
   padding-left: 40px;
 }
+

--- a/src/moj/components/date-picker/_date-picker.scss
+++ b/src/moj/components/date-picker/_date-picker.scss
@@ -15,8 +15,10 @@ $moj-datepicker-mid-grey: #949494;
   padding: govuk-spacing(4);
   outline: 2px solid $govuk-text-colour;
   outline-offset: -2px;
-  background-color: govuk-colour('white');
-  transition: background-color 0.2s, outline-color 0.2s;
+  background-color: govuk-colour("white");
+  transition:
+    background-color 0.2s,
+    outline-color 0.2s;
   z-index: 2;
 }
 
@@ -64,11 +66,10 @@ $moj-datepicker-mid-grey: #949494;
     font-weight: bold;
     color: $govuk-text-colour;
   }
-
 }
 
 .moj-datepicker__dialog > .govuk-button-group {
-    margin-bottom: 0;
+  margin-bottom: 0;
 
   > * {
     margin-bottom: 0;
@@ -77,111 +78,110 @@ $moj-datepicker-mid-grey: #949494;
 
 .moj-datepicker__button {
   @include govuk-font(16);
-    background-color: transparent;
-    outline: 2px solid rgba(0, 0, 0, 0);
-    outline-offset: -2px;
-    border-width: 0;
-    color: $govuk-text-colour;
-    height: 40px;
-    margin: 0;
-    padding: 0;
-    width: 44px;
-    position: relative;
+  background-color: transparent;
+  outline: 2px solid rgba(0, 0, 0, 0);
+  outline-offset: -2px;
+  border-width: 0;
+  color: $govuk-text-colour;
+  height: 40px;
+  margin: 0;
+  padding: 0;
+  width: 44px;
+  position: relative;
 
-    @media (forced-colors: active) {
-      // Don't show the bottom bar in forced-color modes as it blocks the outline
-      &:after {
-        display: none
-      }
-    }
-
+  @media (forced-colors: active) {
+    // Don't show the bottom bar in forced-color modes as it blocks the outline
     &:after {
-      content: "";
-      position: absolute;
-      bottom: 0px;
-      height: 4px;
-      left: 0;
-      right: 0;
+      display: none;
+    }
+  }
+
+  &:after {
+    content: "";
+    position: absolute;
+    bottom: 0px;
+    height: 4px;
+    left: 0;
+    right: 0;
+    background-color: transparent;
+  }
+
+  &[aria-disabled="true"],
+  &[aria-disabled="true"]:hover {
+    background-color: govuk-colour("light-grey");
+    color: $govuk-text-colour;
+    cursor: not-allowed;
+    text-decoration: line-through;
+  }
+
+  &:hover {
+    color: $govuk-text-colour;
+    background-color: $moj-datepicker-mid-grey;
+    text-decoration: none;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    cursor: pointer;
+  }
+
+  &:focus {
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
+    outline-color: transparent;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    &:after {
+      background-color: $govuk-text-colour;
+    }
+  }
+
+  &:focus:hover {
+    background-color: $moj-datepicker-mid-grey;
+    outline-color: $govuk-focus-colour;
+    &:after {
       background-color: transparent;
     }
+  }
 
-    &[aria-disabled="true"],
-    &[aria-disabled="true"]:hover {
-      background-color: govuk-colour('light-grey');
-      color: $govuk-text-colour;
-      cursor: not-allowed;
-      text-decoration: line-through;
+  &--current:not(:focus) {
+    background-color: $govuk-link-colour;
+    color: govuk-colour("white");
+    outline-color: $govuk-link-colour;
+    &:after {
+      background-color: $govuk-link-colour;
+    }
+  }
+
+  &--current[tabindex="-1"] {
+    background: transparent;
+    color: currentColor;
+    outline-color: transparent;
+    &:after {
+      background-color: transparent;
+    }
+  }
+
+  &--today {
+    border: 2px solid $govuk-text-colour;
+  }
+
+  &--selected:not(:focus) {
+    background-color: $govuk-link-colour;
+    color: govuk-colour("white");
+
+    &:after {
+      background-color: $govuk-link-colour;
     }
 
     &:hover {
-      color: $govuk-text-colour;
-      background-color: $moj-datepicker-mid-grey;
-      text-decoration: none;
-      -webkit-box-decoration-break: clone;
-      box-decoration-break: clone;
-      cursor: pointer;
-    }
-
-    &:focus {
-      color: $govuk-text-colour;
-      background-color: $govuk-focus-colour;
-      outline-color: transparent;
-      -webkit-box-decoration-break: clone;
-      box-decoration-break: clone;
-      &:after {
-        background-color: $govuk-text-colour;
-      }
-    }
-
-    &:focus:hover {
-      background-color: $moj-datepicker-mid-grey;
-      outline-color: $govuk-focus-colour;
-      &:after {
-        background-color: transparent;
-      }
-    }
-
-    &--current:not(:focus) {
-      background-color: $govuk-link-colour;
-      color: govuk-colour('white');
       outline-color: $govuk-link-colour;
-      &:after {
-        background-color: $govuk-link-colour;
-      }
-    }
+      background-color: $moj-datepicker-mid-grey;
+      color: $govuk-text-colour;
 
-    &--current[tabindex="-1"] {
-      background: transparent;
-      color: currentColor;
-      outline-color: transparent;
       &:after {
         background-color: transparent;
       }
     }
-
-    &--today {
-      border: 2px solid $govuk-text-colour;
-    }
-
-    &--selected:not(:focus) {
-      background-color: $govuk-link-colour;
-      color: govuk-colour('white');
-
-      &:after {
-        background-color: $govuk-link-colour;
-      }
-
-      &:hover {
-        outline-color: $govuk-link-colour;
-        background-color: $moj-datepicker-mid-grey;
-        color: $govuk-text-colour;
-
-        &:after {
-          background-color: transparent;
-        }
-      }
-    }
-
+  }
 }
 
 /*
@@ -201,51 +201,62 @@ $moj-datepicker-mid-grey: #949494;
   }
 
   &.govuk-\!-width-full {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
   }
 
   &.govuk-\!-width-three-quarters {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
 
     @include govuk-media-query($from: tablet) {
+      // stylelint-disable-next-line declaration-no-important
       width: 75% !important;
     }
   }
 
   &.govuk-\!-width-two-thirds {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
 
     @include govuk-media-query($from: tablet) {
+      // stylelint-disable-next-line declaration-no-important
       width: 66.66% !important;
     }
   }
 
   &.govuk-\!-width-one-half {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
 
     @include govuk-media-query($from: tablet) {
+      // stylelint-disable-next-line declaration-no-important
       width: 50% !important;
     }
   }
 
   &.govuk-\!-width-one-third {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
 
     @include govuk-media-query($from: tablet) {
+      // stylelint-disable-next-line declaration-no-important
       width: 33.33% !important;
     }
   }
 
   &.govuk-\!-width-one-quarter {
+    // stylelint-disable-next-line declaration-no-important
     width: 100% !important;
     max-width: none;
 
     @include govuk-media-query($from: tablet) {
+      // stylelint-disable-next-line declaration-no-important
       width: 25% !important;
     }
   }
@@ -255,7 +266,6 @@ $moj-datepicker-mid-grey: #949494;
   position: relative;
 }
 
-
 @media (min-width: 768px) {
   .moj-datepicker__dialog {
     width: auto;
@@ -264,7 +274,7 @@ $moj-datepicker-mid-grey: #949494;
 
 .moj-datepicker__toggle {
   background-color: $govuk-text-colour;
-  color: govuk-colour('white');
+  color: govuk-colour("white");
   outline: 3px solid rgba(0, 0, 0, 0);
   outline-offset: -3px;
   height: 40px;

--- a/src/moj/components/date-picker/_date-picker.scss
+++ b/src/moj/components/date-picker/_date-picker.scss
@@ -193,6 +193,7 @@ $moj-datepicker-mid-grey: #949494;
  Allow that to be overriden by the input width modifiers or global width overrides.
  Width classes less than 10ch not included as that is narrower than a date.
 */
+// stylelint-disable selector-no-qualifying-type
 .moj-datepicker input {
   max-width: 11.5em; // govuk-input--width-10
 
@@ -265,6 +266,7 @@ $moj-datepicker-mid-grey: #949494;
     }
   }
 }
+// stylelint-enable selector-no-qualifying-type
 
 .moj-datepicker__wrapper {
   position: relative;

--- a/src/moj/components/date-picker/_date-picker.scss
+++ b/src/moj/components/date-picker/_date-picker.scss
@@ -10,16 +10,16 @@ $moj-datepicker-mid-grey: #949494;
 .moj-datepicker__dialog {
   display: none;
   position: absolute;
+  z-index: 2;
   top: 0;
   min-width: 280px;
   padding: govuk-spacing(4);
-  outline: 2px solid $govuk-text-colour;
-  outline-offset: -2px;
-  background-color: govuk-colour("white");
   transition:
     background-color 0.2s,
     outline-color 0.2s;
-  z-index: 2;
+  outline: 2px solid $govuk-text-colour;
+  outline-offset: -2px;
+  background-color: govuk-colour("white");
 }
 
 .moj-datepicker__dialog--open {
@@ -27,18 +27,18 @@ $moj-datepicker-mid-grey: #949494;
 }
 
 .moj-datepicker__dialog-header {
-  position: relative;
   display: flex;
+  position: relative;
+  margin-bottom: govuk-spacing(2);
   align-items: center;
   justify-content: space-between;
-  margin-bottom: govuk-spacing(2);
 }
 
 .moj-datepicker__dialog-title {
   @include govuk-font(16);
-  font-weight: bold;
   margin-top: 0;
   margin-bottom: 0;
+  font-weight: bold;
 }
 
 .moj-datepicker__dialog-navbuttons {
@@ -47,24 +47,24 @@ $moj-datepicker-mid-grey: #949494;
 }
 
 .moj-datepicker__calendar {
-  border-collapse: collapse;
   margin-bottom: govuk-spacing(4);
+  border-collapse: collapse;
 
   tbody:focus-within {
     outline: 2px solid $govuk-focus-colour;
   }
 
   td {
-    border: 0;
     margin: 0;
-    outline: 0;
     padding: 0;
+    border: 0;
+    outline: 0;
   }
 
   th {
     @include govuk-font(16);
-    font-weight: bold;
     color: $govuk-text-colour;
+    font-weight: bold;
   }
 }
 
@@ -78,40 +78,40 @@ $moj-datepicker-mid-grey: #949494;
 
 .moj-datepicker__button {
   @include govuk-font(16);
-  background-color: transparent;
-  outline: 2px solid rgba(0, 0, 0, 0);
-  outline-offset: -2px;
-  border-width: 0;
-  color: $govuk-text-colour;
+  position: relative;
+  width: 44px;
   height: 40px;
   margin: 0;
   padding: 0;
-  width: 44px;
-  position: relative;
+  border-width: 0;
+  outline: 2px solid rgba(0, 0, 0, 0);
+  outline-offset: -2px;
+  color: $govuk-text-colour;
+  background-color: transparent;
 
   @media (forced-colors: active) {
     // Don't show the bottom bar in forced-color modes as it blocks the outline
-    &:after {
+    &::after {
       display: none;
     }
   }
 
-  &:after {
+  &::after {
     content: "";
     position: absolute;
-    bottom: 0px;
-    height: 4px;
-    left: 0;
     right: 0;
+    bottom: 0;
+    left: 0;
+    height: 4px;
     background-color: transparent;
   }
 
   &[aria-disabled="true"],
   &[aria-disabled="true"]:hover {
-    background-color: govuk-colour("light-grey");
     color: $govuk-text-colour;
-    cursor: not-allowed;
+    background-color: govuk-colour("light-grey");
     text-decoration: line-through;
+    cursor: not-allowed;
   }
 
   &:hover {
@@ -124,38 +124,42 @@ $moj-datepicker-mid-grey: #949494;
   }
 
   &:focus {
+    outline-color: transparent;
     color: $govuk-text-colour;
     background-color: $govuk-focus-colour;
-    outline-color: transparent;
     -webkit-box-decoration-break: clone;
     box-decoration-break: clone;
-    &:after {
+
+    &::after {
       background-color: $govuk-text-colour;
     }
   }
 
   &:focus:hover {
-    background-color: $moj-datepicker-mid-grey;
     outline-color: $govuk-focus-colour;
-    &:after {
+    background-color: $moj-datepicker-mid-grey;
+
+    &::after {
       background-color: transparent;
     }
   }
 
   &--current:not(:focus) {
-    background-color: $govuk-link-colour;
-    color: govuk-colour("white");
     outline-color: $govuk-link-colour;
-    &:after {
+    color: govuk-colour("white");
+    background-color: $govuk-link-colour;
+
+    &::after {
       background-color: $govuk-link-colour;
     }
   }
 
   &--current[tabindex="-1"] {
-    background: transparent;
-    color: currentColor;
     outline-color: transparent;
-    &:after {
+    color: currentcolor;
+    background: transparent;
+
+    &::after {
       background-color: transparent;
     }
   }
@@ -165,19 +169,19 @@ $moj-datepicker-mid-grey: #949494;
   }
 
   &--selected:not(:focus) {
-    background-color: $govuk-link-colour;
     color: govuk-colour("white");
+    background-color: $govuk-link-colour;
 
-    &:after {
+    &::after {
       background-color: $govuk-link-colour;
     }
 
     &:hover {
       outline-color: $govuk-link-colour;
-      background-color: $moj-datepicker-mid-grey;
       color: $govuk-text-colour;
+      background-color: $moj-datepicker-mid-grey;
 
-      &:after {
+      &::after {
         background-color: transparent;
       }
     }
@@ -273,31 +277,31 @@ $moj-datepicker-mid-grey: #949494;
 }
 
 .moj-datepicker__toggle {
-  background-color: $govuk-text-colour;
-  color: govuk-colour("white");
-  outline: 3px solid rgba(0, 0, 0, 0);
-  outline-offset: -3px;
   height: 40px;
   padding-top: 6px;
   border: none;
   border-bottom: 4px solid rgba(0, 0, 0, 0);
+  outline: 3px solid rgba(0, 0, 0, 0);
+  outline-offset: -3px;
+  color: govuk-colour("white");
+  background-color: $govuk-text-colour;
   cursor: pointer;
 
   &:focus {
-    background-color: $govuk-focus-colour;
-    color: $govuk-text-colour;
     border-bottom: 4px solid $govuk-text-colour;
+    color: $govuk-text-colour;
+    background-color: $govuk-focus-colour;
   }
 
   &:hover {
-    background-color: $moj-datepicker-mid-grey;
-    color: $govuk-text-colour;
     border-bottom: 4px solid $moj-datepicker-mid-grey;
+    color: $govuk-text-colour;
+    background-color: $moj-datepicker-mid-grey;
   }
 
   &:focus:hover {
-    background-color: $moj-datepicker-mid-grey;
-    color: $govuk-text-colour;
     border-bottom: 4px solid $govuk-text-colour;
+    color: $govuk-text-colour;
+    background-color: $moj-datepicker-mid-grey;
   }
 }

--- a/src/moj/components/filter/_filter.scss
+++ b/src/moj/components/filter/_filter.scss
@@ -13,18 +13,18 @@
 
 
 .moj-filter__header {
+  padding: govuk-spacing(2) govuk-spacing(4);
   background-color: govuk-colour("mid-grey");
   font-size: 0; // Hide whitespace between elements
-  padding: govuk-spacing(2) govuk-spacing(4);
   text-align: justify; // Trick to remove the need for floats
 
-  &:after {
+  &::after {
     content: '';
     display: inline-block;
     width: 100%;
   }
 
-  [class^=govuk-heading-] {
+  [class^="govuk-heading-"] {
     margin-bottom: 0;
   }
 
@@ -33,22 +33,22 @@
 
 // JavaScript
 .moj-filter__legend {
-  overflow: visible; // Override govuk to allow for focus style to be seen
   width: 100%;
+  overflow: visible; // Override govuk to allow for focus style to be seen
 
   button {
     @include govuk-font($size: 24, $weight: bold);
-    background-color: transparent;
     box-sizing: border-box;
-    border-radius: 0;
-    border: 0 none;
-    cursor: pointer; // Adam would not approve
     display: block;
+    position: relative;
+    width: 100%;
     margin: 0;
     padding: 0;
-    position: relative;
+    border: 0 none;
+    border-radius: 0;
+    background-color: transparent;
     text-align: left;
-    width: 100%;
+    cursor: pointer; // Adam would not approve
     -webkit-appearance: none;
 
     // Fix unwanted button padding in Firefox
@@ -58,14 +58,14 @@
     }
 
     &::after {
-      background-image: url(#{$moj-images-path}icon-toggle-plus-minus.svg);
-      background-position: 0 0;
       content: "";
       display: block;
-      height: 16px;
-      margin-top: -8px; // Half the height of the icon
       position: absolute; top: 50%; right: 0;
       width: 16px;
+      height: 16px;
+      margin-top: -8px; // Half the height of the icon
+      background-image: url(#{$moj-images-path}icon-toggle-plus-minus.svg);
+      background-position: 0 0;
     }
 
     &[aria-expanded="true"] {
@@ -92,22 +92,22 @@
 
 
 .moj-filter__close {
-  // @include govuk-focusable;
-  color: govuk-colour("black");
-  cursor: pointer; // I know Adam won’t like this
-  background-color: transparent;
-  border: none;
-  border-radius: 0;
   margin: 0;
   padding: 0;
+  border: none;
+  border-radius: 0;
+  // @include govuk-focusable;
+  color: govuk-colour("black");
+  background-color: transparent;
+  cursor: pointer; // I know Adam won’t like this
   -webkit-appearance: none;
 
 
   &:focus {
-    background-color: $govuk-focus-colour;
-    color: $govuk-focus-text-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
     outline: none;
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   }
 
   // Fix unwanted button padding in Firefox
@@ -117,15 +117,15 @@
   }
 
   &::before {
-    background-image: url(#{$moj-images-path}icon-close-cross-black.svg);
     content: "";
     display: inline-block;
-    height: 14px;
-    margin-right: govuk-spacing(1);
     position: relative;
     top: -1px; // Alignment tweak
-    vertical-align: middle;
     width: 14px;
+    height: 14px;
+    margin-right: govuk-spacing(1);
+    background-image: url(#{$moj-images-path}icon-close-cross-black.svg);
+    vertical-align: middle;
   }
 
 }
@@ -137,9 +137,9 @@
 
 
 .moj-filter__selected {
+  padding: govuk-spacing(4);
   background-color: govuk-colour("light-grey");
   box-shadow: inset 0 0 0 1px govuk-colour("mid-grey");
-  padding: govuk-spacing(4);
 
   ul:last-of-type {
     margin-bottom: 0; // IE9 +
@@ -152,7 +152,7 @@
   font-size: 0; // Hide whitespace between elements
   text-align: justify; // Trick to remove the need for floats
 
-  &:after {
+  &::after {
     content: '';
     display: inline-block;
     width: 100%;
@@ -171,9 +171,9 @@
 
 
 .moj-filter-tags {
-  font-size: 0;
   margin-bottom: govuk-spacing(4); // Needs to adjust to 15px on mobile
   padding-left: 0;
+  font-size: 0;
 
   li {
     display: inline-block;
@@ -185,12 +185,12 @@
 
 .moj-filter__tag {
   @include govuk-font(16);
-  background-color: govuk-colour("white");
-  border: 1px solid govuk-colour("black");
-  color: govuk-colour("black");
   display: inline-block;
   margin-top: govuk-spacing(1);
   padding: govuk-spacing(1);
+  border: 1px solid govuk-colour("black");
+  color: govuk-colour("black");
+  background-color: govuk-colour("white");
   text-decoration: none;
 
   &:link,
@@ -204,22 +204,22 @@
   }
 
   &:hover {
-    background-color: govuk-colour("black");
     color: govuk-colour("white");
+    background-color: govuk-colour("black");
   }
 
-  &:after {
-    background-image: url(#{$moj-images-path}icon-tag-remove-cross.svg);
+  &::after {
     content: "";
     display: inline-block;
-    font-weight: bold;
+    width: 10px;
     height: 10px;
     margin-left: govuk-spacing(1);
+    background-image: url(#{$moj-images-path}icon-tag-remove-cross.svg);
+    font-weight: bold;
     vertical-align: middle;
-    width: 10px;
   }
 
-  &:hover:after {
+  &:hover::after {
     background-image: url(#{$moj-images-path}icon-tag-remove-cross-white.svg);
   }
 
@@ -227,9 +227,9 @@
 
 
 .moj-filter__options {
-  box-shadow: inset 0 0 0 1px govuk-colour("mid-grey");
   margin-top: -1px;
   padding: govuk-spacing(4);
+  box-shadow: inset 0 0 0 1px govuk-colour("mid-grey");
 
   div:last-of-type {
     margin-bottom: 0; // IE9 +

--- a/src/moj/components/filter/_filter.scss
+++ b/src/moj/components/filter/_filter.scss
@@ -38,6 +38,7 @@
 
   button {
     @include govuk-font($size: 24, $weight: bold);
+    appearance: none;
     box-sizing: border-box;
     display: block;
     position: relative;
@@ -68,14 +69,8 @@
       background-position: 0 0;
     }
 
-    &[aria-expanded="true"] {
-      &::after {
+    &[aria-expanded="true"]::after {
         background-position: 16px 16px;
-      }
-    }
-
-    &:focus {
-      // @include govuk-focusable;
     }
 
   }
@@ -92,6 +87,7 @@
 
 
 .moj-filter__close {
+  @include govuk-font(19);
   margin: 0;
   padding: 0;
   border: none;
@@ -101,6 +97,7 @@
   background-color: transparent;
   cursor: pointer; // I know Adam won’t like this
   -webkit-appearance: none;
+    appearance: none;
 
 
   &:focus {
@@ -129,12 +126,6 @@
   }
 
 }
-
-
-.moj-filter__close {
-  @include govuk-font(19);
-}
-
 
 .moj-filter__selected {
   padding: govuk-spacing(4);

--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -20,7 +20,6 @@
   @include govuk-media-query($from: desktop) {
     float: left;
   }
-
 }
 
 .moj-header__logotype-crown {
@@ -28,7 +27,6 @@
   top: -4px;
   margin-right: govuk-spacing(1);
   vertical-align: top;
-
 }
 
 .moj-header__logotype-crest {
@@ -44,10 +42,10 @@
   @include govuk-media-query($from: desktop) {
     float: right;
   }
-
 }
 
-.moj-header__link, .moj-header__link > a {
+.moj-header__link,
+.moj-header__link > a {
   @include govuk-link-common;
   @include govuk-link-style-default;
   border-bottom: 1px solid transparent;
@@ -113,7 +111,6 @@
   }
 }
 
-
 span.moj-header__link {
   &:hover {
     border-color: transparent;
@@ -141,7 +138,6 @@ span.moj-header__link {
   &:last-child {
     margin-right: 0;
   }
-
 }
 
 .moj-header__navigation-link {
@@ -156,15 +152,15 @@ span.moj-header__link {
   }
 
   &:hover {
+    // stylelint-disable-next-line declaration-no-important
     text-decoration: underline !important;
   }
 
   &:focus {
     color: govuk-colour("black");
   }
-
 }
 
-.moj-header__navigation-link[aria-current=page] {
+.moj-header__navigation-link[aria-current="page"] {
   text-decoration: none;
 }

--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -112,7 +112,7 @@
     vertical-align: middle;
   }
 }
-
+// stylelint-disable-next-line selector-no-qualifying-type
 span.moj-header__link {
   &:hover {
     border-color: transparent;
@@ -121,7 +121,7 @@ span.moj-header__link {
 
 // Navigation
 .moj-header__navigation {
-  margin-top: govuk-spacing(1)-2px;
+  margin-top: govuk-spacing(1) - 2px;
   color: govuk-colour("white");
 }
 

--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -3,9 +3,9 @@
    ========================================================================== */
 
 .moj-header {
-  background-color: govuk-colour("black");
   padding-top: govuk-spacing(3);
   border-bottom: 10px solid $govuk-brand-colour;
+  background-color: govuk-colour("black");
 }
 
 .moj-header__container {
@@ -48,13 +48,13 @@
 .moj-header__link > a {
   @include govuk-link-common;
   @include govuk-link-style-default;
-  border-bottom: 1px solid transparent;
-  color: govuk-colour("white");
   display: inline-block;
-  text-decoration: none;
-  line-height: 25px; // Override due to alignment issue in Chrome
   margin-bottom: -1px;
   overflow: hidden; // Fixes focus gaps in background colour
+  border-bottom: 1px solid transparent;
+  color: govuk-colour("white");
+  line-height: 25px; // Override due to alignment issue in Chrome
+  text-decoration: none;
   vertical-align: middle;
 
   &:link,
@@ -76,6 +76,7 @@
   &--organisation-name {
     @include govuk-font($size: 24, $weight: "bold");
     vertical-align: middle;
+
     &:hover {
       border-color: transparent;
     }
@@ -91,6 +92,7 @@
     @include govuk-media-query($from: desktop) {
       margin-left: govuk-spacing(1);
     }
+
     &:hover {
       border-color: transparent;
     }
@@ -98,16 +100,16 @@
 }
 
 .moj-header__link a {
-  vertical-align: text-bottom;
   margin-bottom: 1px;
+  vertical-align: text-bottom;
 
   &:hover {
     border-color: govuk-colour("white");
   }
 
   @include govuk-media-query($until: desktop) {
-    vertical-align: middle;
     margin-bottom: -1px;
+    vertical-align: middle;
   }
 }
 
@@ -119,15 +121,15 @@ span.moj-header__link {
 
 // Navigation
 .moj-header__navigation {
-  color: govuk-colour("white");
   margin-top: govuk-spacing(1)-2px;
+  color: govuk-colour("white");
 }
 
 .moj-header__navigation-list {
-  font-size: 0; // Removes white space when using inline-block on child element.
-  list-style: none;
   margin: 0;
   padding: 0;
+  font-size: 0; // Removes white space when using inline-block on child element.
+  list-style: none;
 }
 
 .moj-header__navigation-item {

--- a/src/moj/components/identity-bar/_identity-bar.scss
+++ b/src/moj/components/identity-bar/_identity-bar.scss
@@ -4,11 +4,11 @@
 
 .moj-identity-bar {
   @include govuk-clearfix;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2) - 1px; /* Negative by 1px to compensate */
+  color: govuk-colour("black");
   background-color: govuk-colour("white");
   box-shadow: inset 0 -1px 0 0 govuk-colour("mid-grey"); /* Takes up no space */
-  color: govuk-colour("black");
-  padding-bottom: govuk-spacing(2) - 1px; /* Negative by 1px to compensate */
-  padding-top: govuk-spacing(2);
 }
 
 .moj-identity-bar__container {
@@ -16,7 +16,7 @@
   font-size: 0; /* Hide whitespace between elements */
   text-align: justify; /* Trick to remove the need for floats */
 
-  &:after {
+  &::after {
     content: "";
     display: inline-block;
     width: 100%;
@@ -36,9 +36,9 @@
 
   @include govuk-media-query($from: tablet) {
     display: inline-block;
-    vertical-align: top;
     padding-top: govuk-spacing(2) + 1px; /* Alignment tweaks */
     padding-bottom: govuk-spacing(2) - 1px; /* Alignment tweaks */
+    vertical-align: top;
   }
 }
 

--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -2,7 +2,7 @@
   margin-bottom: govuk-spacing(3);
   border: $govuk-border-width solid transparent;
   background-color: govuk-colour("blue");
-  @include govuk-responsive-padding(7, $adjustment: $govuk-border-width*-1);
+  @include govuk-responsive-padding(7, $adjustment: $govuk-border-width * -1);
 }
 
 .moj-interruption-card__content {

--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -1,8 +1,8 @@
 .moj-interruption-card {
-  background-color: govuk-colour("blue");
   margin-bottom: govuk-spacing(3);
-  @include govuk-responsive-padding(7, $adjustment: $govuk-border-width*-1);
   border: $govuk-border-width solid transparent;
+  background-color: govuk-colour("blue");
+  @include govuk-responsive-padding(7, $adjustment: $govuk-border-width*-1);
 }
 
 .moj-interruption-card__content {

--- a/src/moj/components/messages/_messages.scss
+++ b/src/moj/components/messages/_messages.scss
@@ -9,38 +9,38 @@
 
 .moj-message-list {
   min-height: 200px;
-  overflow-y: scroll;
-  overflow-x: hidden;
   padding: govuk-spacing(1);
+  overflow-x: hidden;
+  overflow-y: scroll;
 
   &__date {
     @include govuk-font($size: 19, $weight: "bold");
+    display: inline-block;
+    width: 100%;
     padding: govuk-spacing(3) 0;
     color: govuk-colour("dark-grey");
-    display: inline-block;
     text-align: center;
-    width: 100%;
   }
 
 }
 
 .moj-message-item {
-  border-radius: 0.5em 0.5em 0.75em 0.5em;
+  position: relative;
   margin-bottom: govuk-spacing(1);
   padding: govuk-spacing(3);
-  position: relative;
+  border-radius: 0.5em 0.5em 0.75em;
 
   @include govuk-media-query($from: tablet) {
     width: 50%;
   }
 
   &--sent {
-    color: govuk-colour("white");
-    background-color: $govuk-brand-colour;
     margin-right: govuk-spacing(2);
     padding-right: govuk-spacing(5);
-    text-align: right;
     float: right;
+    color: govuk-colour("white");
+    background-color: $govuk-brand-colour;
+    text-align: right;
 
     &::after {
       content: "";
@@ -55,16 +55,16 @@
   }
 
   &--received {
-    background-color: govuk-colour("light-grey");
-    float: left;
     margin-left: govuk-spacing(2);
     padding-left: govuk-spacing(5);
+    float: left;
+    background-color: govuk-colour("light-grey");
 
     &::after {
       content: "";
       position: absolute;
-      left: -1.5em;
       bottom: 0;
+      left: -1.5em;
       width: 1.5em;
       height: 1.5em;
       border-right: 1em solid govuk-colour("light-grey");
@@ -85,7 +85,6 @@
 }
 
 .moj-message-item__text {
-
   &--sent table {
     color: govuk-colour("white");
 

--- a/src/moj/components/multi-file-upload/_multi-file-upload.scss
+++ b/src/moj/components/multi-file-upload/_multi-file-upload.scss
@@ -7,40 +7,40 @@
 }
 
 .moj-multi-file-upload__dropzone {
-  outline: 3px dashed govuk-colour('black');
 	display: flex;
-	text-align: center;
 	padding: govuk-spacing(9) govuk-spacing(3);
 	transition: outline-offset .1s ease-in-out, background-color .1s linear;
+  outline: 3px dashed govuk-colour('black');
+	text-align: center;
 }
 
 .moj-multi-file-upload__dropzone label {
-	margin-bottom: 0;
 	display: inline-block;
 	width: auto;
+	margin-bottom: 0;
 }
 
 .moj-multi-file-upload__dropzone p {
-  margin-bottom: 0;
   margin-right: 10px;
+  margin-bottom: 0;
   padding-top: 7px;
 }
 
-.moj-multi-file-upload__dropzone [type=file] {
+.moj-multi-file-upload__dropzone [type="file"] {
 	position: absolute;
 	left: -9999em;
 }
 
 .moj-multi-file-upload--dragover {
-	background: #b1b4b6;
 	outline-color: #6f777b;
+	background: #b1b4b6;
 }
 
 .moj-multi-file-upload--focused {
-	background-color: $govuk-focus-colour;
-  color: $govuk-focus-text-colour;
-  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   outline: none;
+  color: $govuk-focus-text-colour;
+	background-color: $govuk-focus-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
 }
 
 .moj-multi-file-upload__error {
@@ -54,13 +54,13 @@
 }
 
 .moj-multi-file-upload__error svg {
-   fill: currentColor;
-   float: left;
    margin-right: govuk-spacing(2);
+   float: left;
+   fill: currentcolor;
 }
 
 .moj-multi-file-upload__success svg {
-	fill: currentColor;
-	float: left;
 	margin-right: govuk-spacing(2);
+	float: left;
+	fill: currentcolor;
 }

--- a/src/moj/components/multi-select/_multi-select.scss
+++ b/src/moj/components/multi-select/_multi-select.scss
@@ -9,7 +9,7 @@
 
 .moj-multi-select__toggle-label {
   // stylelint-disable-next-line declaration-no-important
-  padding: 0 !important;
-  // stylelint-disable-next-line declaration-no-important
   margin: 0 !important;
+  // stylelint-disable-next-line declaration-no-important
+  padding: 0 !important;
 }

--- a/src/moj/components/multi-select/_multi-select.scss
+++ b/src/moj/components/multi-select/_multi-select.scss
@@ -2,13 +2,14 @@
    # MULTI-SELECT
    ========================================================================== */
 
-
 .moj-multi-select__checkbox {
   display: inline-block;
   padding-left: 0;
 }
 
 .moj-multi-select__toggle-label {
+  // stylelint-disable-next-line declaration-no-important
   padding: 0 !important;
+  // stylelint-disable-next-line declaration-no-important
   margin: 0 !important;
 }

--- a/src/moj/components/notification-badge/_notification-badge.scss
+++ b/src/moj/components/notification-badge/_notification-badge.scss
@@ -4,11 +4,11 @@
 
 .moj-notification-badge {
     @include govuk-font($size: 16, $weight: "bold");
-    color: govuk-colour("white");
     display: inline-block;
     min-width: 15px;
-    padding: 5px 8px 2px 8px;
+    padding: 5px 8px 2px;
     border-radius: 75px;
+    color: govuk-colour("white");
     background-color: govuk-colour("red");
     font-size: 16px;
     font-weight: 600;

--- a/src/moj/components/organisation-switcher/_organisation-switcher.scss
+++ b/src/moj/components/organisation-switcher/_organisation-switcher.scss
@@ -13,8 +13,8 @@
 .moj-organisation-nav__title {
   @include govuk-font($size: 19, $weight: "bold");
   @include govuk-media-query($from: tablet) {
-    float: left;
     width: 75%;
+    float: left;
   }
 }
 

--- a/src/moj/components/page-header-actions/_page-header-actions.scss
+++ b/src/moj/components/page-header-actions/_page-header-actions.scss
@@ -1,11 +1,11 @@
 .moj-page-header-actions {
   display: flex;
+  min-height: govuk-spacing(7); // Match button height
+  margin-bottom: govuk-spacing(7);
   flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   gap: govuk-spacing(2);
-  margin-bottom: govuk-spacing(7);
-  min-height: govuk-spacing(7); // Match button height
 }
 
 .moj-page-header-actions__title {
@@ -18,6 +18,7 @@
   .moj-button-group {
     margin-bottom: 0;
   }
+
   .govuk-button {
     margin-bottom: 0;
   }

--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -36,6 +36,7 @@
 .moj-pagination__results {
   @include govuk-font(19);
   margin-top: 0;
+  padding: govuk-spacing(1);
   @include govuk-media-query($from: desktop) {
     display: inline-block;
     margin-bottom: 0;
@@ -109,6 +110,3 @@
 
 }
 
-.moj-pagination__results {
-  padding: govuk-spacing(1);
-}

--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -2,10 +2,10 @@
   // text-align: center;
 
   @include govuk-media-query($from: desktop) {
+    margin-right: - govuk-spacing(1);
 
     // Alignment adjustments
     margin-left: - govuk-spacing(1);
-    margin-right: - govuk-spacing(1);
 
     // Hide whitespace between elements
     font-size: 0;
@@ -13,7 +13,7 @@
     // Trick to remove the need for floats
     text-align: justify;
 
-    &:after {
+    &::after {
       content: '';
       display: inline-block;
       width: 100%;
@@ -23,9 +23,9 @@
 }
 
 .moj-pagination__list {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
   @include govuk-media-query($from: desktop) {
     display: inline-block;
     margin-bottom: 0;
@@ -50,49 +50,49 @@
 
 .moj-pagination__item--active,
 .moj-pagination__item--dots {
-  font-weight: bold;
   height: 25px;
   padding: govuk-spacing(1) govuk-spacing(2);
+  font-weight: bold;
   text-align: center;
 }
 
 .moj-pagination__item--dots {
-  padding-left: 0;
   padding-right: 0;
+  padding-left: 0;
 }
 
-.moj-pagination__item--prev .moj-pagination__link:before,
-.moj-pagination__item--next .moj-pagination__link:after {
+.moj-pagination__item--prev .moj-pagination__link::before,
+.moj-pagination__item--next .moj-pagination__link::after {
+    content: "";
     display: inline-block;
-    height: 10px;
     width: 10px;
-    border-style: solid;
-    color: govuk-colour("black");
-    background: transparent;
+    height: 10px;
     -webkit-transform: rotate(-45deg);
     -ms-transform: rotate(-45deg);
     transform: rotate(-45deg);
-    content: "";
+    border-style: solid;
+    color: govuk-colour("black");
+    background: transparent;
 }
 
-.moj-pagination__item--prev .moj-pagination__link:before {
-    border-width: 3px 0 0 3px;
+.moj-pagination__item--prev .moj-pagination__link::before {
     margin-right: govuk-spacing(1);
+    border-width: 3px 0 0 3px;
 }
 
-.moj-pagination__item--next .moj-pagination__link:after {
-    border-width: 0 3px 3px 0;
+.moj-pagination__item--next .moj-pagination__link::after {
     margin-left: govuk-spacing(1);
+    border-width: 0 3px 3px 0;
 }
 
 .moj-pagination__link {
   @include govuk-link-common;
   @include govuk-link-style-default;
   display: block;
+  min-width: 25px;
   padding: govuk-spacing(1);
   text-align: center;
   text-decoration: none;
-  min-width: 25px;
 
   &:link,
   &:visited {

--- a/src/moj/components/primary-navigation/_primary-navigation.scss
+++ b/src/moj/components/primary-navigation/_primary-navigation.scss
@@ -11,7 +11,7 @@
   font-size: 0; // Hide whitespace between elements
   text-align: justify; // Trick to remove the need for floats
 
-  &:after {
+  &::after {
     content: '';
     display: inline-block;
     width: 100%;
@@ -29,17 +29,17 @@
 }
 
 .moj-primary-navigation__list {
-  font-size: 0; // Removes white space when using inline-block on child element.
-  list-style: none;
   margin: 0;
   padding: 0;
+  font-size: 0; // Removes white space when using inline-block on child element.
+  list-style: none;
 }
 
 .moj-primary-navigation__item {
   @include govuk-font($size: 19);
   display: inline-block;
-  margin-right: govuk-spacing(4);
   margin-top: 0;
+  margin-right: govuk-spacing(4);
 
   &:last-child {
     margin-right: 0;
@@ -51,10 +51,10 @@
   @include govuk-link-common;
   @include govuk-link-style-default;
   display: block;
-  padding-bottom: 15px;
   padding-top: 15px;
-  text-decoration: none;
+  padding-bottom: 15px;
   font-weight: bold;
+  text-decoration: none;
 
   &:link,
   &:visited {
@@ -66,49 +66,50 @@
   }
 
   &:focus {
-    color: govuk-colour("black"); // Focus colour on yellow should really be black.
     position: relative; // Ensure focus sits above everything else.
     z-index: 1;
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
     box-shadow: none;
   }
 
-  &:focus:before {
-    background-color: govuk-colour("black");
+  &:focus::before {
     content: "";
     display: block;
-    height: 5px;
     position: absolute; bottom: 0; left: 0;
     width: 100%;
+    height: 5px;
+    background-color: govuk-colour("black");
   }
 
   &[aria-current] {
-    color: $govuk-link-colour;
     position: relative;
-    text-decoration: none;
+    color: $govuk-link-colour;
     font-weight: bold;
-    &:before {
-      background-color: $govuk-link-colour;
+    text-decoration: none;
+
+    &::before {
       content: "";
       display: block;
-      height: 5px;
       position: absolute; bottom: 0; left: 0;
       width: 100%;
+      height: 5px;
+      background-color: $govuk-link-colour;
     }
 
     &:hover {
       color: $govuk-link-hover-colour;
 
-      &:before {
+      &::before {
         background-color: $govuk-link-hover-colour;
       }
     }
 
     &:focus {
-      color: govuk-colour("black"); // Focus colour on yellow should really be black.
       position: relative; // Ensure focus sits above everything else.
       border: none;
+      color: govuk-colour("black"); // Focus colour on yellow should really be black.
 
-      &:before {
+      &::before {
         background-color: govuk-colour("black");
       }
 

--- a/src/moj/components/progress-bar/_progress-bar.scss
+++ b/src/moj/components/progress-bar/_progress-bar.scss
@@ -7,11 +7,11 @@
 }
 
 .moj-progress-bar__list {
-  font-size: 0; // Hide white space between elements
-  list-style: none;
+  position: relative;
   margin: 0;
   padding: 0;
-  position: relative;
+  font-size: 0; // Hide white space between elements
+  list-style: none;
   text-align: justify;
   vertical-align: top;
 
@@ -22,12 +22,12 @@
   }
 
   &::before {
-    border-top: 6px solid govuk-colour("green");
     content: "";
-    left: 0;
     position: absolute;
     top: 13px;
+    left: 0;
     width: 100%;
+    border-top: 6px solid govuk-colour("green");
   }
 
 }
@@ -35,25 +35,24 @@
 .moj-progress-bar__item {
   @include govuk-font(19);
   display: inline-block;
-  max-width: 20%;
   position: relative;
+  max-width: 20%;
   text-align: center;
   vertical-align: top;
 
   &:first-child,
   &:last-child {
     &::before {
-      border-top: 6px solid govuk-colour("white");
       content: "";
       position: absolute;
       top: 13px; left: 0;
       width: 50%;
+      border-top: 6px solid govuk-colour("white");
     }
 
   }
 
   &:first-child {
-
     &::before {
       left: 0;
     }
@@ -61,45 +60,44 @@
   }
 
   &:last-child {
-
     &::before {
-      left: auto;
       right: 0;
+      left: auto;
     }
 
   }
 
-  &[aria-current=step] { // https://tink.uk/using-the-aria-current-attribute
+  &[aria-current="step"] { // https://tink.uk/using-the-aria-current-attribute
     @include govuk-font($size: 19, $weight: "bold");
   }
 
 }
 
 .moj-progress-bar__icon {
-  position: relative;
-  background-color: govuk-colour("white");
-  border: 6px solid govuk-colour("green");
-  border-radius: 50%;
   box-sizing: border-box;
   display: block;
-  height: 32px;
-  margin-left: auto;
-  margin-right: auto;
+  position: relative;
   width: 32px;
+  height: 32px;
+  margin-right: auto;
+  margin-left: auto;
+  border: 6px solid govuk-colour("green");
+  border-radius: 50%;
+  background-color: govuk-colour("white");
 }
 
 .moj-progress-bar__icon--complete {
   background-color: govuk-colour("green");
   background-image: url(#{$moj-images-path}icon-progress-tick.svg);
-  background-position: 50% 50%;
   background-repeat: no-repeat;
+  background-position: 50% 50%;
 }
 
 .moj-progress-bar__label {
   @include govuk-font(16);
   display: block;
-  font-weight: inherit;
-  margin-top: govuk-spacing(3);
   position: relative;
+  margin-top: govuk-spacing(3);
+  font-weight: inherit;
   word-wrap: break-word; // Just in case
 }

--- a/src/moj/components/rich-text-editor/_rich-text-editor.scss
+++ b/src/moj/components/rich-text-editor/_rich-text-editor.scss
@@ -8,20 +8,20 @@
 }
 
 .moj-rich-text-editor__toolbar-button {
-  background-color: govuk-colour("white");
-  background-position: 50% 50%;
-  background-repeat: no-repeat;
-  background-size: 40px 40px;
-  border: 2px solid govuk-colour("black");
-  color: govuk-colour("black");
-  cursor: pointer;
-  float: left;
-  text-decoration: none;
+  width: 40px;
   height: 40px;
   margin-left: -2px;
+  float: left;
+  border: 2px solid govuk-colour("black");
   outline: 0;
+  color: govuk-colour("black");
+  background-color: govuk-colour("white");
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+  background-size: 40px 40px;
+  text-decoration: none;
   vertical-align: top;
-  width: 40px;
+  cursor: pointer;
 
   &:first-child {
     margin-left: 0;
@@ -34,12 +34,12 @@
   }
 
   &:focus {
-    background-color: $govuk-focus-colour;
-    color: $govuk-focus-text-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
-    outline: none;
     position: relative;
     z-index: 2;
+    outline: none;
+    color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
+    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   }
 
 }
@@ -57,8 +57,8 @@
 }
 
 .moj-rich-text-editor__toolbar-button--unordered-list {
-  background-image: url(#{$moj-images-path}icon-wysiwyg-unordered-list.svg);
   margin-left: govuk-spacing(2);
+  background-image: url(#{$moj-images-path}icon-wysiwyg-unordered-list.svg);
 }
 
 .moj-rich-text-editor__toolbar-button--ordered-list {
@@ -67,7 +67,7 @@
 
 .moj-rich-text-editor__content {
   min-height: 130px;
-  outline: none;
   overflow: auto;
   resize: vertical;
+  outline: none;
 }

--- a/src/moj/components/search-toggle/search-toggle.scss
+++ b/src/moj/components/search-toggle/search-toggle.scss
@@ -1,24 +1,24 @@
 .moj-search-toggle__button {
   @include govuk-font($size: 19, $weight: bold);
-  background-color: transparent;
-  border: none;
-  color: $govuk-link-colour;
-  cursor: pointer;
   display: inline-block;
   padding-top: 12px;
+  padding-right: 0;
   padding-bottom: 13px;
   padding-left: 0;
-  padding-right: 0;
+  border: none;
+  color: $govuk-link-colour;
+  background-color: transparent;
+  cursor: pointer;
   -webkit-font-smoothing: antialiased;
   -webkit-appearance: none;
 
   &__icon {
     display: inline-block;
+    width: 20px;
     height: 20px;
     margin-left: govuk-spacing(2);
+    fill: currentcolor;
     vertical-align: middle;
-    width: 20px;
-    fill: currentColor;
 
     @media screen and (forced-colors: active) {
       fill: windowText;
@@ -26,14 +26,14 @@
   }
 
   &:focus {
-    background-color: $govuk-focus-colour;
+    position: relative;
+    z-index: 1;
+    outline: none;
     color: $govuk-focus-text-colour;
+    background-color: $govuk-focus-colour;
     box-shadow:
       0 -2px $govuk-focus-colour,
       0 4px $govuk-focus-text-colour;
-    outline: none;
-    position: relative;
-    z-index: 1;
   }
 }
 
@@ -42,9 +42,9 @@
 
   @include govuk-media-query($until: desktop) {
     // stylelint-disable-next-line declaration-no-important
-    padding-left: 0 !important;
-    // stylelint-disable-next-line declaration-no-important
     padding-right: 0 !important;
+    // stylelint-disable-next-line declaration-no-important
+    padding-left: 0 !important;
   }
 }
 
@@ -64,11 +64,11 @@
   background-color: govuk-colour("light-grey");
 
   @include govuk-media-query($from: desktop) {
-    max-width: 450px;
     position: absolute;
-    right: -15px;
-    top: 50px; // Height of nav bar
-    width: 450px;
     z-index: 10;
+    top: 50px; // Height of nav bar
+    right: -15px;
+    width: 450px;
+    max-width: 450px;
   }
 }

--- a/src/moj/components/search-toggle/search-toggle.scss
+++ b/src/moj/components/search-toggle/search-toggle.scss
@@ -28,7 +28,9 @@
   &:focus {
     background-color: $govuk-focus-colour;
     color: $govuk-focus-text-colour;
-    box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+    box-shadow:
+      0 -2px $govuk-focus-colour,
+      0 4px $govuk-focus-text-colour;
     outline: none;
     position: relative;
     z-index: 1;
@@ -39,7 +41,9 @@
   padding: govuk-spacing(3);
 
   @include govuk-media-query($until: desktop) {
+    // stylelint-disable-next-line declaration-no-important
     padding-left: 0 !important;
+    // stylelint-disable-next-line declaration-no-important
     padding-right: 0 !important;
   }
 }
@@ -47,6 +51,7 @@
 // JS enabled
 .js-enabled .moj-search--toggle {
   @include govuk-media-query($until: desktop) {
+    // stylelint-disable-next-line declaration-no-important
     padding-top: 0 !important;
   }
 }

--- a/src/moj/components/search-toggle/search-toggle.scss
+++ b/src/moj/components/search-toggle/search-toggle.scss
@@ -11,6 +11,7 @@
   cursor: pointer;
   -webkit-font-smoothing: antialiased;
   -webkit-appearance: none;
+  appearance: none;
 
   &__icon {
     display: inline-block;

--- a/src/moj/components/search/_search.scss
+++ b/src/moj/components/search/_search.scss
@@ -26,12 +26,12 @@
 
 .moj-search__button {
   display: inline-block;
-  margin-bottom: 0;
-  margin-left: govuk-spacing(2);
   position: relative;
   top: -2px; // Override default gov properties due to active pixel movement
-  vertical-align: bottom;
   width: auto;
+  margin-bottom: 0;
+  margin-left: govuk-spacing(2);
+  vertical-align: bottom;
 }
 
 .moj-search--inline {

--- a/src/moj/components/search/_search.scss
+++ b/src/moj/components/search/_search.scss
@@ -35,8 +35,11 @@
 }
 
 .moj-search--inline {
+  // stylelint-disable-next-line declaration-no-important
   padding: govuk-spacing(2) 0 !important;
   @include govuk-media-query($from: desktop) {
+    // stylelint-disable-next-line declaration-no-important
     padding: 0 !important;
   }
 }
+

--- a/src/moj/components/side-navigation/_side-navigation.scss
+++ b/src/moj/components/side-navigation/_side-navigation.scss
@@ -19,11 +19,11 @@
 
 .moj-side-navigation__title {
   @include govuk-font($size: 19);
-  color: govuk-colour("dark-grey");
-  font-weight: normal;
   margin: 0;
   padding: govuk-spacing(2);
   padding-left: govuk-spacing(2) + 4px;
+  color: govuk-colour("dark-grey");
+  font-weight: normal;
 
   @include govuk-media-query($until: tablet) {
     display: none;
@@ -32,9 +32,9 @@
 }
 
 .moj-side-navigation__list {
-  list-style: none;
   margin: 0;
   padding: 0;
+  list-style: none;
 
   @include govuk-media-query($until: tablet) {
     display: flex;
@@ -56,21 +56,21 @@
   a,
   a:link,
   a:visited {
-    background-color: inherit;
-    color: $govuk-link-colour;
     display: block;
+    color: $govuk-link-colour;
+    background-color: inherit;
     text-decoration: none;
 
     @include govuk-media-query($until: tablet) {
-      border-bottom: 4px solid transparent;
       padding: govuk-spacing(3);
       padding-bottom: govuk-spacing(3) - 4px; // Compensate for 4px border
+      border-bottom: 4px solid transparent;
     }
 
     @include govuk-media-query($from: tablet) {
-      background-color: inherit;
-      border-left: 4px solid transparent;
       padding: govuk-spacing(2);
+      border-left: 4px solid transparent;
+      background-color: inherit;
     }
 
 
@@ -81,16 +81,15 @@
   }
 
   a:focus {
+    position: relative;
+    border-color: $govuk-focus-text-colour;
     color: $govuk-focus-text-colour;
     background-color: $govuk-focus-colour;
-    border-color: $govuk-focus-text-colour;
-    position: relative;
   }
 
 }
 
 .moj-side-navigation__item--active {
-
   a:link,
   a:visited {
     border-color: $govuk-link-colour;
@@ -99,14 +98,14 @@
   }
 
   a:hover {
-    color: $govuk-link-hover-colour;
     border-color: $govuk-link-hover-colour;
+    color: $govuk-link-hover-colour;
   }
 
   a:focus {
+    border-color: $govuk-focus-text-colour;
     color: $govuk-focus-text-colour;
     background-color: $govuk-focus-colour;
-    border-color: $govuk-focus-text-colour;
   }
 
   @include govuk-media-query($from: tablet) {

--- a/src/moj/components/sortable-table/_sortable-table.scss
+++ b/src/moj/components/sortable-table/_sortable-table.scss
@@ -1,66 +1,66 @@
 [aria-sort] button,
 [aria-sort] button:hover {
-  background-color: transparent;
+  position: relative;
+  margin: 0;
+  padding: 0 10px 0 0;
   border-width: 0;
+  color: #005ea5;
+  background-color: transparent;
   -webkit-box-shadow: 0 0 0 0;
   -moz-box-shadow: 0 0 0 0;
   box-shadow: 0 0 0 0;
-  color: #005ea5;
-  cursor: pointer;
   font-family: inherit;
   font-size: inherit;
-  font-weight: inherit;
-  padding: 0 10px 0 0;
-  position: relative;
-  text-align: inherit;
   font-size: 1em;
-  margin: 0;
+  font-weight: inherit;
+  text-align: inherit;
+  cursor: pointer;
 }
 
 [aria-sort] button:focus {
-  background-color: $govuk-focus-colour;
-  color: $govuk-focus-text-colour;
-  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   outline: none;
+  color: $govuk-focus-text-colour;
+  background-color: $govuk-focus-colour;
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
 }
 
 [aria-sort]:first-child button {
   right: auto;
 }
 
-[aria-sort] button:before {
+[aria-sort] button::before {
   content: " \25bc";
   position: absolute;
-  right: -1px;
   top: 9px;
+  right: -1px;
   font-size: 0.5em;
 }
 
-[aria-sort] button:after {
+[aria-sort] button::after {
   content: " \25b2";
   position: absolute;
-  right: -1px;
   top: 1px;
+  right: -1px;
   font-size: 0.5em;
 }
 
-[aria-sort="ascending"] button:before,
-[aria-sort="descending"] button:before {
+[aria-sort="ascending"] button::before,
+[aria-sort="descending"] button::before {
   content: none;
 }
 
-[aria-sort="ascending"] button:after {
+[aria-sort="ascending"] button::after {
   content: " \25b2";
-  font-size: .8em;
   position: absolute;
-  right: -5px;
   top: 2px;
+  right: -5px;
+  font-size: .8em;
 }
 
-[aria-sort="descending"] button:after {
+[aria-sort="descending"] button::after {
   content: " \25bc";
-  font-size: .8em;
   position: absolute;
-  right: -5px;
   top: 2px;
+  right: -5px;
+  font-size: .8em;
 }

--- a/src/moj/components/sub-navigation/_sub-navigation.scss
+++ b/src/moj/components/sub-navigation/_sub-navigation.scss
@@ -8,33 +8,33 @@
 
 
 .moj-sub-navigation__list {
-  font-size: 0; // Removes white space when using inline-block on child element.
-  list-style: none;
   margin: 0;
   padding: 0;
+  font-size: 0; // Removes white space when using inline-block on child element.
+  list-style: none;
 
   @include govuk-media-query($from: tablet) {
-    box-shadow: inset 0 -1px 0 $govuk-border-colour;
     width: 100%;
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
   }
 }
 
 
 .moj-sub-navigation__item {
   @include govuk-font(19);
-  box-shadow: inset 0 -1px 0 $govuk-border-colour;
   display: block;
   margin-top: -1px;
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
 
   &:last-child {
     box-shadow: none;
   }
 
   @include govuk-media-query($from: tablet) {
-    box-shadow: none;
     display: inline-block;
-    margin-right: govuk-spacing(4);
     margin-top: 0;
+    margin-right: govuk-spacing(4);
+    box-shadow: none;
   }
 
 }
@@ -44,11 +44,11 @@
   @include govuk-link-common;
   @include govuk-link-style-default;
   display: block;
+  position: relative;
   padding-top: 12px;
   padding-bottom: 12px;
   padding-left: govuk-spacing(3);
   text-decoration: none;
-  position: relative;
 
   @include govuk-media-query($from: tablet) {
     padding-left: 0;
@@ -64,22 +64,22 @@
   }
 
   &:focus {
-    color: govuk-colour("black"); // Focus colour on yellow should really be black.
     position: relative; // Ensure focus sits above everything else.
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
     box-shadow: none;
   }
 
-  &:focus:before {
-    background-color: govuk-colour("black");
+  &:focus::before {
     content: "";
     display: block;
-    height: 100%;
     position: absolute; bottom: 0; left: 0;
     width: 5px;
+    height: 100%;
+    background-color: govuk-colour("black");
 
     @include govuk-media-query($from: tablet) {
-      height: 5px;
       width: 100%;
+      height: 5px;
     }
   }
 
@@ -87,21 +87,21 @@
 
 
 .moj-sub-navigation__link[aria-current="page"] {
-  color: $govuk-link-active-colour;
   position: relative;
+  color: $govuk-link-active-colour;
   text-decoration: none;
 
-  &:before {
-    background-color: $govuk-link-colour;
+  &::before {
     content: "";
     display: block;
-    height: 100%;
     position: absolute; bottom: 0; left: 0;
     width: 5px;
+    height: 100%;
+    background-color: $govuk-link-colour;
 
     @include govuk-media-query($from: tablet) {
-      height: 5px;
       width: 100%;
+      height: 5px;
     }
 
   }
@@ -110,7 +110,7 @@
     color: $govuk-link-hover-colour;
   }
 
-  &:focus:before {
+  &:focus::before {
     background-color: govuk-colour("black");
   }
 

--- a/src/moj/components/tag/_tag.scss
+++ b/src/moj/components/tag/_tag.scss
@@ -4,52 +4,52 @@
 
 .moj-tag {
   border: 2px solid $govuk-brand-colour;
-  background-color: $govuk-brand-colour;
   color: govuk-colour("white");
+  background-color: $govuk-brand-colour;
 
   &--purple {
     border: 2px solid govuk-colour("purple");
-    background-color: govuk-colour("purple");
     color: govuk-colour("white");
+    background-color: govuk-colour("purple");
   }
 
   &--bright-purple {
     border: 2px solid govuk-colour("bright-purple");
-    background-color: govuk-colour("bright-purple");
     color: govuk-colour("white");
+    background-color: govuk-colour("bright-purple");
   }
 
   &--red,
   &--error {
     border: 2px solid govuk-colour("red");
-    background-color: govuk-colour("red");
     color: govuk-colour("white");
+    background-color: govuk-colour("red");
   }
 
   &--green,
   &--success {
     border: 2px solid govuk-colour("green");
-    background-color: govuk-colour("green");
     color: govuk-colour("white");
+    background-color: govuk-colour("green");
   }
 
   &--blue,
   &--information {
     border: 2px solid govuk-colour("blue");
-    background-color: govuk-colour("blue");
     color: govuk-colour("white");
+    background-color: govuk-colour("blue");
   }
 
   &--black {
     border: 2px solid govuk-colour("black");
-    background-color: govuk-colour("black");
     color: govuk-colour("white");
+    background-color: govuk-colour("black");
   }
 
   &--grey {
     border: 2px solid govuk-colour("dark-grey");
-    background-color: govuk-colour("dark-grey");
     color: govuk-colour("white");
+    background-color: govuk-colour("dark-grey");
   }
 
 }

--- a/src/moj/components/task-list/_task-list.scss
+++ b/src/moj/components/task-list/_task-list.scss
@@ -14,7 +14,7 @@
 
 .moj-task-list__section {
   display: table;
-  @include govuk-font($size:24, $weight: bold);
+  @include govuk-font($size: 24, $weight: bold);
 }
 
 .moj-task-list__section-number {
@@ -38,6 +38,7 @@
 
 .moj-task-list__item {
   border-bottom: 1px solid $govuk-border-colour;
+  // stylelint-disable-next-line declaration-no-important
   margin-bottom: 0 !important;
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(2);

--- a/src/moj/components/task-list/_task-list.scss
+++ b/src/moj/components/task-list/_task-list.scss
@@ -3,10 +3,10 @@
    ========================================================================== */
 
 .moj-task-list {
-  list-style-type: none;
-  padding-left: 0;
   margin-top: 0;
   margin-bottom: 0;
+  padding-left: 0;
+  list-style-type: none;
   @include govuk-media-query($from: tablet) {
     min-width: 550px;
   }
@@ -29,19 +29,19 @@
 .moj-task-list__items {
   @include govuk-font($size: 19);
   @include govuk-responsive-margin(9, "bottom");
-  list-style: none;
   padding-left: 0;
+  list-style: none;
   @include govuk-media-query($from: tablet) {
     padding-left: govuk-spacing(6);
   }
 }
 
 .moj-task-list__item {
-  border-bottom: 1px solid $govuk-border-colour;
   // stylelint-disable-next-line declaration-no-important
   margin-bottom: 0 !important;
   padding-top: govuk-spacing(2);
   padding-bottom: govuk-spacing(2);
+  border-bottom: 1px solid $govuk-border-colour;
   @include govuk-clearfix;
 }
 
@@ -52,8 +52,8 @@
 .moj-task-list__task-name {
   display: block;
   @include govuk-media-query($from: 450px) {
-    float: left;
     width: 75%;
+    float: left;
   }
 }
 
@@ -62,8 +62,8 @@
   margin-bottom: govuk-spacing(1);
 
   @include govuk-media-query($from: 450px) {
-    float: right;
     margin-top: 0;
     margin-bottom: 0;
+    float: right;
   }
 }

--- a/src/moj/components/ticket-panel/_ticket-panel.scss
+++ b/src/moj/components/ticket-panel/_ticket-panel.scss
@@ -25,30 +25,36 @@
   &__content {
     display: block;
     position: relative;
-    background-color: govuk-colour("light-grey");
-    padding: govuk-spacing(4);
     margin-bottom: govuk-spacing(3);
-    flex-grow: 1;
+    padding: govuk-spacing(4);
     border-left: 4px solid transparent;
+    background-color: govuk-colour("light-grey");
+    flex-grow: 1;
 
     &--grey {
       border-left-color: $govuk-border-colour;
     }
+
     &--blue {
       border-left-color: govuk-colour("blue");
     }
+
     &--red {
       border-left-color: govuk-colour("red");
     }
+
     &--yellow {
       border-left-color: govuk-colour("yellow");
     }
+
     &--green {
       border-left-color: govuk-colour("green");
     }
+
     &--purple {
       border-left-color: govuk-colour("purple");
     }
+
     &--orange {
       border-left-color: govuk-colour("orange");
     }

--- a/src/moj/components/ticket-panel/_ticket-panel.scss
+++ b/src/moj/components/ticket-panel/_ticket-panel.scss
@@ -11,10 +11,12 @@
     @include govuk-media-query($from: desktop) {
       display: flex;
       flex-wrap: nowrap;
+    }
+  }
 
-      & > * + * {
-        margin-left: govuk-spacing(3);
-      }
+  &--inline > * + * {
+    @include govuk-media-query($from: desktop) {
+      margin-left: govuk-spacing(3);
     }
   }
 

--- a/src/moj/components/timeline/_timeline.scss
+++ b/src/moj/components/timeline/_timeline.scss
@@ -3,42 +3,43 @@
    ========================================================================== */
 
 .moj-timeline {
+  position: relative;
   margin-bottom: govuk-spacing(4);
   overflow: hidden;
-  position: relative;
 
-  &:before {
-    background-color: $govuk-brand-colour;
+  &::before {
     content: "";
-    height: 100%;
-    left: 0;
     position: absolute;
     top: govuk-spacing(2);
+    left: 0;
     width: 5px;
+    height: 100%;
+    background-color: $govuk-brand-colour;
   }
 
 }
 
 .moj-timeline--full {
   margin-bottom: 0;
-  &:before {
+
+  &::before {
     height: calc(100% - 75px);
   }
 }
 
 .moj-timeline__item {
+  position: relative;
   padding-bottom: govuk-spacing(6);
   padding-left: govuk-spacing(4);
-  position: relative;
 
-  &:before {
-    background-color: $govuk-brand-colour;
+  &::before {
     content: "";
-    height: 5px;
-    left: 0;
     position: absolute;
     top: govuk-spacing(2);
+    left: 0;
     width: 15px;
+    height: 5px;
+    background-color: $govuk-brand-colour;
   }
 
 }
@@ -50,9 +51,9 @@
 
 .moj-timeline__byline {
   @include govuk-font($size: 19);
-  color: $govuk-secondary-text-colour;
   display: inline;
   margin: 0;
+  color: $govuk-secondary-text-colour;
 }
 
 .moj-timeline__date {
@@ -71,9 +72,9 @@
    ========================================================================== */
 
 .moj-timeline__documents {
-  list-style: none;
   margin-bottom: 0;
   padding-left: 0;
+  list-style: none;
 }
 
 .moj-timeline__document-item {
@@ -86,10 +87,10 @@
 }
 
 .moj-timeline__document-icon {
-  float: left;
   margin-top: 4px;
   margin-right: 4px;
-  fill: currentColor;
+  float: left;
+  fill: currentcolor;
 
   @media screen and (forced-colors: active) {
     fill: linkText;
@@ -97,11 +98,11 @@
 }
 
 .moj-timeline__document-link {
+  padding-left: govuk-spacing(5);
   background-image: url(#{$moj-images-path}icon-document.svg);
   background-repeat: no-repeat;
-  background-size: 20px 16px;
   background-position: 0 50%;
-  padding-left: govuk-spacing(5);
+  background-size: 20px 16px;
 
   &:focus {
     color: govuk-colour("black"); // Focus colour on yellow should really be black.

--- a/src/moj/objects/_filter-layout.scss
+++ b/src/moj/objects/_filter-layout.scss
@@ -6,22 +6,21 @@
   box-shadow: inset 0 0 0 1px govuk-colour("light-grey"); // Extends the inset border left full height of the filters on mobile
 
   @include govuk-media-query(desktop) {
-    float: left;
-    margin-right: govuk-spacing(7);
-    max-width: 385px;
-    min-width: 260px;
     width: 100%;
+    min-width: 260px;
+    max-width: 385px;
+    margin-right: govuk-spacing(7);
+    float: left;
   }
 }
 
 // Filters with javascript enabled
 @include govuk-media-query($until: desktop) {
-
   .js-enabled .moj-filter-layout__filter {
-    background-color: govuk-colour("white");
-    position: fixed; top: 0; right: 0; bottom: 0;
+    position: fixed;
+    z-index: 100; top: 0; right: 0; bottom: 0;
     overflow-y: scroll;
-    z-index: 100;
+    background-color: govuk-colour("white");
   }
 
 }

--- a/src/moj/objects/_scrollable-pane.scss
+++ b/src/moj/objects/_scrollable-pane.scss
@@ -1,8 +1,10 @@
 .moj-scrollable-pane {
-  $scrollableBgColor: white;
+  // stylelint-disable scss/dollar-variable-pattern
+  $scrollableBgColor: govuk-colour("white");
   $scrollableTransparentColor: rgba(255, 255, 255, 0);
   $scrollableShadowColor: rgba(0, 0, 0, 0.2);
   $scrollableShadowSize: 0.75em;
+  // stylelint-enable scss/dollar-variable-pattern
 
   overflow-x: scroll;
   background: linear-gradient(

--- a/src/moj/utilities/_hidden.scss
+++ b/src/moj/utilities/_hidden.scss
@@ -1,7 +1,7 @@
 .js-enabled .moj-js-hidden {
-  @include moj-hidden();
+  @include moj-hidden;
 }
 
 .moj-hidden {
-  @include moj-hidden();
+  @include moj-hidden;
 }

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -20,6 +20,7 @@ module.exports = {
   plugins: ['stylelint-order'],
   rules: {
     'scss/comment-no-loud': null,
+    'scss/at-extend-no-missing-placeholder': null,
 
     /**
      * Use the same rule ordering as GOVUK Frontend

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,0 +1,185 @@
+module.exports = {
+  extends: 'stylelint-config-gds/scss',
+  ignoreFiles: [
+    '**/dist/**',
+    '**/package/**',
+    '**/vendor/**',
+
+    // Ignore CSS-in-JS (including dotfiles)
+    '**/?(.)*.{cjs,js,mjs}',
+
+    // Prevent CHANGELOG history changes
+    'CHANGELOG.md'
+  ],
+  overrides: [
+    // {
+    //   customSyntax: 'postcss-scss',
+    //   files: ['**/*.scss']
+    // }
+  ],
+  plugins: ['stylelint-order'],
+  rules: {
+    'scss/comment-no-loud': false,
+
+    /**
+     * Use the same rule ordering as GOVUK Frontend
+     *
+     * https://github.com/hudochenkov/stylelint-order/blob/master/rules/properties-order/README.md
+     */
+    'order/properties-order': [
+      'content',
+      'quotes',
+
+      // Box-sizing - Allow here until global is decided
+      'box-sizing',
+
+      'display',
+      'visibility',
+
+      'position',
+      'z-index',
+      'top',
+      'right',
+      'bottom',
+      'left',
+
+      'width',
+      'min-width',
+      'max-width',
+      'height',
+      'min-height',
+      'max-height',
+
+      'margin',
+      'margin-top',
+      'margin-right',
+      'margin-bottom',
+      'margin-left',
+
+      'padding',
+      'padding-top',
+      'padding-right',
+      'padding-bottom',
+      'padding-left',
+
+      'float',
+      'clear',
+
+      'overflow',
+      'overflow-x',
+      'overflow-y',
+
+      'clip',
+      'clip-path',
+      'zoom',
+      'resize',
+
+      'columns',
+
+      'table-layout',
+      'empty-cells',
+      'caption-side',
+      'border-spacing',
+      'border-collapse',
+
+      'list-style',
+      'list-style-position',
+      'list-style-type',
+      'list-style-image',
+
+      'transform',
+      'transition',
+      'animation',
+
+      'border',
+      'border-top',
+      'border-right',
+      'border-bottom',
+      'border-left',
+
+      'border-width',
+      'border-top-width',
+      'border-right-width',
+      'border-bottom-width',
+      'border-left-width',
+
+      'border-style',
+      'border-top-style',
+      'border-right-style',
+      'border-bottom-style',
+      'border-left-style',
+
+      'border-radius',
+      'border-top-left-radius',
+      'border-top-right-radius',
+      'border-bottom-left-radius',
+      'border-bottom-right-radius',
+
+      'border-color',
+      'border-top-color',
+      'border-right-color',
+      'border-bottom-color',
+      'border-left-color',
+
+      'outline',
+      'outline-color',
+      'outline-offset',
+      'outline-style',
+      'outline-width',
+
+      'opacity',
+
+      // Color has been moved to ensure it appears before background
+      'color',
+      'background',
+      'background-color',
+      'background-image',
+      'background-repeat',
+      'background-position',
+      'background-size',
+      'box-shadow',
+      'fill',
+
+      'font',
+      'font-family',
+      'font-size',
+      'font-style',
+      'font-variant',
+      'font-weight',
+
+      'font-emphasize',
+
+      'letter-spacing',
+      'line-height',
+      'list-style',
+      'word-spacing',
+
+      'text-align',
+      'text-align-last',
+      'text-decoration',
+      'text-indent',
+      'text-justify',
+      'text-overflow',
+      'text-overflow-ellipsis',
+      'text-overflow-mode',
+      'text-rendering',
+      'text-outline',
+      'text-shadow',
+      'text-transform',
+      'text-wrap',
+      'word-wrap',
+      'word-break',
+
+      'text-emphasis',
+
+      'vertical-align',
+      'white-space',
+      'word-spacing',
+      'hyphens',
+
+      'src',
+      'cursor',
+      '-webkit-appearance'
+    ]
+  }
+}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -19,7 +19,7 @@ module.exports = {
   ],
   plugins: ['stylelint-order'],
   rules: {
-    'scss/comment-no-loud': false,
+    'scss/comment-no-loud': null,
 
     /**
      * Use the same rule ordering as GOVUK Frontend


### PR DESCRIPTION
This PR adds stylelint and configures it to GDS conventions

All scss files have been linted and fixed, except where a fix would affect specificity.  In those instances, the stylelint rule has been diasbled. 

A future task will be to go through the `stylelint-disable` comments and see if they can be resolved without breaking the component.
