### PR TITLE
build(deps): always run `npm install` after updating etc

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -79,6 +79,11 @@
       "matchPackageNames": ["concurrently", "gulp", "gulp-*", "nodemon"]
     }
   ],
+  "postUpgradeTasks": {
+    "commands": ["npm install --ignore-scripts"],
+    "fileFilters": ["package-lock.json", "**/*.package.json"],
+    "executionMode": "branch"
+  },
   "rangeStrategy": "bump",
   "updateInternalDeps": true
 }


### PR DESCRIPTION
Looks like Renovate tries to update nested **package.json** files without rebuilding **package-lock.json**