### PR TITLE
fix(add another): increment indexes for select and textarea elements 

### DIFF
--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -100,7 +100,7 @@ export class AddAnother extends Component {
    */
   updateAttributes($item, index) {
     $item.querySelectorAll('[data-name]').forEach(($input) => {
-      if (!($input instanceof HTMLInputElement)) {
+      if (!this.isValidInputElement($input)) {
         return
       }
 
@@ -145,14 +145,22 @@ export class AddAnother extends Component {
    */
   resetItem($item) {
     $item.querySelectorAll('[data-name], [data-id]').forEach(($input) => {
-      if (!($input instanceof HTMLInputElement)) {
+      if (!this.isValidInputElement($input)) {
         return
       }
 
-      if ($input.type === 'checkbox' || $input.type === 'radio') {
-        $input.checked = false
-      } else {
-        $input.value = ''
+      switch ($input.type) {
+        case 'checkbox':
+        case 'radio':
+          $input.checked = false
+          break
+        case 'select-one':
+        case 'select-multiple':
+          $input.selectedIndex = -1
+          $input.value = ''
+          break
+        default:
+          $input.value = ''
       }
     })
   }
@@ -192,6 +200,14 @@ export class AddAnother extends Component {
     if ($heading && $heading instanceof HTMLElement) {
       $heading.focus()
     }
+  }
+
+  isValidInputElement($input) {
+    return (
+      $input instanceof HTMLInputElement ||
+      $input instanceof HTMLSelectElement ||
+      $input instanceof HTMLTextAreaElement
+    )
   }
 
   /**

--- a/src/moj/components/add-another/add-another.spec.mjs
+++ b/src/moj/components/add-another/add-another.spec.mjs
@@ -16,6 +16,16 @@ function createComponent() {
         <fieldset class="govuk-fieldset moj-add-another__item">
           <legend>Person</legend>
           <div class="govuk-form-group">
+            <label for="person[0][title]">Title</label>
+            <select class="govuk-select" id="person[0][title]" name="person[0][title]" data-name="person[%index%][title]" data-id="person[%index%][title]">
+              <option></option>
+              <option>Mr</option>
+              <option>Mrs</option>
+              <option>Miss</option>
+              <option>Ms</option>
+            </select>
+          </div>
+          <div class="govuk-form-group">
             <label for="person[0][first_name]">First name</label>
             <input class="govuk-input" id="person[0][first_name]" name="person[0][first_name]" type="text" data-name="person[%index%][first_name]" data-id="person[%index%][first_name]">
           </div>
@@ -23,6 +33,58 @@ function createComponent() {
             <label for="person[0][last_name]">Last name</label>
             <input class="govuk-input" id="person[0][last_name]" name="person[0][last_name]" type="text" data-name="person[%index%][last_name]" data-id="person[%index%][last_name]">
           </div>
+          <div class="govuk-form-group">
+            <label for="person[0][bio]">Bio</label>
+            <textarea class="govuk-textarea" id="person[0][bio]" name="person[0][bio]" data-name="person[%index%][bio]" data-id="person[%index%][bio]"></textarea>
+          </div>
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h3 class="govuk-fieldset__heading">
+        Have you changed your name?
+      </h3>
+    </legend>
+    <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="person[0][changedName]-yes" name="person[0][changedName]" type="radio" value="yes" data-name="person[%index%][changedName]" data-id="person[%index%][changedName]-yes">
+        <label class="govuk-label govuk-radios__label" for="person[0][changedName]-yes">
+          Yes
+        </label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="person[0][changedName]-no" name="person[0][changedName]" type="radio" value="no" data-name="person[%index%][changedName]" data-id="person[%index%][changedName]-no">
+        <label class="govuk-label govuk-radios__label" for="person[0][changedName]-no">
+          No
+        </label>
+      </div>
+    </div>
+  </fieldset>
+</div>
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset" aria-describedby="contact-hint">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h3 class="govuk-fieldset__heading">
+        How would you like to be contacted?
+      </h3>
+    </legend>
+    <div id="contact-hint" class="govuk-hint">
+      Select all options that are relevant to you
+    </div>
+    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="person[0][contact]-email" name="person[0][contact]" type="checkbox" value="email" data-name="person[%index%][contact]" data-id="person[%index%][contact]-email">
+        <label class="govuk-label govuk-checkboxes__label" for="person[0][contact]-email">
+          Email
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="person[0][contact]-phone" name="person[0][contact]" type="checkbox" value="phone" data-name="person[%index%][contact]" data-id="person[%index%][contact]-phone">
+        <label class="govuk-label govuk-checkboxes__label" for="person[0][contact]-phone">
+          Phone
+        </label>
+      </div>
+  </fieldset>
+</div>
         </fieldset>
         <button type="button" class="govuk-button moj-add-another__add-button">Add another person</button>
       </form>
@@ -64,6 +126,34 @@ describe('Add Another component', () => {
     )
     expect(secondItemFirstName).toBeInTheDocument()
     expect(secondItemFirstName.value).toBe('')
+
+    const secondItemTitle = updatedItems[1].querySelector(
+      '[name="person[1][title]"]'
+    )
+    expect(secondItemTitle).toBeInTheDocument()
+    expect(secondItemTitle.value).toBe('')
+
+    const secondItemBio = updatedItems[1].querySelector(
+      '[name="person[1][bio]"]'
+    )
+    expect(secondItemBio).toBeInTheDocument()
+    expect(secondItemBio.value).toBe('')
+
+    const secondItemRadios = updatedItems[1].querySelectorAll(
+      '[name="person[1][changedName]"]'
+    )
+    expect(secondItemRadios).toHaveLength(2)
+    secondItemRadios.forEach((radio) => {
+      expect(radio).not.toBeChecked()
+    })
+
+    const secondItemCheckboxes = updatedItems[1].querySelectorAll(
+      '[name="person[1][contact]"]'
+    )
+    expect(secondItemCheckboxes).toHaveLength(2)
+    secondItemCheckboxes.forEach((checkbox) => {
+      expect(checkbox).not.toBeChecked()
+    })
   })
 
   test('adds a remove button to new items', async () => {
@@ -102,32 +192,73 @@ describe('Add Another component', () => {
     await user.click(addButton)
 
     const secondItem = component.querySelectorAll('.moj-add-another__item')[1]
+    const titleSelect = getByLabelText(secondItem, 'Title')
     const firstNameInput = getByLabelText(secondItem, 'First name')
     const lastNameInput = getByLabelText(secondItem, 'Last name')
+    const bioTextArea = getByLabelText(secondItem, 'Bio')
+    const changedNameRadiosYes = getByLabelText(secondItem, 'Yes')
+    const changedNameRadiosNo = getByLabelText(secondItem, 'No')
+    const contactCheckboxesEmail = getByLabelText(secondItem, 'Email')
+    const contactCheckboxesPhone = getByLabelText(secondItem, 'Phone')
 
+    expect(titleSelect).toHaveValue('')
     expect(firstNameInput).toHaveValue('')
     expect(lastNameInput).toHaveValue('')
+    expect(bioTextArea).toHaveValue('')
+    expect(changedNameRadiosYes).not.toBeChecked()
+    expect(changedNameRadiosNo).not.toBeChecked()
+    expect(contactCheckboxesEmail).not.toBeChecked()
+    expect(contactCheckboxesPhone).not.toBeChecked()
   })
 
   test('resets form values in a new item', async () => {
     await user.click(addButton)
 
     const firstItem = component.querySelectorAll('.moj-add-another__item')[0]
+    const firstItemTitleSelect = getByLabelText(firstItem, 'Title')
     const firstItemFirstNameInput = getByLabelText(firstItem, 'First name')
     const firstItemLastNameInput = getByLabelText(firstItem, 'Last name')
+    const firstItemBioTextArea = getByLabelText(firstItem, 'Bio')
+    const firstItemChangedNameYes = getByLabelText(firstItem, 'Yes')
+    const firstItemChangedNameNo = getByLabelText(firstItem, 'No')
+    const firstItemContactEmail = getByLabelText(firstItem, 'Email')
+    const firstItemContactPhone = getByLabelText(firstItem, 'Phone')
 
+    await user.selectOptions(firstItemTitleSelect, 'Mrs')
     await user.type(firstItemFirstNameInput, 'Steve')
     await user.type(firstItemLastNameInput, 'Jobs')
+    await user.type(firstItemBioTextArea, 'Apple')
+    await user.click(firstItemChangedNameYes)
+    await user.click(firstItemContactEmail)
+    await user.click(firstItemContactPhone)
 
+    expect(firstItemTitleSelect).toHaveValue('Mrs')
     expect(firstItemFirstNameInput).toHaveValue('Steve')
     expect(firstItemLastNameInput).toHaveValue('Jobs')
+    expect(firstItemBioTextArea).toHaveValue('Apple')
+    expect(firstItemChangedNameYes).toBeChecked()
+    expect(firstItemChangedNameNo).not.toBeChecked()
+    expect(firstItemContactEmail).toBeChecked()
+    expect(firstItemContactPhone).toBeChecked()
 
     const secondItem = component.querySelectorAll('.moj-add-another__item')[1]
+    const secondItemTitleSelect = getByLabelText(secondItem, 'Title')
     const secondItemFirstNameInput = getByLabelText(secondItem, 'First name')
     const secondItemLastNameInput = getByLabelText(secondItem, 'Last name')
+    const secondItemBioTextArea = getByLabelText(secondItem, 'Bio')
+    const secondItemChangedNameYes = getByLabelText(secondItem, 'Yes')
+    const secondItemChangedNameNo = getByLabelText(secondItem, 'No')
+    const secondItemContactEmail = getByLabelText(secondItem, 'Email')
+    const secondItemContactPhone = getByLabelText(secondItem, 'Phone')
 
+    expect(secondItemTitleSelect).toHaveValue('')
     expect(secondItemFirstNameInput).toHaveValue('')
     expect(secondItemLastNameInput).toHaveValue('')
+    expect(secondItemBioTextArea).toHaveValue('')
+    expect(secondItemChangedNameYes).not.toBeChecked()
+    expect(secondItemChangedNameNo).not.toBeChecked()
+    expect(secondItemContactEmail).not.toBeChecked()
+    expect(secondItemContactPhone).not.toBeChecked()
   })
 
   test('focuses the heading after removing an item', async () => {


### PR DESCRIPTION
This PR fixes a regression introduce in v5.1.0 where the add another component no longer incremented the indexes within field names and ids for `select` elements.

This was caused by a too strict type check for `HTMLInputElement` 

This PR extends the type check to include `HTMLInputElement`, `HTMLSelectElement` and `HTMLTextAreaElement`

It also extends the tests to check for correct behaviour with `select`,`textarea`,`radio` and `checkbox` inputs.
