### PR TITLE
Use a flexible auto-grid for homepage layout

### DIFF
--- a/docs/_data/env.js
+++ b/docs/_data/env.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   return {
     isStaging: process.env.ENV === 'staging' || false,
-    showCommunity: false
+    showCommunity: true
   }
 }

--- a/docs/_data/env.js
+++ b/docs/_data/env.js
@@ -1,6 +1,6 @@
 module.exports = function () {
   return {
     isStaging: process.env.ENV === 'staging' || false,
-    showCommunity: true
+    showCommunity: false
   }
 }

--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -33,8 +33,7 @@
         size: "large"
       }) }}
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half-from-desktop">
+      <div class="app-grid">
         {% call card({
           title: "Benefits of using the MoJ Design System",
           imageLink: "assets/images/home-img/benefits-of-using-moj-design-system.png",
@@ -44,8 +43,6 @@
           <p>Learn about how reusing building blocks helps product teams as well as users.</p>
           <a class="gov-link" href="/design-system-benefits">Read about the benefits of the MoJ Design System</a>
         {% endcall %}
-        </div>
-        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
           title: "Building block statuses",
           imageLink: "assets/images/home-img/how-to-use-building-blocks.png",
@@ -55,7 +52,6 @@
           <p>Every component, page and pattern has a status. This helps you know how to use them.</p>
           <a class="gov-link" href="/design-system-statuses/">Read about the 4 Design System statuses</a>
         {% endcall %}
-        </div>
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -69,9 +65,10 @@
           size: "large"
         }) }}
 
-        <div class="govuk-grid-row">
+
           {% call card({
             layout: "horizontal",
+            reverse: true,
             title: "Collaborate with the community",
             imageLink: "assets/images/home-img/contribute.png",
             imageLinkLarge: "assets/images/home-img/contributex2.png",
@@ -85,7 +82,7 @@
             </p>
             <a class="gov-link" href="#">Discover more about collaborating with the community</a>
           {% endcall %}
-        </div>
+
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       </section>
@@ -98,20 +95,17 @@
         size: "large"
       }) }}
 
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full govuk-!-margin-bottom-9">
+      <div class="app-grid" style="--min-column-width: 290px;">
         {% call card({
-          title: "How to choose the right prototyping tool"
+          title: "How to choose the right prototyping tool",
+          classes: "app-grid__item--full"
         }) %}
           <p>
             You can prototype using paper, Figma or a coded prototype. Understand which method you need for your task.
           </p>
           <a class="gov-link" href="/prototyping/prototyping-methods/">How to choose a prototyping tool</a>
         {% endcall %}
-        </div>
-      </div>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half-from-desktop">
+
         {% call card({
           title: "How to set up Figma prototypes"
         }) %}
@@ -120,8 +114,7 @@
           </p>
           <a class="gov-link" href="/prototyping/setting-up-figma-prototypes/">How to set up Figma prototypes</a>
         {% endcall %}
-        </div>
-        <div class="govuk-grid-column-one-half-from-desktop">
+
         {% call card({
           title: "How to set up coded prototypes"
         }) %}
@@ -130,7 +123,6 @@
           </p>
           <a class="gov-link" href="/prototyping/setting-up-coded-prototypes/">How to set up coded prototypes</a>
           {% endcall %}
-        </div>
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -143,8 +135,7 @@
         size: "large"
       }) }}
 
-      <div class="govuk-grid-row govuk-!-margin-bottom-8">
-        <div class="govuk-grid-column-one-half-from-desktop">
+      <div class="app-grid govuk-!-margin-bottom-8">
         {% call card({
           title: "Installing MoJ Frontend"
         }) %}
@@ -155,8 +146,6 @@
             <a href="/production/moj-frontend">Read technical documentation</a> or <a href="/production/installing-with-npm/">install with Node.js package manager (npm)</a>.
           </p>
         {% endcall %}
-        </div>
-        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
           title: "Find out more"
         }) %}
