### PR TITLE
feat: add MoJ Frontend Nunjucks page template

### DIFF
--- a/docs/production/install-using-precompiled-files.md
+++ b/docs/production/install-using-precompiled-files.md
@@ -68,7 +68,7 @@ Next, follow [the instructions for installing GOV.UK Frontend](https://frontend.
 
 ## Update your example page to check for errors
 
-1. Update the example page in your project to match the following HTML (in your live application, you should use the [GOV.UK Design System page template](https://design-system.service.gov.uk/styles/page-template/) instead):
+1. Update the example page in your project to match the following HTML (in your live application, you should use the [MoJ Frontend page template](/use-nunjucks/#set-up-nunjucks-and-use-the-page-template) instead):
 
    ```html
    <!DOCTYPE html>

--- a/docs/production/use-nunjucks.md
+++ b/docs/production/use-nunjucks.md
@@ -40,19 +40,17 @@ You must first:
    ]);
    ```
 
-2. Use the GOV.UK Frontend template by adding the following at the top of your view file:
+2. Use the MoJ Frontend template by adding the following at the top of your view file:
 
    ```njk
    {% raw %}
-   {% extends "govuk/template.njk" %}
+   {% extends "moj/template.njk" %}
    {% endraw %}
    ```
 
-3. Go to the [default page template example](https://design-system.service.gov.uk/styles/page-template/#default) on the GOV.UK Design System website, then copy the Nunjucks code into your view file.
-
 You may need to change the paths in the Nunjucks code to get the CSS, assets and JavaScript working.
 
-Find out how to [change how the page template works](https://design-system.service.gov.uk/styles/page-template/#changing-template-content).
+Find out how to [change template content](https://design-system.service.gov.uk/styles/page-template/#changing-template-content).
 
 ## Adding Nunjucks filters
 

--- a/src/moj/template.njk
+++ b/src/moj/template.njk
@@ -1,0 +1,13 @@
+{% extends "govuk/template.njk" -%}
+
+{% if opengraphImageUrl or assetUrl -%}
+  {% set opengraphImageUrl = opengraphImageUrl if opengraphImageUrl else assetUrl + "/images/moj-opengraph-image-2024.png" %}
+{% endif -%}
+
+{% block headIcons %}
+  <link rel="shortcut icon" href="{{ assetPath | default("/assets", true) }}/images/favicon.ico">
+  <link rel="apple-touch-icon" href="{{ assetPath | default("/assets", true) }}/images/moj-apple-touch-icon-180x180-2024.png" sizes="180x180">
+  <link rel="apple-touch-icon" href="{{ assetPath | default("/assets", true) }}/images/moj-apple-touch-icon-167x167-2024.png" sizes="167x167">
+  <link rel="apple-touch-icon" href="{{ assetPath | default("/assets", true) }}/images/moj-apple-touch-icon-152x152-2024.png" sizes="152x152">
+  <link rel="apple-touch-icon" href="{{ assetPath | default("/assets", true) }}/images/moj-apple-touch-icon-2024.png">
+{% endblock %}


### PR DESCRIPTION
This PR adds a new MoJ Frontend page template

It wraps `govuk/template.njk` and overrides all the icons to use MoJ Frontend assets

```patch
- {% extends "govuk/template.njk" %}
+ {% extends "moj/template.njk" %}
```

Closes https://github.com/ministryofjustice/moj-frontend/issues/1294