### PR TITLE
docs(community): multiple image upload

### DIFF
--- a/middleware/component-session.js
+++ b/middleware/component-session.js
@@ -159,6 +159,28 @@ const saveSession = (req, res, next) => {
 const getFormDataFromSession = (req, res, next) => {
   req.formData = null
   req.formData = req.session[req.url] || {}
+
+  if(req.url.split('/')[1] === 'component-image') {
+    console.log('component image page')
+    req.formData.componentImages = []
+    for (const [key, value] of Object.entries(req.session)) {
+      console.log(key)
+      if(key.includes('component-image')) {
+        const isSubpage = key.split('/').length > 2
+        console.log(isSubpage)
+        const subpage = isSubpage ? key.split('/')[2] : false
+        console.log(subpage)
+        console.log(value)
+        req.formData.componentImages.push({
+          changeUrl: `${ADD_NEW_COMPONENT_ROUTE}/change/component-image${(subpage ? `/${subpage}` : '')}`,
+          originalname: value.componentImage.originalname
+        })
+      }
+    }
+  }
+
+  console.log(req.formData.componentImages)
+
   next()
 }
 

--- a/routes/add-component.js
+++ b/routes/add-component.js
@@ -281,7 +281,7 @@ router.post(
   (req, res, next) => {
     if(req.fileUploaded) {
       // return to same page after upload
-      res.redirect(`${ADD_NEW_COMPONENT_ROUTE}/${req.url}`)
+      res.redirect(`${ADD_NEW_COMPONENT_ROUTE}${req.url}`)
     }
     if (req.nextPage) {
       res.redirect(`${ADD_NEW_COMPONENT_ROUTE}/${req.nextPage}`)

--- a/views/community/pages/component-image.njk
+++ b/views/community/pages/component-image.njk
@@ -32,15 +32,12 @@
       <p class="govuk-body">You'll also have an opportunity to add more images of this after submitting the
         component.</p>
 
-
-      {% if imageUploaded %}
-        <input type="hidden" name="componentImage" value="{{formData.componentImage.originalname}}">
-        {{ govukSummaryList({
-              classes: 'govuk-summary-list--long-key',
-              rows: [
+      {% set uploadedImages = [] %}
+        {% for image in formData.componentImages %}
+          {% set uploadedImages = (uploadedImages.push(
                 {
                   key: {
-                    text: formData.componentImage.originalname
+                    text: image.originalname
                   },
                   value: {
                     text: govukTag({ text: "Uploaded", classes: "govuk-tag--green" })
@@ -48,21 +45,32 @@
                   actions: {
                     items: [
                       {
-                        href: changeUrl,
+                        href: image.changeUrl,
                         text: "Remove",
-                        visuallyHiddenText: formData.componentImage.originalname
+                        visuallyHiddenText: image.originalname
                       }
                     ]
                   }
                 }
-              ]
-            }) }}
+            ), uploadedImages) %}
+        {% endfor %}
+
+        {% if uploadedImages | length %}
+        <h3 class="govuk-heading-m">Uploaded Images</h3>
+        {{ govukSummaryList({
+              classes: 'govuk-summary-list--long-key',
+              rows: uploadedImages
+              }) }}
+        {% endif %}
+
+      {% if imageUploaded %}
+        <input type="hidden" name="componentImage" value="{{formData.componentImage.originalname}}">
       {% else %}
         {{ govukFileUpload({
           id: "component-image",
           name: "componentImage",
           label: {
-            text: "Upload a file",
+            text: "Upload another file" if uploadedImages | length else "Upload a file",
             classes: "govuk-label--m"
           },
           hint: {
@@ -74,6 +82,9 @@
           errorMessage: formErrors.componentImage
         }) }}
       {% endif %}
+
+
+
 
 
       <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>


### PR DESCRIPTION
This attempts to streamline image uploading by showing the whole list of uploaded images on each component image screen.  This is nice, but possibly introduces some tricky issues/edge cases - namely, it becomes possible to delete the first image and leave the second in place, breaking some assumptions made later in the process