@@ -166,8 +155,7 @@
             <li><a class="gov-link" href="/production/import-font-and-image-assets/">Importing font and image assets</a></li>
             <li><a class="gov-link" href="/production/import-javascript/">Importing JavaScript</a></li>
           </ul>
-          {% endcall %}
-        </div>
+        {% endcall %}
       </div>
     </section>
 

--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -68,7 +68,6 @@
 
           {% call card({
             layout: "horizontal",
-            reverse: true,
             title: "Collaborate with the community",
             imageLink: "assets/images/home-img/contribute.png",
             imageLinkLarge: "assets/images/home-img/contributex2.png",
@@ -95,7 +94,7 @@
         size: "large"
       }) }}
 
-      <div class="app-grid" style="--min-column-width: 290px;">
+      <div class="app-grid" style="--min-column-width: 310px;">
         {% call card({
           title: "How to choose the right prototyping tool",
           classes: "app-grid__item--full"

--- a/docs/_includes/macros/card/template.njk
+++ b/docs/_includes/macros/card/template.njk
@@ -15,7 +15,7 @@ Arguments to be passed:
   {% set classNames = "app-card__image" -%}
 
   {% if params.imageClass %}
-    {% set classNames = classNames + " " + params.imageClass %}
+    {% set classNames = classNames + " " + params.imageClasses %}
   {% endif -%}
 
   <img {{- govukAttributes({
@@ -34,14 +34,12 @@ Arguments to be passed:
 {% endmacro %}
 
 {% if params.layout == "horizontal" %}
-  <article class="app-card app-card--horizontal {% if params.reverse %} app-card--reverse{% endif %}">
-    <div class="govuk-grid-column-one-half-from-desktop">
+<article class="app-card app-card--horizontal app-grid {% if params.reverse %} app-card--reverse{% endif %} {{ params.classes }}" style="--gap: 30px; --gap-small: 20px;">
       {% if params.imageLink %}
         {{ _cardImage(params) }}
       {% endif %}
-    </div>
 
-    <div class="govuk-grid-column-one-half-from-desktop">
+    <div>
       {{ heading({
         text: params.title,
         size: "medium"
@@ -53,7 +51,7 @@ Arguments to be passed:
     </div>
   </article>
 {% else %}
-  <article class="app-card">
+  <article class="app-card {{ params.classes }}">
     {{ _cardImage(params) if params.imageLink }}
 
     {{ heading({

--- a/docs/stylesheets/application.scss
+++ b/docs/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @forward "components/vertical-nav";
 @forward "components/page";
 @forward "components/menu-toggle";
+@forward "components/app-grid";
 @forward "components/app-card";
 @forward "components/app-article";
 @forward "components/status";

--- a/docs/stylesheets/components/_app-card.scss
+++ b/docs/stylesheets/components/_app-card.scss
@@ -3,10 +3,6 @@
 .app-card {
   margin-bottom: 0;
 
-  @include govuk-media-query($until: desktop) {
-    margin-bottom: govuk-spacing(7);
-  }
-
   &__image {
     display: block;
     width: 100%;
@@ -18,13 +14,10 @@
   &__content {
     margin-bottom: 0;
   }
+}
 
-  &--reverse {
-    display: flex;
-    flex-direction: row-reverse;
-
-    @include govuk-media-query($until: desktop) {
-      flex-direction: column;
-    }
+.app-card--reverse {
+  > *:last-child {
+    order: -1;
   }
 }

--- a/docs/stylesheets/components/_app-grid.scss
+++ b/docs/stylesheets/components/_app-grid.scss
@@ -1,0 +1,19 @@
+@use "../moj-frontend" as *;
+
+.app-grid {
+  column-gap: var(--column-gap, var(--gap, govuk-spacing(9)));
+  row-gap: var(--row-gap, var(--gap, govuk-spacing(9)));
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(var(--min-column-width, 225px), 100%), 1fr));
+
+  @include govuk-media-query($until: tablet) {
+    column-gap: var(--column-gap-small, var(--gap-small, var(--gap, govuk-spacing(7))));
+    row-gap: var(--row-gap-small, var(--gap-small, var(--gap, govuk-spacing(7))));
+  }
+}
+
+.app-grid__item {
+  &--full {
+    grid-column: 1 / -1;
+  }
+}

--- a/docs/stylesheets/components/_app-grid.scss
+++ b/docs/stylesheets/components/_app-grid.scss
@@ -1,14 +1,14 @@
 @use "../moj-frontend" as *;
 
 .app-grid {
-  column-gap: var(--column-gap, var(--gap, govuk-spacing(9)));
-  row-gap: var(--row-gap, var(--gap, govuk-spacing(9)));
+  column-gap: var(--column-gap, var(--gap, govuk-spacing(6)));
+  row-gap: var(--row-gap, var(--gap, govuk-spacing(6)));
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(var(--min-column-width, 225px), 100%), 1fr));
 
   @include govuk-media-query($until: tablet) {
-    column-gap: var(--column-gap-small, var(--gap-small, var(--gap, govuk-spacing(7))));
-    row-gap: var(--row-gap-small, var(--gap-small, var(--gap, govuk-spacing(7))));
+    column-gap: var(--column-gap-small, var(--gap-small, var(--gap, govuk-spacing(6))));
+    row-gap: var(--row-gap-small, var(--gap-small, var(--gap, govuk-spacing(6))));
   }
 }
 

--- a/views/common/homepage-nav.html
+++ b/views/common/homepage-nav.html
@@ -8,7 +8,7 @@
   <nav class="app-vertical-nav" aria-labelledby="building-nav-title">
     <h2 class="app-vertical-nav__header" id="building-nav-title">Building blocks</h2>
     <ul class="app-vertical-nav__list">
-        
+
 
 
 
@@ -188,7 +188,7 @@
   <a class="app-vertical-nav__link" href="/components/timeline/">Timeline</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -228,7 +228,7 @@
   <a class="app-vertical-nav__link" href="/patterns/upload-files/">Upload files</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -247,7 +247,7 @@
   <a class="app-vertical-nav__link" href="/pages/case-list/">Case list page</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -322,7 +322,7 @@
   <nav class="app-vertical-nav" aria-labelledby="standards-nav-title">
     <h2 class="app-vertical-nav__header" id="standards-nav-title">Standards and principles</h2>
     <ul class="app-vertical-nav__list">
-        
+
 
 
 
@@ -362,7 +362,7 @@
   <a class="app-vertical-nav__link" href="/ethics/assessment/">Preparing for a service assessment</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -379,7 +379,7 @@
   <nav class="app-vertical-nav" aria-labelledby="using-nav-title">
     <h2 class="app-vertical-nav__header" id="using-nav-title">Using the design system</h2>
     <ul class="app-vertical-nav__list">
-        
+
 
 
 
@@ -387,7 +387,7 @@
 <li class="app-vertical-nav__item  ">
   <a class="app-vertical-nav__link" href="/design-system-benefits/">Benefits of using the Design System</a></li>
 
-        
+
 
 
 
@@ -395,7 +395,7 @@
 <li class="app-vertical-nav__item  ">
   <a class="app-vertical-nav__link" href="/design-system-statuses/">Design system statuses</a></li>
 
-        
+
 
 
 
@@ -435,7 +435,7 @@
   <a class="app-vertical-nav__link" href="/prototyping/deploying-coded-prototypes/">Deploying coded prototypes</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -496,7 +496,7 @@
   <a class="app-vertical-nav__link" href="/production/import-javascript/">Import JavaScript</a></li>
 </ul></li>
 
-        
+
 
 
 
@@ -529,7 +529,7 @@
   <a class="app-vertical-nav__link" href="/get-involved/suggest-a-change/">Suggest a change or give feedback</a></li>
 </ul></li>
 
-        
+
 
 
 


### PR DESCRIPTION
This PR replaces the govuk grid classes on the homepage for a flexible auto layout grid based on css grid.

This allows for very flexible layouts, and eliminates the need for media queries.

The grid component can be customised using css variables, which can be set using inline styles on the component itself, or it can fall back to defaults.




