### PR TITLE
fix: revert to `$` for jQuery external global

### DIFF
--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -21,7 +21,7 @@ function compileScripts(assetPath, { srcPath, destPath, output = {} }) {
       input: join(srcPath, assetPath),
       plugins: [
         externalGlobals({
-          jquery: 'window.jQuery'
+          jquery: '$'
         }),
         nodeResolve(),
         commonjs()


### PR DESCRIPTION
This PR fixes issue https://github.com/ministryofjustice/moj-frontend/issues/1188