### PR TITLE
docs: add Sass load path guidance

### DIFF
--- a/docs/production/import-css.md
+++ b/docs/production/import-css.md
@@ -55,7 +55,7 @@ You must add the root of your application to Sass load paths, by either:
 - calling the Sass compiler from the command line with the `--load-path .` flag
 - using the JavaScript API with `loadPaths: ['.']` in the `options` object
 
-For more details, see how to [simplify Sass load paths](#simplify-sass-load-paths) or [silence deprecation warnings from dependencies](#silence-deprecation-warnings-from-dependencies-in-dart-sass) below.
+For more details, view guidance on [simplifying Sass load paths](#simplify-sass-load-paths) and [silencing deprecation warnings from dependencies](#silence-deprecation-warnings-from-dependencies-in-dart-sass).
 
 ### Load an individual component’s CSS using a single Sass forward
 

--- a/docs/production/import-javascript.md
+++ b/docs/production/import-javascript.md
@@ -65,7 +65,7 @@ Then import the JavaScript files before the closing `</body>` tag of your HTML p
 </body>
 ```
 
-**Some components cannot be initialised by this method** and this is noted on their individual documentation pages. For more details, see how to [initialise individual components](#initialise-individual-components) below.
+**Some components cannot be initialised by this method** and this is noted on their individual documentation pages. For more details, view guidance on [initialising individual components](#initialise-individual-components).
 
 ### Serve the JavaScript files from the combined javascripts folders – recommended
 


### PR DESCRIPTION
This PR adds extra info regarding Sass load paths

For example, adding `.` as the base directory to resolve `node_modules`