### PR TITLE
ci(publishing): add github.sha for commit status action

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -38,6 +38,7 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ github.sha }}
           status: pending
           context: Tests
 
@@ -76,6 +77,7 @@ jobs:
         uses: myrotvorets/set-commit-status-action@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ github.sha }}
           status: ${{ needs.test.result }}
           context: Tests
 


### PR DESCRIPTION
Provides the sha of the latest commit to the set commit status action.