### PR TITLE
build(deps): configure allowed Renovate commands

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
+  "allowedCommands": ["^npm install( --ignore-scripts)?$"],
   "ignoreDeps": ["eslint", "eslint-plugin-promise", "eslint-plugin-n"],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7",


### PR DESCRIPTION
Sorry @chrispymm turns out `allowedCommands` is necessary for Renovate to run `npm install`

E.g. See https://github.com/ministryofjustice/moj-frontend/pull/1325#issuecomment-2751635603