### PR TITLE
Removing sub nav tabs from documentation pages

### DIFF
--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -13,10 +13,6 @@ eleventyNavigation:
 
 <span class="govuk-caption-xl">The alert component uses visual design to display a notification to users. It has a range of use cases.</span>
 
-{% tabs "Contents" %}
-
-{% tab "Overview" %}
-
 {% example "/examples/alert" %}
 
 ## Overview
@@ -133,10 +129,6 @@ This alert pauses the user with a prominent message. This prioritisation should 
 
 An alert needs a title, which does not need to be displayed as a heading. The title gives each alert a unique label and helps screenreaders to identify the alert. It does not have to be read out.
 
-{% endtab %}
-
-{% tab "How to use" %}
-
 ## How to use
 
 The alert works best when it contains a single, succinct message.
@@ -218,10 +210,6 @@ An alert should not be placed on a coloured background because:
 - the colour contrast between the border and page may not be accessible
 - the background may distract from the border colour and change the emphasis of the message
 
-{% endtab %}
-
-{% tab "Examples" %}
-
 ## Examples
 
 ### Alerts in a case management system
@@ -235,9 +223,5 @@ An error and success alert under an H1 shows a user that one of their tasks fail
 Alerts positioned inline with other content help people to understand what the message relates to. In this example the heading level of the alert component should be changed to H3 as it appears within an H2 heading.
 
 <p><img src="{{ 'assets/images/alert-example-contextual.png' | rev | url }}" alt="A warning alert with heading level 3 is shown beneath a heading level 2 on an MoJ webpage to highlight the importance of maintaining heading structure.'"></p>
-
-{% endtab %}
-
-{% endtabs %}
 
 <hr />

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -11,7 +11,7 @@ eleventyNavigation:
   excerpt: "Use the alert component to display a prominent message and related actions to take."
 ---
 
-<span class="govuk-caption-xl">The alert component uses visual design to display a notification to users. It has a range of use cases.</span>
+<span class="govuk-caption-xl govuk-!-margin-bottom-9">The alert component uses visual design to display a notification to users. It has a range of use cases.</span>
 
 {% example "/examples/alert" %}
 

--- a/docs/components/button-menu.md
+++ b/docs/components/button-menu.md
@@ -13,10 +13,6 @@ eleventyNavigation:
 
 <span class="govuk-caption-xl">The button menu is a versatile component that allows users to view tasks as buttons in a collapsible menu.</span>
 
-{% tabs "Contents" %}
-
-{% tab "Overview" %}
-
 {% example "/examples/button-menu", 250 %}
 
 ## Overview
