### PR TITLE
refactor(card macro): update card macro to not include grid classes

### DIFF
--- a/docs/_includes/layouts/home.njk
+++ b/docs/_includes/layouts/home.njk
@@ -34,8 +34,8 @@
       }) }}
 
       <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "Benefits of using the MoJ Design System",
           imageLink: "assets/images/home-img/benefits-of-using-moj-design-system.png",
           imageLinkLarge: "assets/images/home-img/benefits-of-using-moj-design-systemx2.png",
@@ -44,9 +44,9 @@
           <p>Learn about how reusing building blocks helps product teams as well as users.</p>
           <a class="gov-link" href="/design-system-benefits">Read about the benefits of the MoJ Design System</a>
         {% endcall %}
-
+        </div>
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "Building block statuses",
           imageLink: "assets/images/home-img/how-to-use-building-blocks.png",
           imageLinkLarge: "assets/images/home-img/how-to-use-building-blocksx2.png",
@@ -55,6 +55,7 @@
           <p>Every component, page and pattern has a status. This helps you know how to use them.</p>
           <a class="gov-link" href="/design-system-statuses/">Read about the 4 Design System statuses</a>
         {% endcall %}
+        </div>
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -70,7 +71,7 @@
 
         <div class="govuk-grid-row">
           {% call card({
-            layout: "image-content",
+            layout: "horizontal",
             title: "Collaborate with the community",
             imageLink: "assets/images/home-img/contribute.png",
             imageLinkLarge: "assets/images/home-img/contributex2.png",
@@ -98,8 +99,8 @@
       }) }}
 
       <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-!-margin-bottom-9">
         {% call card({
-          layout: "full",
           title: "How to choose the right prototyping tool"
         }) %}
           <p>
@@ -107,10 +108,11 @@
           </p>
           <a class="gov-link" href="/prototyping/prototyping-methods/">How to choose a prototyping tool</a>
         {% endcall %}
+        </div>
       </div>
       <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "How to set up Figma prototypes"
         }) %}
           <p>
@@ -118,16 +120,17 @@
           </p>
           <a class="gov-link" href="/prototyping/setting-up-figma-prototypes/">How to set up Figma prototypes</a>
         {% endcall %}
-
+        </div>
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "How to set up coded prototypes"
         }) %}
           <p>
             Learn how to create coded prototypes using the MoJ Design System and GOV.UK Prototype Kit.
           </p>
           <a class="gov-link" href="/prototyping/setting-up-coded-prototypes/">How to set up coded prototypes</a>
-        {% endcall %}
+          {% endcall %}
+        </div>
       </div>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -141,8 +144,8 @@
       }) }}
 
       <div class="govuk-grid-row govuk-!-margin-bottom-8">
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "Installing MoJ Frontend"
         }) %}
           <p>
@@ -152,9 +155,9 @@
             <a href="/production/moj-frontend">Read technical documentation</a> or <a href="/production/installing-with-npm/">install with Node.js package manager (npm)</a>.
           </p>
         {% endcall %}
-
+        </div>
+        <div class="govuk-grid-column-one-half-from-desktop">
         {% call card({
-          layout: "side-by-side",
           title: "Find out more"
         }) %}
           <ul class="govuk-list">
@@ -163,7 +166,8 @@
             <li><a class="gov-link" href="/production/import-font-and-image-assets/">Importing font and image assets</a></li>
             <li><a class="gov-link" href="/production/import-javascript/">Importing JavaScript</a></li>
           </ul>
-        {% endcall %}
+          {% endcall %}
+        </div>
       </div>
     </section>
 

--- a/docs/_includes/macros/card/template.njk
+++ b/docs/_includes/macros/card/template.njk
@@ -1,18 +1,18 @@
 {% from "govuk/macros/attributes.njk" import govukAttributes -%}
 {% from "macros/heading/macro.njk" import heading -%}
 
