### PR TITLE
feat: 1126 build tier design

### DIFF
--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -1,12 +1,15 @@
 {% extends "./base.njk" %}
 
+{% import "./macros/tier.njk" as macros %}
+
+
 {% block content %}
+     {{ macros.tierLabel(tier, tierMessage, tierLink, tierUrl) }}
     <div class="app-layout__content">
         <h1 class="govuk-heading-xl">
           {% if not isIndex %}<span class="govuk-caption-xl">Components</span>{% endif %}
           {{ title }}
         </h1>
-
         {{ content | safe }}
 
         {% include "./partials/get-help-and-contribute.njk" %}

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -10,7 +10,7 @@
           {% if not isIndex %}<span class="govuk-caption-xl">Components</span>{% endif %}
           {{ title }}
         </h1>
-        
+
         {{ content | safe }}
 
         {% include "./partials/get-help-and-contribute.njk" %}

--- a/docs/_includes/layouts/component.njk
+++ b/docs/_includes/layouts/component.njk
@@ -10,6 +10,7 @@
           {% if not isIndex %}<span class="govuk-caption-xl">Components</span>{% endif %}
           {{ title }}
         </h1>
+        
         {{ content | safe }}
 
         {% include "./partials/get-help-and-contribute.njk" %}

--- a/docs/_includes/layouts/macros/tier.njk
+++ b/docs/_includes/layouts/macros/tier.njk
@@ -4,13 +4,13 @@
     {% set tierClass = "" %}
     
     {% if tier == "Reviewed" %}
-      {% set tierClass = "app-tier__content--reviewed" %}
+      {% set tierClass = "govuk-tag--green" %}
     {% elif tier == "Due for review" %}
-      {% set tierClass = "app-tier__content--due-for-review" %}
+      {% set tierClass = "govuk-tag--orange" %}
     {% elif tier == "Community" %}
-      {% set tierClass = "app-tier__content--community" %}
+      {% set tierClass = "govuk-tag--light-blue" %}
     {% elif tier == "Archived" %}
-      {% set tierClass = "app-tier__content--archived" %}
+      {% set tierClass = "govuk-tag--grey" %}
     {% endif %}
 
     <div class="app-tier">

--- a/docs/_includes/layouts/macros/tier.njk
+++ b/docs/_includes/layouts/macros/tier.njk
@@ -1,0 +1,30 @@
+{% macro tierLabel(tier, tierMessage, tierUrl) %}
+  {% if tier %}
+    
+    {% set tierClass = "" %}
+    
+    {% if tier == "Reviewed" %}
+      {% set tierClass = "app-tier__content--reviewed" %}
+    {% elif tier == "Due for review" %}
+      {% set tierClass = "app-tier__content--due-for-review" %}
+    {% elif tier == "Community" %}
+      {% set tierClass = "app-tier__content--community" %}
+    {% elif tier == "Archived" %}
+      {% set tierClass = "app-tier__content--archived" %}
+    {% endif %}
+
+    <div class="app-tier">
+      <p class="govuk-phase-banner__content govuk-!-margin-bottom-0">
+        <strong class="govuk-tag govuk-phase-banner__content__tag {{ tierClass }}">
+          {{ tier }}
+        </strong>
+        <span class="govuk-phase-banner__text">
+          {{ tierMessage }}
+          {% if tierUrl %}
+            <a class="govuk-link" href="{{ tierUrl }}">{{ tierUrl }}</a>
+          {% endif %}
+        </span>
+      </p>
+    </div>
+  {% endif %}
+{% endmacro %}

--- a/docs/_includes/layouts/macros/tier.njk
+++ b/docs/_includes/layouts/macros/tier.njk
@@ -3,7 +3,7 @@
     {% set tierClass = {
       "Reviewed": "govuk-tag--green",
       "Due for review": "govuk-tag--orange",
-      "Community": "govuk-tag--light-blue",
+      "Community component": "govuk-tag--light-blue",
       "Archived": "govuk-tag--grey"
     }[tier] or "" %}
 

--- a/docs/_includes/layouts/macros/tier.njk
+++ b/docs/_includes/layouts/macros/tier.njk
@@ -15,7 +15,7 @@
 
         {% if tierMessage %}
           <span class="govuk-phase-banner__text">
-            {{ tierMessage }} {{siteName}}
+            {{ tierMessage }} 
             {% if tierLink %}
               <a class="govuk-link" href="{{ tierUrl | default('#') }}">{{ tierLink }}</a>
             {% endif %}

--- a/docs/_includes/layouts/macros/tier.njk
+++ b/docs/_includes/layouts/macros/tier.njk
@@ -1,29 +1,26 @@
-{% macro tierLabel(tier, tierMessage, tierUrl) %}
+{% macro tierLabel(tier, tierMessage, tierLink, tierUrl) %}
   {% if tier %}
-    
-    {% set tierClass = "" %}
-    
-    {% if tier == "Reviewed" %}
-      {% set tierClass = "govuk-tag--green" %}
-    {% elif tier == "Due for review" %}
-      {% set tierClass = "govuk-tag--orange" %}
-    {% elif tier == "Community" %}
-      {% set tierClass = "govuk-tag--light-blue" %}
-    {% elif tier == "Archived" %}
-      {% set tierClass = "govuk-tag--grey" %}
-    {% endif %}
+    {% set tierClass = {
+      "Reviewed": "govuk-tag--green",
+      "Due for review": "govuk-tag--orange",
+      "Community": "govuk-tag--light-blue",
+      "Archived": "govuk-tag--grey"
+    }[tier] or "" %}
 
     <div class="app-tier">
       <p class="govuk-phase-banner__content govuk-!-margin-bottom-0">
