### PR TITLE
Fixing typo on home page masthead.

### DIFF
--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -16,10 +16,7 @@
       }) }}
 
       <p class="govuk-body">
-        Use the MoJ Design System alongside the
-        <a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/">
-          GOV.UK Design System
-        </a>.
+        Use the MoJ Design System alongside the<a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/">GOV.UK Design System</a>.
       </p>
       <p class="govuk-!-margin-bottom-0">
         The MoJ Design System enables teams to avoid repetition by learning from the work and experiences of others.

--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -16,7 +16,7 @@
       }) }}
 
       <p class="govuk-body">
-        Use the MoJ Design System alongside the<a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/">GOV.UK Design System</a>.
+        Use the MoJ Design System alongside the <a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/">GOV.UK Design System</a>.
       </p>
       <p class="govuk-!-margin-bottom-0">
         The MoJ Design System enables teams to avoid repetition by learning from the work and experiences of others.


### PR DESCRIPTION
- Rogue space at the end of text on the documentation site home page.
- FIX: Space removed.