@@ -59,10 +55,6 @@ There’s also the:
 - [page header actions component](/components/page-header-actions/)
 - [summary list component on the GOV.UK Design System](https://design-system.service.gov.uk/components/summary-list/)
 - [identity bar component](/components/identity-bar/)
-
-{% endtab %}
-
-{% tab "How to use" %}
 
 ## How to use
 
@@ -128,10 +120,6 @@ Users may believe that menu buttons with the same title (particularly generic ti
 
 Content can run into a second line.
 
-{% endtab %}
-
-{% tab "Examples" %}
-
 ## Examples
 
 ### Within a case management system
@@ -145,9 +133,5 @@ The location of the buttons helps users to know what the tasks relate to.
 Adding a button menu to the multi select component helps users complete common tasks quickly, for example assigning cases.
 
 <p><img src="{{ 'assets/images/button-menu-multi-select-example-2024.png' | rev | url }}" alt="An example of a button menu and GOV.UK default button on a Ministry of Justice webpage. The grey button menu is to the right of the green button. This is next to the H2 title 'Case management'. Both are below the H1 title 'Case management'. The title of the green button is 'Record review' and the button menu is 'Print options', which contains: Print case, Print review, Print investigation and Print referral."></p>
-
-{% endtab %}
-
-{% endtabs %}
 
 <hr />

--- a/docs/components/button-menu.md
+++ b/docs/components/button-menu.md
@@ -11,7 +11,7 @@ eleventyNavigation:
   excerpt: "The button menu is a versatile component that allows users to view tasks as buttons in a collapsible menu."
 ---
 
-<span class="govuk-caption-xl">The button menu is a versatile component that allows users to view tasks as buttons in a collapsible menu.</span>
+<span class="govuk-caption-xl govuk-!-margin-bottom-9">The button menu is a versatile component that allows users to view tasks as buttons in a collapsible menu.</span>
 
 {% example "/examples/button-menu", 250 %}
 

--- a/docs/components/date-picker.md
+++ b/docs/components/date-picker.md
@@ -13,10 +13,6 @@ eleventyNavigation:
 
 <span class="govuk-caption-xl">The date picker component enables users to select a date from a calendar. </span>
 
-{% tabs "Contents" %}
-
-{% tab "Overview" %}
-
 {% example "/examples/date-picker", 590 %}
 
 ## Overview
@@ -49,10 +45,6 @@ Date pickers are fully navigable using a keyboard, but can be slow for keyboard-
 
 There's also the ['Ask users for dates' pattern in the GOV.UK Design System](https://design-system.service.gov.uk/patterns/dates/).
 
-{% endtab %}
-
-{% tab "Accessibility issues" %}
-
 ## Accessibility issues
 
 There’s an accessibility issue with the date picker component. If you’re using it in your service you need to add these issue details to your accessibility statement.
@@ -60,10 +52,6 @@ There’s an accessibility issue with the date picker component. If you’re usi
 ### No focus indicator shown when navigating between dates (NVDA only)
 
 When people use the screen reader software NVDA, no focus indicator is displayed when they navigate between dates. This only happens with NVDA software. This fails [WCAG 2.2 success criterion 2.4.7 (Focus visible)](https://www.w3.org/TR/WCAG22/#focus-visible). We’re aware of this issue and plan to implement a fix by April 2025.
-
-{% endtab %}
-
-{% tab "How to use" %}
 
 ## How to use
 
@@ -128,10 +116,6 @@ Follow the [GOV.UK Design System guidance on error messages](https://design-syst
 
 If you're using more than one date picker, give each text field its own error summary and message (even if the error is the same).
 
-{% endtab %}
-
-{% tab "Examples" %}
-
 ## Examples
 
 ### Filtering information with a date picker
@@ -141,9 +125,5 @@ If you're using more than one date picker, give each text field its own error su
 ### Asking a question with a date picker
 
 <p><img src="{{ 'assets/images/date-picker-question-example-2024.png' | rev | url }}" alt="A screenshot with the title 'What date do you want to view appointments for?' Underneath is the title 'Date' and then a text input field with the calendar icon. Underneath that is a green 'Continue' button."></p>
-
-{% endtab %}
-
-{% endtabs %}
 
 <hr />

--- a/docs/components/date-picker.md
+++ b/docs/components/date-picker.md
@@ -11,7 +11,7 @@ eleventyNavigation:
   excerpt: "The date picker component enables users to select a date from a calendar."
 ---
 
-<span class="govuk-caption-xl">The date picker component enables users to select a date from a calendar. </span>
+<span class="govuk-caption-xl govuk-!-margin-bottom-9">The date picker component enables users to select a date from a calendar. </span>
 
 {% example "/examples/date-picker", 590 %}
 

--- a/docs/components/interruption-card.md
+++ b/docs/components/interruption-card.md
@@ -13,10 +13,6 @@ eleventyNavigation:
 
 <span class="govuk-caption-xl">The interruption card component pauses a user’s journey with important information.</span>
 
-{% tabs "Contents" %}
-
-{% tab "Overview" %}
-
 {% example "/examples/interruption-card", 590 %}
 
 ## Overview
@@ -119,10 +115,6 @@ There’s also the:
 - [GOV.UK Design System panel](https://design-system.service.gov.uk/components/panel/)
 - [GOV.UK Design System notification banner](https://design-system.service.gov.uk/components/notification-banner/)
 
-{% endtab %}
-
-{% tab "How to use" %}
-
 ## How to use
 
 ### What to add to it
@@ -180,9 +172,5 @@ If a lot of interruption cards are emerging in a service, it might be a sign tha
 Users completing the same journey multiple times in a service will become overexposed to a particular interruption card. This could be a poor user experience if the card is used to highlight something important and the user has already seen it several times.
 
 Consider limiting the amount of times a particular interruption card is shown to users at the same stage of the journey.
-
-{% endtab %}
-
-{% endtabs %}
 
 <hr />

--- a/docs/components/interruption-card.md
+++ b/docs/components/interruption-card.md
@@ -11,7 +11,7 @@ eleventyNavigation:
   excerpt: "The interruption card component stops users in a flow with important information."
 ---
 
-<span class="govuk-caption-xl">The interruption card component pauses a user’s journey with important information.</span>
+<span class="govuk-caption-xl govuk-!-margin-bottom-9">The interruption card component pauses a user’s journey with important information.</span>
 
 {% example "/examples/interruption-card", 590 %}
 


### PR DESCRIPTION
Sub nav component (tabs) removed from alert, button menu, date picker, and interruption card component.
