### PR TITLE
fix(alert): fix line-height on smaller screens

### DIFF
--- a/src/moj/components/alert/_alert.scss
+++ b/src/moj/components/alert/_alert.scss
@@ -72,9 +72,12 @@
   @include govuk-link-print-friendly;
 }
 
-.moj-alert__content h2,
-.moj-alert__content h3,
-.moj-alert__content h4 {
+.moj-alert__heading {
+  @include govuk-text-colour;
+  @include govuk-font-size($size: 24);
+  @include govuk-typography-weight-bold;
+  display: block;
+  margin-top: 0;
   margin-bottom: govuk-px-to-rem(5px);
 
   @include govuk-media-query($from: tablet) {

--- a/src/moj/components/alert/_alert.scss
+++ b/src/moj/components/alert/_alert.scss
@@ -75,20 +75,16 @@
 .moj-alert__content h2,
 .moj-alert__content h3,
 .moj-alert__content h4 {
-  margin-bottom: 2px;
-  line-height: 30px;
-}
-
-.moj-alert--with-heading .moj-alert__content {
-  // No padding needed when there is a heading
-  padding-top: 0;
+  margin-bottom: govuk-px-to-rem(5px);
 
   @include govuk-media-query($from: tablet) {
-    padding-top: 0;
+    margin-bottom: govuk-px-to-rem(3px);
   }
 }
 
-.moj-alert__content *:last-child {
+.moj-alert__content p:last-child,
+.moj-alert__content a:last-child,
+.moj-alert__content ul:last-child {
   margin-bottom: 0;
 }
 

--- a/src/moj/components/alert/template.njk
+++ b/src/moj/components/alert/template.njk
@@ -65,7 +65,7 @@
   </div>
   <div class="moj-alert__content">
     {%- if params.showTitleAsHeading and content %}
-      <{{-headingTag }} class="govuk-heading-m">
+      <{{-headingTag }} class="moj-alert__heading">
         {{- params.title }}
       </{{-headingTag}}>
     {%- endif %}


### PR DESCRIPTION
Tweaks to the line-height and margins for headings on the alert component.  Instead of a fixed line-height(!?) the headings now use the default line height for govuk headings.  This also required small tweaks to the padding and margins for the headings too.

**Before:**
![image](https://github.com/user-attachments/assets/78749145-ab69-4f6d-b63a-14772ba9b6af)

**After:**
![image](https://github.com/user-attachments/assets/bc2b9837-e7df-4785-ab11-c8e7f7224e0f)
