### PR TITLE
Remove accessibility report uploads

### DIFF
--- a/schema/add-assistive-tech.schema.js
+++ b/schema/add-assistive-tech.schema.js
@@ -76,8 +76,8 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter any issues discovered',
-      'string.empty': 'Enter any issues discovered',
+      'any.required': 'Enter details about issues discovered by the assistive technology testing',
+      'string.empty': 'Enter details about issues discovered by the assistive technology testing',
       'custom.max.words': 'Enter 250 words or less'
     }),
 })

--- a/schema/add-assistive-tech.schema.js
+++ b/schema/add-assistive-tech.schema.js
@@ -73,20 +73,13 @@ const schema = Joi.object({
     }),
 
   issuesDiscovered: Joi.string()
-    .optional()
-    .allow(null, '')
+    .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
+      'any.required': 'Enter any issues discovered',
+      'string.empty': 'Enter any issues discovered',
       'custom.max.words': 'Enter 250 words or less'
     }),
-
-  accessibilityReport: Joi.string()
-    .allow('')
-    .pattern(/\.pdf$/i)
-    .messages({
-      'string.pattern.base': 'The file must be a PDF'
-    })
-    .optional()
 })
 
 module.exports = schema

--- a/schema/add-external-audit.schema.js
+++ b/schema/add-external-audit.schema.js
@@ -86,8 +86,8 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter any issues discovered',
-      'string.empty': 'Enter any issues discovered',
+      'any.required': 'Enter details about issues discovered by the external audit',
+      'string.empty': 'Enter details about issues discovered by the external audit',
       'custom.max.words': 'Enter 250 words or less'
     })
 })

--- a/schema/add-external-audit.schema.js
+++ b/schema/add-external-audit.schema.js
@@ -82,19 +82,12 @@ const schema = Joi.object({
       'any.invalid': '{{#message}}'
     }),
 
-  accessibilityReport: Joi.string()
-    .allow('')
-    .pattern(/\.pdf$/i)
-    .messages({
-      'string.pattern.base': 'The file must be a PDF'
-    })
-    .optional(),
-
   issuesDiscovered: Joi.string()
-    .optional()
-    .allow(null, '')
+    .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
+      'any.required': 'Enter any issues discovered',
+      'string.empty': 'Enter any issues discovered',
       'custom.max.words': 'Enter 250 words or less'
     })
 })

--- a/schema/add-internal-audit.schema.js
+++ b/schema/add-internal-audit.schema.js
@@ -80,19 +80,12 @@ const schema = Joi.object({
       'any.invalid': '{{#message}}'
     }),
 
-  accessibilityReport: Joi.string()
-    .allow('')
-    .pattern(/\.pdf$/i)
-    .messages({
-      'string.pattern.base': 'The file must be a PDF'
-    })
-    .optional(),
-
   issuesDiscovered: Joi.string()
-    .optional()
-    .allow(null, '')
+    .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
+      'any.required': 'Enter any issues discovered',
+      'string.empty': 'Enter any issues discovered',
       'custom.max.words': 'Enter 250 words or less'
     })
 })

--- a/schema/add-internal-audit.schema.js
+++ b/schema/add-internal-audit.schema.js
@@ -84,8 +84,8 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter any issues discovered',
-      'string.empty': 'Enter any issues discovered',
+      'any.required': 'Enter details about issues discovered by the internal review',
+      'string.empty': 'Enter details about issues discovered by the internal review',
       'custom.max.words': 'Enter 250 words or less'
     })
 })

--- a/views/community/pages/add-assistive-tech.njk
+++ b/views/community/pages/add-assistive-tech.njk
@@ -9,8 +9,6 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "base.njk" %}
 
-{% set uploadedFileName = formData.accessibilityReport.originalname if formData.accessibilityReport.originalname else file.originalname %}
-
 {% block content %}
   <div class="app-layout__content">
     {% if backLink %}
@@ -64,26 +62,6 @@
         }
       }) }}
 
