### PR TITLE
ci: switch publish action to workflow_dispatch trigger

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,7 +44,6 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
 
-
     steps:
       - name: Set commit status as pending
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,6 +44,7 @@ jobs:
       matrix:
         node-version: [18.x, 20.x, 22.x]
 
+
     steps:
       - name: Set commit status as pending
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,13 +1,6 @@
 name: Publish package
 
 on:
-  pull_request:
-
-  push:
-    branches:
-      - 'main'
-      - '*.*.x'
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Simple initial PR to set publishing a new version of the package to a manual trigger
