### PR TITLE
docs: fix “Copy code” button to find `<pre>` block

### DIFF
--- a/docs/assets/javascript/copy.mjs
+++ b/docs/assets/javascript/copy.mjs
@@ -19,11 +19,13 @@ Copy.prototype.init = function () {
 }
 
 Copy.prototype.copyAction = function () {
+  const $pre = this.$module.querySelector('pre')
+
   // Copy to clipboard
   try {
     new ClipboardJS('.js-copy-button', {
-      target: function (trigger) {
-        return trigger.nextElementSibling
+      target: function () {
+        return $pre
       }
     }).on('success', function (e) {
       e.trigger.textContent = 'Code copied'


### PR DESCRIPTION
Looks like some stray empty `<p></p>` tags have broken the "Copy code" button

The code currentlys targets `trigger.nextElementSibling` instead of `$module.querySelector('pre')`

Which means it tries to copy an empty paragraph

I've fixed it