### PR TITLE
style(sass): upgrade gulp-sass to use new sass js api and use quietDeps

### DIFF
--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -4,13 +4,13 @@ $moj-assets-path: "../" !default;
 $govuk-assets-path: "../" !default;
 
 // GOV.UK Frontend
-@import "govuk-frontend/dist/govuk/index";
+@import "node_modules/govuk-frontend/dist/govuk/index";
 
 // MOJ Frontend
 @import "src/moj/all";
 
 // highlight.js
-@import "highlight.js/scss/github";
+@import "node_modules/highlight.js/scss/github";
 
 // Custom documentation components
 @import "./components/accordions";

--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -4,13 +4,13 @@ $moj-assets-path: "../" !default;
 $govuk-assets-path: "../" !default;
 
 // GOV.UK Frontend
-@import "node_modules/govuk-frontend/dist/govuk/index";
+@import "govuk-frontend/dist/govuk/index";
 
 // MOJ Frontend
 @import "src/moj/all";
 
 // highlight.js
-@import "node_modules/highlight.js/scss/github";
+@import "highlight.js/scss/github";
 
 // Custom documentation components
 @import "./components/accordions";

--- a/docs/assets/stylesheets/govuk-frontend.scss
+++ b/docs/assets/stylesheets/govuk-frontend.scss
@@ -3,4 +3,4 @@ $govuk-assets-path: "../" !default;
 $govuk-global-styles: false;
 
 // GOV.UK Frontend
-@import "node_modules/govuk-frontend/dist/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/index";

--- a/gulp/build-styles.js
+++ b/gulp/build-styles.js
@@ -8,7 +8,12 @@ const sass = require('gulp-sass')(require('sass'))
 gulp.task('build:css', () => {
   return gulp
     .src('gulp/dist-scss/*.scss')
-    .pipe(sass())
+    .pipe(
+      sass({
+        loadPaths: ['node_modules', './'],
+        quietDeps: true
+      })
+    )
     .pipe(postcss([autoprefixer, cssnano]))
     .pipe(
       rename((path) => ({

--- a/gulp/build-styles.js
+++ b/gulp/build-styles.js
@@ -10,7 +10,7 @@ gulp.task('build:css', () => {
     .src('gulp/dist-scss/*.scss')
     .pipe(
       sass({
-        loadPaths: ['node_modules', './'],
+        loadPaths: ['./'],
         quietDeps: true
       })
     )

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -27,7 +27,12 @@ gulp.task('dist:javascript', () => {
 gulp.task('dist:css', () => {
   return gulp
     .src('gulp/dist-scss/*.scss')
-    .pipe(sass())
+    .pipe(
+      sass({
+        loadPaths: ['node_modules', './'],
+        quietDeps: true
+      })
+    )
     .pipe(postcss([autoprefixer, cssnano]))
     .pipe(
       rename((path) => ({

--- a/gulp/dist.js
+++ b/gulp/dist.js
@@ -29,7 +29,7 @@ gulp.task('dist:css', () => {
     .src('gulp/dist-scss/*.scss')
     .pipe(
       sass({
-        loadPaths: ['node_modules', './'],
+        loadPaths: ['./'],
         quietDeps: true
       })
     )

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -48,7 +48,9 @@ gulp.task('docs:styles', () => {
     .src('docs/assets/stylesheets/*.scss')
     .pipe(
       sass({
-        outputStyle: process.env.ENV == 'dev' ? 'expanded' : 'compressed'
+        loadPaths: ['node_modules', './'],
+        style: process.env.ENV === 'dev' ? 'expanded' : 'compressed',
+        quietDeps: true
       })
     )
     .pipe(gulp.dest('public/assets/stylesheets/'))
@@ -62,7 +64,7 @@ gulp.task('docs:scripts', () => {
       esbuild({
         outfile: `all.js`,
         target: 'es6',
-        minify: process.env.ENV != 'dev',
+        minify: process.env.ENV !== 'dev',
         bundle: true
       })
     )

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -48,7 +48,7 @@ gulp.task('docs:styles', () => {
     .src('docs/assets/stylesheets/*.scss')
     .pipe(
       sass({
-        loadPaths: ['node_modules', './'],
+        loadPaths: ['./'],
         style: process.env.ENV === 'dev' ? 'expanded' : 'compressed',
         quietDeps: true
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "gulp-rename": "^2.0.0",
         "gulp-rev": "^9.0.0",
         "gulp-rev-rewrite": "^5.0.0",
-        "gulp-sass": "^5.0.0",
+        "gulp-sass": "^6.0.0",
         "gulp-uglify": "^3.0.2",
         "gulp-zip": "^6.0.0",
         "highlight.js": "^11.0.0",
@@ -15809,11 +15809,10 @@
       }
     },
     "node_modules/gulp-sass": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
-      "integrity": "sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-6.0.0.tgz",
+      "integrity": "sha512-FGb4Uab4jnH2GnSfBGd6uW3+imvNodAGfsjGcUhEtpNYPVx+TK2tp5uh7MO0sSR7aIf1Sm544werc+zV7ejHHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-rev": "^9.0.0",
     "gulp-rev-rewrite": "^5.0.0",
-    "gulp-sass": "^5.0.0",
+    "gulp-sass": "^6.0.0",
     "gulp-uglify": "^3.0.2",
     "gulp-zip": "^6.0.0",
     "highlight.js": "^11.0.0",


### PR DESCRIPTION
Adding `quietDeps` removes a lot of noise when building the sass files. In order to use this, the `gulp-sass` dependency needed to be updated to the latest version which uses the new dart-sass js api.

