### PR TITLE
fix(dependencies): set govuk-frontend peer depencency version

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -41,7 +41,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "govuk-frontend": "5.9.0",
+    "govuk-frontend": "^5.8.0",
     "moment": "2.30.1"
   }
 }


### PR DESCRIPTION
Loosens the peer dependency version for govuk-frontend to `^5.8` 

5.8 is the minimum version due to needing the govuk base component class

This allows users to upgrade minor versions of govuk-frontend