-
-
-{{ govukFileUpload({
-        id: "accessibility-report",
-        name: "accessibilityReport",
-        label: {
-          text: "Upload the report (optional)",
-          isPageHeading: true,
-          classes: "govuk-label--m"
-        },
-        hint: {
-          text: "The file needs to be a PDF and smaller than 10MB."
-        },
-        errorMessage: formErrors.accessibilityReport,
-        value: formData.accessibilityReport,
-        attributes: {
-          accept: ".pdf"
-        }
-      }) }}
-
       {{ govukCharacterCount({
         id: "issues-discovered",
         name: "issuesDiscovered",
@@ -97,22 +75,6 @@
         value: formData.issuesDiscovered
       }) }}
 
-      {% if uploadedFileName %}
-        <input type="hidden" name="accessibilityReport" value="{{uploadedFileName}}">
-        {{ govukSummaryList({
-          classes: 'govuk-summary-list--long-key',
-          rows: [
-            {
-              key: {
-              text: "File"
-            },
-              value: {
-              text: uploadedFileName
-            }
-            }
-          ]
-        }) }}
-      {% endif %}
       <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
       <div class="govuk-button-group moj-button-action">

--- a/views/community/pages/add-external-audit.njk
+++ b/views/community/pages/add-external-audit.njk
@@ -9,8 +9,6 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "base.njk" %}
 
-{% set uploadedFileName = formData.accessibilityReport.originalname if formData.accessibilityReport.originalname else file.originalname %}
-
 {% block content %}
   <div class="app-layout__content">
     {% if backLink %}
@@ -72,41 +70,6 @@
           text: "For example, 13 8 2024"
         }
       }) }}
-
-
-{{ govukFileUpload({
-        id: "accessibility-report",
-        name: "accessibilityReport",
-        label: {
-          text: "Upload the accessibility report (optional)",
-          classes: "govuk-label--m"
-        },
-        hint: {
-          text: "The file needs to be a PDF and smaller than 10MB."
-        },
-        errorMessage: formErrors.accessibilityReport,
-        value: formData.accessibilityReport,
-        attributes: {
-          accept: ".pdf"
-        }
-        }) }}
-
-      {% if uploadedFileName %}
-        <input type="hidden" name="accessibilityReport" value="{{uploadedFileName}}">
-        {{ govukSummaryList({
-          classes: 'govuk-summary-list--long-key',
-          rows: [
-            {
-              key: {
-              text: "File"
-            },
-              value: {
-              text: uploadedFileName
-            }
-            }
-          ]
-        }) }}
-        {% endif %}
 
       {{ govukCharacterCount({
         id: "issues-discovered",

--- a/views/community/pages/add-internal-audit.njk
+++ b/views/community/pages/add-internal-audit.njk
@@ -9,8 +9,6 @@
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% extends "base.njk" %}
 
-{% set uploadedFileName = formData.accessibilityReport.originalname if formData.accessibilityReport.originalname else file.originalname %}
-
 {% block content %}
   <div class="app-layout__content">
     {% if backLink %}
@@ -74,41 +72,6 @@
           text: "For example, 13 8 2024"
         }
       }) }}
-
-{{ govukFileUpload({
-        id: "accessibility-report",
-        name: "accessibilityReport",
-        label: {
-          text: "Upload the accessibility review (optional)",
-          isPageHeading: true,
-          classes: "govuk-label--m"
-        },
-        hint: {
-          text: "The file needs to be a PDF and smaller than 10MB."
-        },
-        errorMessage: formErrors.accessibilityReport,
-        value: formData.accessibilityReport,
-        attributes: {
-          accept: ".pdf"
-        }
-      }) }}
-
-      {% if uploadedFileName %}
-        <input type="hidden" name="accessibilityReport" value="{{uploadedFileName}}">
-        {{ govukSummaryList({
-          classes: 'govuk-summary-list--long-key',
-          rows: [
-            {
-              key: {
-              text: "File"
-              },
-                value: {
-                text: uploadedFileName
-              }
-            }
-          ]
-        }) }}
-      {% endif %}
 
       {{ govukCharacterCount({
         id: "issues-discovered",


### PR DESCRIPTION
This PR removes the accessibility report uploads and makes the issues discovered fields for the accessiblity sections required.

This is due to accessibility reports not being publishable to the public domain, but we still need to know the findings from the audits done.  