### PR TITLE
fix: run Autoprefixer on Sass package files

### DIFF
--- a/gulp/build-copy-files.js
+++ b/gulp/build-copy-files.js
@@ -22,7 +22,6 @@ gulp.task('build:copy-others', () => {
   return gulp
     .src(
       [
-        'src/moj/**/*.scss',
         'src/moj/filters/**',
         'src/moj/vendor/**',
         'src/moj/init.js',

--- a/gulp/build-styles.js
+++ b/gulp/build-styles.js
@@ -1,9 +1,28 @@
+const { glob } = require('glob')
 const gulp = require('gulp')
 
 const { compileStyles } = require('./tasks/styles')
 
+gulp.task('build:css', async () => {
+  const modulePaths = await glob('moj/**/*.scss', {
+    cwd: 'src',
+    nodir: true
+  })
+
+  // Apply PostCSS transforms (e.g. vendor prefixes)
+  for (const modulePath of modulePaths) {
+    await compileStyles(modulePath, {
+      srcPath: 'src',
+      destPath: 'package',
+
+      // Customise output
+      output: { file: modulePath }
+    })()
+  }
+})
+
 gulp.task(
-  'build:css',
+  'build:css-minified',
   compileStyles('all.scss', {
     srcPath: 'src/moj',
     destPath: 'package/moj',

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -1,10 +1,11 @@
+const { readFile } = require('fs/promises')
 const { mkdir, writeFile } = require('fs/promises')
 const { dirname, join, parse, relative } = require('path')
 const { fileURLToPath } = require('url')
 
-const autoprefixer = require('autoprefixer')
-const cssnano = require('cssnano')
 const postcss = require('postcss')
+const postcssrc = require('postcss-load-config')
+const scss = require('postcss-scss')
 const { compileAsync } = require('sass-embedded')
 
 /**
@@ -16,48 +17,77 @@ const { compileAsync } = require('sass-embedded')
 function compileStyles(assetPath, { srcPath, destPath, output = {} }) {
   const { name } = parse(assetPath)
 
-  // PostCSS options
-  const from = join(srcPath, assetPath)
-  const to = join(destPath, output.file ?? `${name}.css`)
+  /**
+   * Configure PostCSS
+   *
+   * @satisfies {ProcessOptions}
+   */
+  const options = {
+    from: join(srcPath, assetPath),
+    to: join(destPath, output.file ?? `${name}.css`),
+
+    /**
+     * Always generate source maps for either:
+     *
+     * 1. PostCSS on Sass compiler result
+     * 2. PostCSS on Sass sources (Autoprefixer only)
+     */
+    map: {
+      annotation: true,
+      inline: false,
+      prev: false
+    },
+
+    // Sass syntax support
+    syntax: output.file?.endsWith('.scss') ? scss : postcss
+  }
 
   const taskFn = async () => {
-    const { css, sourceMap } = await compileAsync(from, {
-      loadPaths: ['.', 'node_modules'],
-      quietDeps: true,
-      sourceMap: true,
-      sourceMapIncludeSources: true
-    })
+    let css
+    let map
 
-    // Make source file:// paths relative
-    if (sourceMap?.sources) {
-      sourceMap.sources = sourceMap.sources.map((path) =>
-        path.startsWith('file:') ? relative(from, fileURLToPath(path)) : path
-      )
+    // Compile Sass to CSS
+    if (options.to.endsWith('.css')) {
+      ;({ css, sourceMap: map } = await compileAsync(options.from, {
+        loadPaths: ['.', 'node_modules'],
+        quietDeps: true,
+        sourceMap: true,
+        sourceMapIncludeSources: true
+      }))
+
+      // Make source file:// paths relative
+      if (map?.sources) {
+        map.sources = map.sources.map((path) =>
+          path.startsWith('file:')
+            ? relative(options.from, fileURLToPath(path))
+            : path
+        )
+      }
+
+      // Pass source maps to PostCSS
+      options.map.prev = map
     }
 
+    // Use Sass source when not compiling
+    if (!css) {
+      css = await readFile(options.from)
+    }
+
+    // Locate PostCSS config
+    const config = await postcssrc(options)
+
     // Apply PostCSS transforms (e.g. vendor prefixes)
-    const processor = postcss([
-      autoprefixer({ env: 'stylesheets' }),
-      cssnano({ env: 'stylesheets' })
-    ])
-
-    const result = await processor.process(css, {
-      from,
-      to,
-
-      // Include Sass sources
-      map: {
-        annotation: true,
-        inline: false,
-        prev: sourceMap
-      }
+    const result = await postcss(config.plugins).process(css, {
+      ...options,
+      ...config.options
     })
 
-    await mkdir(dirname(to), { recursive: true })
-    await writeFile(to, result.css)
+    // Write to files
+    await mkdir(dirname(options.to), { recursive: true })
+    await writeFile(options.to, result.css)
 
     if (result.map) {
-      await writeFile(`${to}.map`, result.map.toString())
+      await writeFile(`${options.to}.map`, result.map.toString())
     }
   }
 
@@ -75,5 +105,9 @@ module.exports = {
  * @typedef {object} CompileStylesOptions
  * @property {string} srcPath - Source directory
  * @property {string} destPath - Destination directory
- * @property {{ file: string }} [output] - Output options
+ * @property {{ file?: string }} [output] - Output options
+ */
+
+/**
+ * @import { ProcessOptions } from 'postcss'
  */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ gulp.task(
     'build:javascript',
     'build:javascript-minified',
     'build:css',
+    'build:css-minified',
     'build:compress-images'
   )
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,7 @@
         "mock-match-media": "^0.4.3",
         "nodemon": "^3.1.9",
         "postcss": "^8.5.3",
+        "postcss-load-config": "^6.0.1",
         "postcss-markdown": "^1.3.0",
         "postcss-scss": "^4.0.9",
         "prettier": "^3.5.2",
@@ -26145,6 +26146,49 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.31"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-markdown": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "mock-match-media": "^0.4.3",
     "nodemon": "^3.1.9",
     "postcss": "^8.5.3",
+    "postcss-load-config": "^6.0.1",
     "postcss-markdown": "^1.3.0",
     "postcss-scss": "^4.0.9",
     "prettier": "^3.5.2",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,35 @@
+import autoprefixer from 'autoprefixer'
+import cssnano from 'cssnano'
+import postcss from 'postcss'
+import scss from 'postcss-scss'
+
+/**
+ * PostCSS config
+ *
+ * @type {ConfigFn}
+ */
+export default (ctx = {}) => {
+  const { to } = ctx
+
+  return {
+    plugins: [
+      // Add vendor prefixes
+      autoprefixer({
+        env: 'stylesheets'
+      }),
+
+      // Minify CSS only
+      to?.endsWith('.css') &&
+        cssnano({
+          env: 'stylesheets'
+        })
+    ],
+
+    // Sass syntax support
+    syntax: to?.endsWith('.scss') ? scss : postcss
+  }
+}
+
+/**
+ * @import { ConfigFn } from 'postcss-load-config'
+ */


### PR DESCRIPTION
This PR fixes an issue affecting MoJ Frontend where CSS vendor prefixes are not applied to Sass files

Workarounds to add vendor prefixes manually are no longer necessary:

```patch
- -webkit-transform: rotate(-45deg);
- -ms-transform: rotate(-45deg);
  transform: rotate(-45deg);
```

This feature was added in [GOV.UK Frontend `v0.0.24-alpha`](https://github.com/alphagov/govuk-frontend/blob/v0.0.24-alpha/tasks/gulp/copy-to-destination.js#L23-L25) but see [**govuk-frontend**/shared/tasks/styles.mjs](https://github.com/alphagov/govuk-frontend/blob/main/shared/tasks/styles.mjs)