### PR TITLE
fix(alert): avoid Sass deprecated `mixed-decls`

### DIFF
--- a/src/moj/components/alert/_alert.scss
+++ b/src/moj/components/alert/_alert.scss
@@ -73,12 +73,12 @@
 }
 
 .moj-alert__heading {
-  @include govuk-text-colour;
-  @include govuk-font-size($size: 24);
-  @include govuk-typography-weight-bold;
   display: block;
   margin-top: 0;
   margin-bottom: govuk-px-to-rem(5px);
+  @include govuk-text-colour;
+  @include govuk-font-size($size: 24);
+  @include govuk-typography-weight-bold;
 
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-px-to-rem(3px);


### PR DESCRIPTION
Fixing a quick `mixed-decls` Sass warning that crept in

```console
Deprecation Warning [mixed-decls]: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls

    ┌──> ../../../../src/moj/components/alert/_alert.scss
80  │     margin-top: 0;
    │     ^^^^^^^^^^^^^ declaration
    ╵
    ┌──> ../../../govuk-frontend/dist/govuk/vendor/_sass-mq.scss
229 │ ┌         @media #{$media-type + $media-query} {
230 │ │             @content;
231 │ │         }
    │ └─── nested rule
    ╵
    ../../../../src/moj/components/alert/_alert.scss 80:3      @forward
    ../../../../src/moj/components/_all.scss 3:1               @forward
    ../../../../src/moj/all.scss 24:1                          @forward
    ../../../../docs/assets/stylesheets/moj-frontend.scss 2:1  @forward
    ../../../../docs/assets/stylesheets/application.scss 5:1   root stylesheet
```