### PR TITLE
build(deps): remove `postUpgradeTasks` from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
-  "allowedCommands": ["^npm install( --ignore-scripts)?$"],
   "ignoreDeps": ["eslint", "eslint-plugin-promise", "eslint-plugin-n"],
   "labels": ["dependencies"],
   "minimumReleaseAge": "7",
@@ -80,11 +79,6 @@
       "matchPackageNames": ["concurrently", "gulp", "gulp-*", "nodemon"]
     }
   ],
-  "postUpgradeTasks": {
-    "commands": ["npm install --ignore-scripts"],
-    "fileFilters": ["package-lock.json", "**/*.package.json"],
-    "executionMode": "branch"
-  },
   "rangeStrategy": "bump",
   "updateInternalDeps": true
 }


### PR DESCRIPTION
This PR removes changes from https://github.com/ministryofjustice/moj-frontend/pull/1321 and https://github.com/ministryofjustice/moj-frontend/pull/1326 except for `"updateInternalDeps": true`

It was a nice idea, but looks like there might be a global Renovate config that requires the change instead