### PR TITLE
fix(button menu): bring back optional `--inline` modifier

### DIFF
--- a/docs/examples/button-menu-grouped/index.njk
+++ b/docs/examples/button-menu-grouped/index.njk
@@ -8,7 +8,7 @@ figma_link: https://www.figma.com/file/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?type
 {%- from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/button-menu/macro.njk" import mojButtonMenu -%}
 
-<div class="moj-button-group">
+<div class="moj-button-group moj-button-group--inline">
   {{ govukButton({
     text: "Accept booking"
   }) }}

--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -27,12 +27,16 @@
 }
 
 .moj-button-menu__wrapper {
-  position: absolute;
   z-index: 10;
-  width: 200px;
   margin: 5px 0 0; // 2px shadow, 3px gap
   padding: 0;
   list-style: none;
+
+  &,
+  .moj-button-group--inline {
+    position: absolute;
+    width: 200px;
+  }
 
   &--right {
     right: 0;

--- a/src/moj/components/page-header-actions/template.njk
+++ b/src/moj/components/page-header-actions/template.njk
@@ -10,7 +10,7 @@
     </div>
     {% if params.items %}
         <div class="moj-page-header-actions__actions">
-            <div class="moj-button-group">
+            <div class="moj-button-group moj-button-group--inline">
                 {% for button in params.items %}
                     {{ govukButton(button) }}
                 {% endfor %}

--- a/src/moj/objects/_button-group.scss
+++ b/src/moj/objects/_button-group.scss
@@ -59,6 +59,7 @@
     margin-bottom: 0;
   }
 
+  // Set button menu to full width on mobile to match GOV.UK Frontend
   @include govuk-media-query($until: tablet) {
     .moj-button-menu,
     .moj-button-menu__wrapper,
@@ -73,7 +74,7 @@
 
   // On tablet and above, we also introduce a 'column gap' between the
   // buttons and links in each row and left align links
-  @include govuk-media-query($from: tablet) {
+  @mixin moj-button-group-inline() {
     // Cancel out the column gap for the last item in each row
     margin-right: ($horizontal-gap * -1);
 
@@ -84,6 +85,7 @@
     .govuk-button,
     .govuk-link,
     .moj-button-menu {
+      width: auto;
       margin-right: $horizontal-gap;
     }
 
@@ -94,5 +96,17 @@
     .govuk-link {
       text-align: left;
     }
+  }
+
+  // Inline buttons on mobile (optional)
+  &--inline {
+    @include govuk-media-query($until: tablet) {
+      @include moj-button-group-inline;
+    }
+  }
+
+  // Inline buttons on tablet and desktop
+  @include govuk-media-query($from: tablet) {
+    @include moj-button-group-inline;
   }
 }


### PR DESCRIPTION
This PR brings back the MoJ button group `--inline` modifier used by [**Button menu**](https://design-patterns.service.justice.gov.uk/components/button-menu/)

Inline support (on mobile) was unintentionally removed in v4.0.0 as part of:

* https://github.com/ministryofjustice/moj-frontend/issues/1175
* https://github.com/ministryofjustice/moj-frontend/pull/1176

But this is behaviour should stay unique to MoJ Frontend, suppressing full width buttons on mobile