### PR TITLE
fix(sortable table): use svg arrows instead of pseudo elements

### DIFF
--- a/docs/components/sortable-table.md
+++ b/docs/components/sortable-table.md
@@ -22,11 +22,3 @@ Use this component when sorting is needed to help find data within a large table
 ## How to use
 
 If you are using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/), you can use the Nunjucks [table macro](https://design-system.service.gov.uk/components/table/).
-
-## Accessibility issues
-
-There’s an accessibility issue with the sortable table component. If you’re using it in your service you need to add these issue details to your accessibility statement.
-
-### The sorting icons are read out in a confusing way
-
-The sorting icons are read out to screen reader users, but without meaningful information. This fails [WCAG 2.2 success criterion 1.1.1 (Non-text content)](https://www.w3.org/TR/WCAG22/#non-text-content) and [WCAG 2.2 success criterion 1.3.1 (Info and relationships)](https://www.w3.org/TR/WCAG22/#info-and-relationships). We’re aware of this issue and plan to implement a fix by April 2025.

--- a/docs/examples/sortable-table/index.njk
+++ b/docs/examples/sortable-table/index.njk
@@ -10,6 +10,7 @@ figma_link: https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?no
   attributes: {
     "data-module": "moj-sortable-table"
   },
+  caption: "Mountains of the world",
   head: [
     {
       text: "Name",

--- a/src/moj/components/sortable-table/_sortable-table.scss
+++ b/src/moj/components/sortable-table/_sortable-table.scss
@@ -2,9 +2,10 @@
 
 [aria-sort] button,
 [aria-sort] button:hover {
+  display: inline-flex;
   position: relative;
   margin: 0;
-  padding: 0 10px 0 0;
+  padding: 0;
   border-width: 0;
   color: #005ea5;
   background-color: transparent;
@@ -17,6 +18,7 @@
   font-weight: inherit;
   text-align: inherit;
   cursor: pointer;
+  align-items: center;
 }
 
 [aria-sort] button:focus {
@@ -26,45 +28,4 @@
   box-shadow:
     0 -2px $govuk-focus-colour,
     0 4px $govuk-focus-text-colour;
-}
-
-[aria-sort]:first-child button {
-  right: auto;
-}
-
-[aria-sort] button::before {
-  content: " \25bc";
-  position: absolute;
-  top: 9px;
-  right: -1px;
-  font-size: 0.5em;
-}
-
-[aria-sort] button::after {
-  content: " \25b2";
-  position: absolute;
-  top: 1px;
-  right: -1px;
-  font-size: 0.5em;
-}
-
-[aria-sort="ascending"] button::before,
-[aria-sort="descending"] button::before {
-  content: none;
-}
-
-[aria-sort="ascending"] button::after {
-  content: " \25b2";
-  position: absolute;
-  top: 2px;
-  right: -5px;
-  font-size: 0.8em;
-}
-
-[aria-sort="descending"] button::after {
-  content: " \25bc";
-  position: absolute;
-  top: 2px;
-  right: -5px;
-  font-size: 0.8em;
 }

--- a/src/moj/components/sortable-table/sortable-table.spec.mjs
+++ b/src/moj/components/sortable-table/sortable-table.spec.mjs
@@ -14,9 +14,9 @@ function createComponent() {
       <table class="govuk-table" data-module="moj-sortable-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header" aria-sort="ascending">Name</th>
+            <th scope="col" class="govuk-table__header" aria-sort="none">Name</th>
             <th scope="col" class="govuk-table__header" aria-sort="none">Elevation</th>
-            <th scope="col" class="govuk-table__header" aria-sort="none">Continent</th>
+            <th scope="col" class="govuk-table__header" aria-sort="ascending">Continent</th>
             <th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">First summit</th>
             <th scope="col" class="govuk-table__header" aria-sort="none">Test nickname</th>
           </tr>
@@ -82,7 +82,7 @@ describe('sortable table', () => {
     for (const header of headers) {
       const button = header.querySelector('button')
       expect(button).toBeInTheDocument()
-      expect(button).toHaveTextContent(`${header.textContent}`)
+      expect(button).toHaveAccessibleName(`${header.textContent.trim()}`)
     }
   })
 
@@ -92,34 +92,17 @@ describe('sortable table', () => {
     expect(statusBox).toHaveClass('govuk-visually-hidden')
   })
 
-  test('sorts ascending by Name on initial load', () => {
+  test('sorts ascending by Continent on initial load', () => {
     const tbody = component.querySelector('tbody')
-    const cells = tbody.querySelectorAll('tr td:first-child')
+    const cells = tbody.querySelectorAll('tr td:nth-child(3)')
     const values = Array.from(cells).map((cell) => cell.textContent.trim())
 
-    expect(component.querySelector('th')).toHaveAttribute(
-      'aria-sort',
-      'ascending'
-    )
-    expect(values).toEqual(['Aconcagua', 'Everest', 'K2', 'Kilimanjaro'])
+    expect(values).toEqual(['Africa', 'Asia', 'Asia', 'South America'])
   })
 
-  test('sorts string column in descending order when clicked', async () => {
+  test('sorts string column in ascending then descending order when clicked', async () => {
     const nameHeaderButton = queryByRole(component, 'button', { name: 'Name' })
     const tbody = component.querySelector('tbody')
-
-    await user.click(nameHeaderButton)
-
-    const descCells = tbody.querySelectorAll('tr td:first-child')
-    const descValues = Array.from(descCells).map((cell) =>
-      cell.textContent.trim()
-    )
-
-    expect(descValues).toEqual(['Kilimanjaro', 'K2', 'Everest', 'Aconcagua'])
-    expect(nameHeaderButton.parentElement).toHaveAttribute(
-      'aria-sort',
-      'descending'
-    )
 
     await user.click(nameHeaderButton)
 
@@ -132,6 +115,18 @@ describe('sortable table', () => {
     expect(nameHeaderButton.parentElement).toHaveAttribute(
       'aria-sort',
       'ascending'
+    )
+
+    await user.click(nameHeaderButton)
+    const descCells = tbody.querySelectorAll('tr td:first-child')
+    const descValues = Array.from(descCells).map((cell) =>
+      cell.textContent.trim()
+    )
+
+    expect(descValues).toEqual(['Kilimanjaro', 'K2', 'Everest', 'Aconcagua'])
+    expect(nameHeaderButton.parentElement).toHaveAttribute(
+      'aria-sort',
+      'descending'
     )
   })
 
@@ -220,7 +215,7 @@ describe('sortable table', () => {
   })
 
   test('cycles through sort states: none -> ascending -> descending', async () => {
-    const headerButton = queryByRole(component, 'button', { name: 'Continent' })
+    const headerButton = queryByRole(component, 'button', { name: 'Name' })
     const header = headerButton.parentElement
 
     expect(header).toHaveAttribute('aria-sort', 'none')
@@ -284,7 +279,6 @@ describe('sortable table options', () => {
     const statusBox = queryByRole(component.parentElement, 'status')
 
     await user.click(nameHeaderButton)
-    await user.click(nameHeaderButton)
 
     expect(statusBox).toHaveTextContent('Sort by Name (A to Z)')
   })
@@ -297,6 +291,7 @@ describe('sortable table options', () => {
     const nameHeaderButton = queryByRole(component, 'button', { name: 'Name' })
     const statusBox = queryByRole(component.parentElement, 'status')
 
+    await user.click(nameHeaderButton)
     await user.click(nameHeaderButton)
 
     expect(statusBox).toHaveTextContent('Sort by Name (Z to A)')


### PR DESCRIPTION
Fixes an issue where screenreaders would announce the utf-8 icon characters within the pseudo elements.  

This PR swaps the pseudo elements for inline svg elements so that screenreader users get a better experience.
