### PR TITLE
fix(button menu): add a class to the single button version of the button menu

### DIFF
--- a/src/moj/components/button-menu/_button-menu.scss
+++ b/src/moj/components/button-menu/_button-menu.scss
@@ -6,7 +6,8 @@
   position: relative;
 }
 
-.moj-button-menu__toggle-button {
+.moj-button-menu__toggle-button,
+.moj-button-menu__single-button {
   margin-bottom: 0;
   vertical-align: baseline;
 }

--- a/src/moj/components/button-menu/button-menu.mjs
+++ b/src/moj/components/button-menu/button-menu.mjs
@@ -48,6 +48,7 @@ ButtonMenu.prototype.init = function () {
         button.classList.remove(className)
       }
       button.classList.remove('moj-button-menu__item')
+      button.classList.add('moj-button-menu__single-button')
     })
     if (this.config.buttonClasses) {
       button.classList.add(...this.config.buttonClasses.split(' '))


### PR DESCRIPTION
This PR adds a class to the single button version of the button menu to fix alignment issues when grouped in the identity bar component.

fix #1285