-<!--
+{#
 Arguments to be passed:
-- layout: {string} "side-by-side", "full", "image-content".
-- reverse: {boolean} Reverse the layout of image-content variant, so image shows either left or right of content.
+- layout: {string} "vertical" (default), "horizontal"
+- reverse: {boolean} Reverse the layout of horizontal variant, so image shows either left or right of content.
 - imageLink: {string} Absolute path of image location (e.g., assets/images/...)
 - imageClass: {string} Additional CSS class to be applied if needed.
 - imageAlt: {string} Alt text for image. If empty, the image will be treated as decorative for screen readers.
 - imageLinkLarge: {string} Absolute path for larger image location for x2 display (e.g., assets/images/...).
--->
+#}
 
 {%- macro _cardImage(params) %}
-  {% set classNames = "app-card__image govuk-!-margin-bottom-4" -%}
+  {% set classNames = "app-card__image" -%}
 
   {% if params.imageClass %}
     {% set classNames = classNames + " " + params.imageClass %}
@@ -33,27 +33,13 @@ Arguments to be passed:
   }) -}}>
 {% endmacro %}
 
-{% if params.layout == "side-by-side" or params.layout == "full" %}
-  <article class="app-card {{ "govuk-grid-column-full app-card--full" if params.layout == "full" else "govuk-grid-column-one-half-from-desktop" }}">
-    {{ _cardImage(params) if params.imageLink }}
-
-    {{ heading({
-      text: params.title,
-      size: "medium"
-    }) }}
-
-    <div class="govuk-body govuk-!-margin-bottom-0">
-      {{ caller() }}
-    </div>
-  </article>
-
-{% elif params.layout == "image-content" %}
-  <article class="app-card{% if params.reverse %} app-card--reverse{% endif %}">
-    {% if params.imageLink %}
-      <div class="govuk-grid-column-one-half-from-desktop">
+{% if params.layout == "horizontal" %}
+  <article class="app-card app-card--horizontal {% if params.reverse %} app-card--reverse{% endif %}">
+    <div class="govuk-grid-column-one-half-from-desktop">
+      {% if params.imageLink %}
         {{ _cardImage(params) }}
-      </div>
-    {% endif %}
+      {% endif %}
+    </div>
 
     <div class="govuk-grid-column-one-half-from-desktop">
       {{ heading({
@@ -61,9 +47,23 @@ Arguments to be passed:
         size: "medium"
       }) }}
 
-      <div class="govuk-body govuk-!-margin-bottom-0">
+      <div class="govuk-body app-card__content">
         {{ caller() }}
       </div>
     </div>
   </article>
+{% else %}
+  <article class="app-card">
+    {{ _cardImage(params) if params.imageLink }}
+
+    {{ heading({
+      text: params.title,
+      size: "medium"
+    }) }}
+
+    <div class="govuk-body app-card__content">
+      {{ caller() }}
+    </div>
+  </article>
 {% endif %}
+

--- a/docs/stylesheets/components/_app-card.scss
+++ b/docs/stylesheets/components/_app-card.scss
@@ -12,6 +12,11 @@
     width: 100%;
     height: auto;
     object-fit: cover;
+    margin-bottom: govuk-spacing(4);
+  }
+
+  &__content {
+    margin-bottom: 0;
   }
 
   &--reverse {
@@ -20,14 +25,6 @@
 
     @include govuk-media-query($until: desktop) {
       flex-direction: column;
-    }
-  }
-
-  &--full {
-    margin-bottom: govuk-spacing(9);
-
-    @include govuk-media-query($until: desktop) {
-      margin-bottom: govuk-spacing(7);
     }
   }
 }


### PR DESCRIPTION
This PR refactors the card macro to be simpler, and not contain any of the govuk grid classes itself.

This makes the card width agnostic - it is always full width within the container it is placed within.

This makes the component macro itself much simpler, and makes it much more flexible to use.

**Before:**
![image](https://github.com/user-attachments/assets/337e1816-b08d-425b-af12-265de069e6ed)

**After:**
![image](https://github.com/user-attachments/assets/0a81f708-b0df-4999-8525-0ba108ed8d15)