-        <strong class="govuk-tag govuk-phase-banner__content__tag {{ tierClass }}">
+        <span class="govuk-tag govuk-phase-banner__content__tag {{ tierClass }}">
           {{ tier }}
-        </strong>
-        <span class="govuk-phase-banner__text">
-          {{ tierMessage }}
-          {% if tierUrl %}
-            <a class="govuk-link" href="{{ tierUrl }}">{{ tierUrl }}</a>
-          {% endif %}
         </span>
+
+        {% if tierMessage %}
+          <span class="govuk-phase-banner__text">
+            {{ tierMessage }} {{siteName}}
+            {% if tierLink %}
+              <a class="govuk-link" href="{{ tierUrl | default('#') }}">{{ tierLink }}</a>
+            {% endif %}
+          </span>
+        {% endif %}
       </p>
     </div>
   {% endif %}

--- a/docs/assets/stylesheets/application.scss
+++ b/docs/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@ $govuk-assets-path: "../" !default;
 @import "./components/page";
 @import "./components/menu-toggle";
 @import "./components/app-card";
+@import "./components/tier";
 @import "./components/documentation_tabs";
 
 @view-transition {

--- a/docs/assets/stylesheets/components/_tier.scss
+++ b/docs/assets/stylesheets/components/_tier.scss
@@ -5,4 +5,13 @@
   position: sticky;
   top: 0;
   z-index: 1000;
+  @include govuk-media-query($until: desktop) {
+    position: relative;
+  }
+  p {
+    @include govuk-font($size: 16, $line-height: 20px);
+    @include govuk-media-query($until: desktop) {
+      @include govuk-font($size: 14, $line-height: 16px);
+    }
+  }
 }

--- a/docs/assets/stylesheets/components/_tier.scss
+++ b/docs/assets/stylesheets/components/_tier.scss
@@ -1,0 +1,27 @@
+.app-tier {
+  background-color: #fff;
+  padding: 10px 20px;
+  border-bottom: 1px solid #b1b4b6;
+  &__content {
+    &--reviewed {
+      background-color: rgba(204, 226, 216, 1);
+      color: rgba(0, 90, 48, 1);
+    }
+    &--due-for-review {
+      background-color: rgba(252, 214, 195, 1);
+      color: rgba(110, 54, 25, 1);
+    }
+    &--due-for-review {
+      background-color: rgba(252, 214, 195, 1);
+      color: rgba(110, 54, 25, 1);
+    }
+    &--community {
+      background-color: rgba(187, 212, 234, 1);
+      color: rgba(12, 45, 74, 1);
+    }
+    &--archived {
+      background-color: rgba(229, 230, 231, 1);
+      color: rgba(40, 45, 48, 1);
+    }
+  }
+}

--- a/docs/assets/stylesheets/components/_tier.scss
+++ b/docs/assets/stylesheets/components/_tier.scss
@@ -1,6 +1,8 @@
-
 .app-tier {
-  background-color: #fff;
-  padding: 10px 20px;
+  background-color: govuk-colour("white");
+  padding: govuk-spacing(2) govuk-spacing(4);
   border-bottom: 1px solid $govuk-border-colour;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
 }

--- a/docs/assets/stylesheets/components/_tier.scss
+++ b/docs/assets/stylesheets/components/_tier.scss
@@ -1,27 +1,6 @@
+
 .app-tier {
   background-color: #fff;
   padding: 10px 20px;
-  border-bottom: 1px solid #b1b4b6;
-  &__content {
-    &--reviewed {
-      background-color: rgba(204, 226, 216, 1);
-      color: rgba(0, 90, 48, 1);
-    }
-    &--due-for-review {
-      background-color: rgba(252, 214, 195, 1);
-      color: rgba(110, 54, 25, 1);
-    }
-    &--due-for-review {
-      background-color: rgba(252, 214, 195, 1);
-      color: rgba(110, 54, 25, 1);
-    }
-    &--community {
-      background-color: rgba(187, 212, 234, 1);
-      color: rgba(12, 45, 74, 1);
-    }
-    &--archived {
-      background-color: rgba(229, 230, 231, 1);
-      color: rgba(40, 45, 48, 1);
-    }
-  }
+  border-bottom: 1px solid $govuk-border-colour;
 }

--- a/docs/components/add-another.md
+++ b/docs/components/add-another.md
@@ -1,6 +1,10 @@
 ---
 layout: layouts/component.njk
 title: Add another
+tier: "Archived"
+tierMessage: "Created: Aug 2024"
+tierLink: "Learn more about 'reviewed' components."
+tierUrl: "#"
 type: component
 githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/686
 eleventyNavigation:

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -2,6 +2,10 @@
 layout: layouts/component.njk
 title: Badge
 type: component
+tier: "Reviewed"
+tierMessage: "Created: Aug 2024"
+tierLink: "Learn more about 'reviewed' components."
+tierUrl: "#"
 githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/687
 eleventyNavigation:
   parent: Components


### PR DESCRIPTION

### Issue or RFC endorsed by the maintainers

Build tier design
[#1126](https://github.com/ministryofjustice/moj-frontend/issues/1126)

### Description of the change

This is to allow maintainers to be able to update the .md docs with a specification of a tier, via the following Front Matter attributes:

tier: "Archived" |  "Due for review" | "Reviewed" | "Community component"
tierMessage: "For example (Created: Feb 2025)"
tierLink: "For example (Learn more about 'reviewed' components.)"
tierUrl: "(url of page link)"

### Alternative designs

No alternative designs

### Possible drawbacks

None suggested

### Verification process

Tested via chrome & responsive view


### Release notes

Added new tier macro to follow design