### PR TITLE
feat: remove duplicate `@font-face` already in GOV.UK Frontend

### DIFF
--- a/docs/assets/stylesheets/moj-frontend.scss
+++ b/docs/assets/stylesheets/moj-frontend.scss
@@ -1,4 +1,2 @@
 // MOJ Frontend
-@forward "../../../src/moj/all" with (
-  $moj-include-default-font-face: false
-);
+@forward "../../../src/moj/all";

--- a/src/moj/settings/_typography.scss
+++ b/src/moj/settings/_typography.scss
@@ -8,9 +8,6 @@
 
 $moj-font-family: "GDS Transport", arial, sans-serif !default;
 
-/// Include the default @font-face declarations
-///
-/// Defaults to true if "GDS Transport" appears in the $moj-font-family
-/// setting.
+/// Exclude @font-face declarations already included in GOV.UK Frontend
 
-$moj-include-default-font-face: if(list.index($moj-font-family, "GDS Transport"), true, false) !default;
+$moj-include-default-font-face: false;


### PR DESCRIPTION
This PR sets the `$moj-include-default-font-face: true` flag by default

It was missed from this issue where we only set it for the docs build:

* https://github.com/ministryofjustice/moj-frontend/issues/1175

We don't we need to duplicate the GDS Transport `@font-face` because it's always provided by GOV.UK Frontend

## Separate CSS files

Font face declarations are included by GOV.UK Frontend:

**HTML**
```html
<link href="/stylesheets/govuk-frontend.min.css" rel="stylesheet">
<link href="/stylesheets/moj-frontend.min.css" rel="stylesheet">
```

## Bundled Sass file

Font face declarations are output by GOV.UK Frontend:

**Sass**
```scss
@use "node_modules/govuk-frontend/dist/govuk" as *;
@forward "node_modules/@ministryofjustice/frontend/moj/all";
```

**HTML**
```html
<link href="/stylesheets/application.min.css" rel="stylesheet">
```

Previously they were output by `moj/all` too