### PR TITLE
docs: fix copy button placement for JavaScript example

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -25,13 +25,12 @@
   </ul>
 
   <div class="app-tabs__panel app-tabs__panel--hidden" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
-
-  <div data-module="app-copy" style="position:relative;">
+    <div class="app-example__code" data-module="app-copy">
 
 ```html
 {{ htmlCode | safe }}
 ```
-  </div>
+    </div>
   </div>
 
   <div class="app-tabs__panel app-tabs__panel--hidden" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
@@ -51,27 +50,24 @@
   </details>
 {% endif %}
 
-  <div data-module="app-copy" style="position:relative;">
+    <div class="app-example__code" data-module="app-copy">
 
 ```jinja
 {{ nunjucksCode | safe }}
 ```
 
-  </div>
-
+    </div>
   </div>
 
 {% if jsCode %}
   <div class="app-tabs__panel app-tabs__panel--hidden" id="js-default-{{ id }}" role="tabpanel" aria-labelledby="tab_js-default-{{ id }}">
-
-  <div data-module="app-copy" style="position:relative;">
+    <div class="app-example__code" data-module="app-copy">
 
 ```js
 {{ jsCode | safe }}
 ```
 
-  </div>
-
+    </div>
   </div>
 {% endif %}
 

--- a/docs/assets/stylesheets/components/_example.scss
+++ b/docs/assets/stylesheets/components/_example.scss
@@ -11,6 +11,10 @@
   background-color: govuk-colour("white");
 }
 
+.app-example__code {
+  position: relative;
+}
+
 .app-example__frame {
   display: block;
   width: 100%;


### PR DESCRIPTION
The "Copy code" button lacks its top/right offset but only on the JavaScript tab

I've also tidied the inline `style="position:relative;"` attribute into `.app-example__code`

<img width="288" alt="Copy code button" src="https://github.com/user-attachments/assets/bd02033a-4885-46e7-bd5a-9af0d5922138" />
