### PR TITLE
docs(wip): move conditions config to a key in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -22,81 +22,46 @@ const config = {
     'component-image': {},
     'accessibility-findings': {},
     'add-external-audit': {
-      '/accessibility-findings': {
-        hasComponentBeenTestedExternalAccessibility: 'yes'
+      conditions: {
+        '/accessibility-findings': {
+          hasComponentBeenTestedExternalAccessibility: 'yes'
+        }
       }
     },
     'add-internal-audit': {
-      '/accessibility-findings': { hasComponentBeenTestedInternalAudit: 'yes' }
+      conditions: {
+        '/accessibility-findings': {
+          hasComponentBeenTestedInternalAudit: 'yes'
+        }
+      }
     },
     'add-assistive-tech': {
-      '/accessibility-findings': {
-        hasComponentBeenTestedUsingAssistiveTechnology: 'yes'
+      conditions: {
+        '/accessibility-findings': {
+          hasComponentBeenTestedUsingAssistiveTechnology: 'yes'
+        }
       }
     },
     prototype: {},
-    'prototype-url': { '/prototype': { componentPrototypeUrl: 'yes' } },
+    'prototype-url': {
+      conditions: {
+        '/prototype': { componentPrototypeUrl: 'yes' }
+      }
+    },
     'component-code': {},
     'component-code-details': {
-      '/component-code': { componentCodeAvailable: 'yes' }
+      conditions: {
+        '/component-code': { componentCodeAvailable: 'yes' }
+      }
     },
     figma: {},
-    'figma-link': { '/figma': { figmaUrl: 'yes' } },
+    'figma-link': {
+      conditions: {
+        '/figma': { figmaUrl: 'yes' }
+      }
+    },
     'your-details': {},
     'check-your-answers': {}
-  },
-  COMPONENT_FORM_PAGES_OPTIONS: {
-    'accessibility-findings': {
-      hasComponentBeenTestedExternalAccessibility: {
-        yes: 'add-external-audit',
-        no: {
-          hasComponentBeenTestedInternalAudit: {
-            yes: 'add-internal-audit',
-            no: {
-              hasComponentBeenTestedUsingAssistiveTechnology: {
-                yes: 'add-assistive-tech',
-                no: 'prototype'
-              }
-            }
-          }
-        }
-      }
-    },
-    'add-external-audit': {
-      hasComponentBeenTestedInternalAudit: {
-        yes: 'add-internal-audit',
-        no: {
-          hasComponentBeenTestedUsingAssistiveTechnology: {
-            yes: 'add-assistive-tech',
-            no: 'prototype'
-          }
-        }
-      }
-    },
-    'add-internal-audit': {
-      hasComponentBeenTestedUsingAssistiveTechnology: {
-        yes: 'add-assistive-tech',
-        no: 'prototype'
-      }
-    },
-    prototype: {
-      componentPrototypeUrl: {
-        yes: 'prototype-url',
-        no: 'component-code'
-      }
-    },
-    'component-code': {
-      componentCodeAvailable: {
-        yes: 'component-code-details',
-        no: 'component-image'
-      }
-    },
-    figma: {
-      figmaUrl: {
-        yes: 'figma-link',
-        no: 'your-details'
-      }
-    }
   },
   ADD_NEW_COMPONENT_ROUTE: '/contribute/add-new-component',
   MAX_ADD_ANOTHER: 10,
@@ -146,9 +111,9 @@ const config = {
       '/component-code-details'
     ],
     ignoreFields: [
-      'componentPrototypeUrl',
-      'figmaUrl',
-      'componentCodeAvailable'
+      // 'componentPrototypeUrl',
+      // 'figmaUrl',
+      // 'componentCodeAvailable'
     ]
   },
   SHARE_YOUR_DETAILS: {

--- a/helpers/next-page.js
+++ b/helpers/next-page.js
@@ -28,7 +28,7 @@ const nextPage = (url, session, body, subpage) => {
 
   for (let i = currentPageIndex + 1; i < pages.length; i++) {
     const page = pages[i]
-    const conditions = COMPONENT_FORM_PAGES[page]
+    const conditions = COMPONENT_FORM_PAGES[page].conditions || {}
     const shouldShowPage = checkConditions(conditions, data)
     if (shouldShowPage) {
       return page

--- a/schema/add-assistive-tech.schema.js
+++ b/schema/add-assistive-tech.schema.js
@@ -76,10 +76,12 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter details about issues discovered by the assistive technology testing',
-      'string.empty': 'Enter details about issues discovered by the assistive technology testing',
+      'any.required':
+        'Enter details about issues discovered by the assistive technology testing',
+      'string.empty':
+        'Enter details about issues discovered by the assistive technology testing',
       'custom.max.words': 'Enter 250 words or less'
-    }),
+    })
 })
 
 module.exports = schema

--- a/schema/add-external-audit.schema.js
+++ b/schema/add-external-audit.schema.js
@@ -86,8 +86,10 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter details about issues discovered by the external audit',
-      'string.empty': 'Enter details about issues discovered by the external audit',
+      'any.required':
+        'Enter details about issues discovered by the external audit',
+      'string.empty':
+        'Enter details about issues discovered by the external audit',
       'custom.max.words': 'Enter 250 words or less'
     })
 })

--- a/schema/add-internal-audit.schema.js
+++ b/schema/add-internal-audit.schema.js
@@ -84,8 +84,10 @@ const schema = Joi.object({
     .required()
     .custom((value, helpers) => maxWords(value, helpers, 250))
     .messages({
-      'any.required': 'Enter details about issues discovered by the internal review',
-      'string.empty': 'Enter details about issues discovered by the internal review',
+      'any.required':
+        'Enter details about issues discovered by the internal review',
+      'string.empty':
+        'Enter details about issues discovered by the internal review',
       'custom.max.words': 'Enter 250 words or less'
     })
 })


### PR DESCRIPTION
In preparation for potential future config changes this PR moves the conditions for the next page into its own `conditions` key on the `COMPONENT_FORM_PAGES` object

