### PR TITLE
feat: split out “base” Sass partial to align with GOV.UK Frontend

### DIFF
--- a/src/moj/_base.scss
+++ b/src/moj/_base.scss
@@ -1,0 +1,8 @@
+// Declare all settings
+@forward "settings/all";
+
+// Configure GOV.UK Frontend
+@forward "vendor/govuk-frontend";
+
+// Partials that depend on GOV.UK Frontend
+@forward "helpers/all";

--- a/src/moj/all.scss
+++ b/src/moj/all.scss
@@ -1,26 +1,4 @@
-// Declare all settings
-@forward "settings/all";
-
-// Use settings for overrides
-@use "settings/all" as *;
-
-// GOV.UK Frontend with settings
-@forward "vendor/govuk-frontend/base" with (
-  // Assets override
-  $govuk-assets-path: $moj-assets-path,
-  $govuk-images-path: $moj-images-path,
-  $govuk-fonts-path: $moj-fonts-path,
-
-  // Measurements override
-  $govuk-gutter: $moj-gutter,
-  $govuk-page-width: $moj-page-width,
-
-  // Typography override
-  $govuk-font-family: $moj-font-family,
-  $govuk-include-default-font-face: $moj-include-default-font-face
-);
-
-@forward "helpers/all";
+@forward "base";
 @forward "objects/all";
 @forward "components/all";
 @forward "utilities/all";

