### PR TITLE
build(preview): use preview name `pr-1234` to avoid special characters

### DIFF
--- a/.github/workflows/branch-preview-cleanup.yml
+++ b/.github/workflows/branch-preview-cleanup.yml
@@ -25,16 +25,13 @@ jobs:
           kubectl config set-credentials deploy-user --token=${KUBE_TOKEN}
           kubectl config set-context ${KUBE_CLUSTER} --cluster=${KUBE_CLUSTER} --user=deploy-user --namespace=${KUBE_NAMESPACE}
           kubectl config use-context ${KUBE_CLUSTER}
-          kubectl delete deployment moj-frontend-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
-          kubectl delete service moj-frontend-service-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
-          kubectl delete ingress moj-frontend-ingress-${{ github.head_ref }} -n ${KUBE_NAMESPACE}
+          kubectl delete deployment moj-frontend-pr-${{ github.event.pull_request.number }} -n ${KUBE_NAMESPACE}
+          kubectl delete service moj-frontend-service-pr-${{ github.event.pull_request.number }} -n ${KUBE_NAMESPACE}
+          kubectl delete ingress moj-frontend-ingress-pr-${{ github.event.pull_request.number }} -n ${KUBE_NAMESPACE}
         env:
           KUBE_CERT: ${{ secrets.KUBE_CERT }}
           KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - uses: actions/checkout@v4
       - name: Remove preview:active label
-        run: |
-          gh pr edit $PRNUM --remove-label "preview:active"
-        env:
-          PRNUM: ${{ github.event.number }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview:active"

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -37,7 +37,7 @@ jobs:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ github.sha }}
-          BRANCH: ${{ github.head_ref }}
+          BRANCH: pr-${{ github.event.pull_request.number }}
       - run: |
           echo "${KUBE_CERT}" > ca.crt
           kubectl config set-cluster ${KUBE_CLUSTER} --certificate-authority=./ca.crt --server=https://${KUBE_CLUSTER}
@@ -51,9 +51,7 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - name: Update PR with success
         run: |
-          echo -e "🚀 Deployed to preview environment! If this is the first deploy, you may have to wait a few minutes for your preview site to be ready on the following URL:\n\n https://moj-frontend-${{ github.head_ref }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
-          gh pr comment $PRNUM --body-file comment.txt
-          gh pr edit $PRNUM --remove-label "preview:request"
-          gh pr edit $PRNUM --add-label "preview:active"
-        env:
-          PRNUM: ${{ github.event.number }}
+          echo -e "🚀 Deployed to preview environment! If this is the first deploy, you may have to wait a few minutes for your preview site to be ready on the following URL:\n\n https://moj-frontend-pr-${{ github.event.pull_request.number }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.txt
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview:request"
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "preview:active"

--- a/.github/workflows/tag-staging.yml
+++ b/.github/workflows/tag-staging.yml
@@ -56,8 +56,6 @@ jobs:
       - name: Update PR with success
         run: |
           echo -e "🚀 Deploying to [staging environment](https://moj-frontend-staging.apps.live.cloud-platform.service.justice.gov.uk/)\n\n**Username:** \`staging\`, **Password:** \`moj\`" > comment.txt
-          gh pr comment $PRNUM --body-file comment.txt
-          gh pr edit $PRNUM --remove-label "staging:request"
-          gh pr edit $PRNUM --add-label "staging:active"
-        env:
-          PRNUM: ${{ github.event.number }}
+          gh pr comment ${{ github.event.pull_request.number }} --body-file comment.txt
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "staging:request"
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "staging:active"


### PR DESCRIPTION
This PR changes preview URLs to use `pr-1234` etc instead of `branch-name`

It fixes previews from Renovate branches (and others) that contain forward slashes