### PR TITLE
fix: maintain `require()` compatibility for filters

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -13,6 +13,8 @@
       "default": "./moj/all.js"
     },
     "./*": "./*",
+    "./moj/filters/*": "./moj/filters/*.js",
+    "./moj/filters/*.js": "./moj/filters/*.js",
     "./package.json": "./package.json"
   },
   "sideEffects": false,


### PR DESCRIPTION
This fix addresses [an issue raised on Slack](https://mojdt.slack.com/archives/CH5RUSB27/p1741187514176239)

I've added a workaround to keep the `moj/filters/all` export working whilst we look at:

* https://github.com/ministryofjustice/moj-frontend/pull/1249

## Module resolution

For example, Node.js can't resolve `moj/filters/all`

```sh
node --eval "console.log(require.resolve('@ministryofjustice/frontend/moj/filters/all'))"
```

But it can resolve `moj/filters/all.js`

```sh
node --eval "console.log(require.resolve('@ministryofjustice/frontend/moj/filters/all.js'))"
```

This is caused by both [Package entry point `"exports"`](https://nodejs.org/api/packages.html#package-entry-points) in **package.json** and [Node.js mandatory file extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions)

## Outdated examples

Both of these examples will need updating in https://github.com/ministryofjustice/moj-frontend/pull/1249

https://github.com/ministryofjustice/moj-frontend/blob/a909349ed62fe84995ce9915704d2cf82f170553/src/moj/components/messages/README.md?plain=1#L11

https://github.com/ministryofjustice/moj-frontend/blob/a909349ed62fe84995ce9915704d2cf82f170553/src/moj/components/timeline/README.md?plain=1#L11