--- a/src/moj/components/action-bar/_action-bar.scss
+++ b/src/moj/components/action-bar/_action-bar.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-action-bar {
   font-size: 0; // Removes white space

--- a/src/moj/components/add-another/_add-another.scss
+++ b/src/moj/components/add-another/_add-another.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #ADD ANOTHER

--- a/src/moj/components/alert/_alert.scss
+++ b/src/moj/components/alert/_alert.scss
@@ -1,7 +1,7 @@
 @use "../../helpers/links" as *;
 @use "../../objects/width-container" as *;
 @use "../../settings/colours" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-alert {
   display: -ms-grid;

--- a/src/moj/components/badge/_badge.scss
+++ b/src/moj/components/badge/_badge.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #BADGE

--- a/src/moj/components/banner/_banner.scss
+++ b/src/moj/components/banner/_banner.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #BANNER

--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -1,5 +1,5 @@
 @use "../../settings/colours" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-button-menu {
   display: inline-block;

--- a/src/moj/components/cookie-banner/_cookie-banner.scss
+++ b/src/moj/components/cookie-banner/_cookie-banner.scss
@@ -1,5 +1,5 @@
 @use "../../objects/width-container" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-cookie-banner {
   box-sizing: border-box;

--- a/src/moj/components/currency-input/_currency-input.scss
+++ b/src/moj/components/currency-input/_currency-input.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #DENOTE

--- a/src/moj/components/date-picker/_date-picker.scss
+++ b/src/moj/components/date-picker/_date-picker.scss
@@ -1,5 +1,5 @@
 @use "../../settings/colours" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-datepicker {
   position: relative;

--- a/src/moj/components/filter/_filter.scss
+++ b/src/moj/components/filter/_filter.scss
@@ -1,5 +1,5 @@
 @use "../../settings/assets" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #FILTER

--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -1,5 +1,5 @@
 @use "../../objects/width-container" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #HEADER

--- a/src/moj/components/identity-bar/_identity-bar.scss
+++ b/src/moj/components/identity-bar/_identity-bar.scss
@@ -1,5 +1,5 @@
 @use "../../objects/width-container" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #IDENTITY BAR

--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-interruption-card {
   margin-bottom: govuk-spacing(3);

--- a/src/moj/components/messages/_messages.scss
+++ b/src/moj/components/messages/_messages.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #MESSAGES

--- a/src/moj/components/multi-file-upload/_multi-file-upload.scss
+++ b/src/moj/components/multi-file-upload/_multi-file-upload.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-multi-file-upload {
   margin-bottom: 40px;

--- a/src/moj/components/notification-badge/_notification-badge.scss
+++ b/src/moj/components/notification-badge/_notification-badge.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #NOTIFICATION BADGE

--- a/src/moj/components/organisation-switcher/_organisation-switcher.scss
+++ b/src/moj/components/organisation-switcher/_organisation-switcher.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #ORGANISATION SWITCHER

--- a/src/moj/components/page-header-actions/_page-header-actions.scss
+++ b/src/moj/components/page-header-actions/_page-header-actions.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-page-header-actions {
   display: flex;

--- a/src/moj/components/pagination/_pagination.scss
+++ b/src/moj/components/pagination/_pagination.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-pagination {
   // text-align: center;

--- a/src/moj/components/password-reveal/_password-reveal.scss
+++ b/src/moj/components/password-reveal/_password-reveal.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #PASSWORD SHOW/HIDE

--- a/src/moj/components/primary-navigation/_primary-navigation.scss
+++ b/src/moj/components/primary-navigation/_primary-navigation.scss
@@ -1,5 +1,5 @@
 @use "../../objects/width-container" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #PRIMARY NAVIGATION

--- a/src/moj/components/progress-bar/_progress-bar.scss
+++ b/src/moj/components/progress-bar/_progress-bar.scss
@@ -1,5 +1,5 @@
 @use "../../settings/assets" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #PROGRESS BAR

--- a/src/moj/components/rich-text-editor/_rich-text-editor.scss
+++ b/src/moj/components/rich-text-editor/_rich-text-editor.scss
@@ -1,5 +1,5 @@
 @use "../../settings/assets" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #RICH TEXT EDITOR

--- a/src/moj/components/search-toggle/search-toggle.scss
+++ b/src/moj/components/search-toggle/search-toggle.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-search-toggle__button {
   display: inline-block;

--- a/src/moj/components/search/_search.scss
+++ b/src/moj/components/search/_search.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 .moj-search {
   font-size: 0; // Fallback

--- a/src/moj/components/side-navigation/_side-navigation.scss
+++ b/src/moj/components/side-navigation/_side-navigation.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #SIDE NAVIGATION

--- a/src/moj/components/sortable-table/_sortable-table.scss
+++ b/src/moj/components/sortable-table/_sortable-table.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 [aria-sort] button,
 [aria-sort] button:hover {

--- a/src/moj/components/sub-navigation/_sub-navigation.scss
+++ b/src/moj/components/sub-navigation/_sub-navigation.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #SECONDARY NAV

--- a/src/moj/components/tag/_tag.scss
+++ b/src/moj/components/tag/_tag.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #TAG

--- a/src/moj/components/task-list/_task-list.scss
+++ b/src/moj/components/task-list/_task-list.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #TASK LIST

--- a/src/moj/components/ticket-panel/_ticket-panel.scss
+++ b/src/moj/components/ticket-panel/_ticket-panel.scss
@@ -1,4 +1,4 @@
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #TICKET PANEL

--- a/src/moj/components/timeline/_timeline.scss
+++ b/src/moj/components/timeline/_timeline.scss
@@ -1,5 +1,5 @@
 @use "../../settings/assets" as *;
-@use "../../vendor/govuk-frontend/base" as *;
+@use "../../vendor/govuk-frontend" as *;
 
 /* ==========================================================================
    #TIMELINE

--- a/src/moj/helpers/_links.scss
+++ b/src/moj/helpers/_links.scss
@@ -1,6 +1,6 @@
 @use "sass:color";
 @use "../settings/colours" as *;
-@use "../vendor/govuk-frontend/base" as *;
+@use "../vendor/govuk-frontend" as *;
 
 @mixin moj-link-style-warning {
   &:link,

--- a/src/moj/objects/_button-group.scss
+++ b/src/moj/objects/_button-group.scss
@@ -1,4 +1,4 @@
-@use "../vendor/govuk-frontend/base" as *;
+@use "../vendor/govuk-frontend" as *;
 
 // Button groups can be used to group buttons and links together as a group.
 //

--- a/src/moj/objects/_filter-layout.scss
+++ b/src/moj/objects/_filter-layout.scss
@@ -1,4 +1,4 @@
-@use "../vendor/govuk-frontend/base" as *;
+@use "../vendor/govuk-frontend" as *;
 
 .moj-filter-layout {
   @include govuk-clearfix;

--- a/src/moj/objects/_scrollable-pane.scss
+++ b/src/moj/objects/_scrollable-pane.scss
@@ -1,4 +1,4 @@
-@use "../vendor/govuk-frontend/base" as *;
+@use "../vendor/govuk-frontend" as *;
 
 .moj-scrollable-pane {
   // stylelint-disable scss/dollar-variable-pattern

--- a/src/moj/objects/_width-container.scss
+++ b/src/moj/objects/_width-container.scss
@@ -1,5 +1,5 @@
 @use "../settings/measurements" as *;
-@use "../vendor/govuk-frontend/base" as *;
+@use "../vendor/govuk-frontend" as *;
 
 @mixin moj-width-container($width: $moj-page-width) {
   // Limit the width of the container to the page width

--- a/src/moj/vendor/govuk-frontend/_index.scss
+++ b/src/moj/vendor/govuk-frontend/_index.scss
@@ -1,0 +1,21 @@
+// Declare all settings
+@forward "../../settings/all";
+
+// Use settings for overrides
+@use "../../settings/all" as *;
+
+// GOV.UK Frontend with settings
+@forward "base" with (
+  // Assets override
+  $govuk-assets-path: $moj-assets-path,
+  $govuk-images-path: $moj-images-path,
+  $govuk-fonts-path: $moj-fonts-path,
+
+  // Measurements override
+  $govuk-gutter: $moj-gutter,
+  $govuk-page-width: $moj-page-width,
+
+  // Typography override
+  $govuk-font-family: $moj-font-family,
+  $govuk-include-default-font-face: $moj-include-default-font-face
+);


### PR DESCRIPTION
This PR adds support for Sass `moj/base` alongside `moj/all`

We likely won't document this but it avoids having to make a breaking change in future

See the [**Import specific parts using Sass** GOV.UK Frontend guidance](https://frontend.design-system.service.gov.uk/import-css/#import-specific-parts-using-sass)