### PR TITLE
Remove multiple image uploads

### DIFF
--- a/config.js
+++ b/config.js
@@ -279,7 +279,7 @@ const config = {
       '/add-assistive-tech'
     ],
     canRemoveMultiples: [
-      '/component-image',
+      // '/component-image',
       '/prototype-url',
       '/figma-link',
       '/component-code-details'

--- a/views/community/pages/component-image.njk
+++ b/views/community/pages/component-image.njk
@@ -89,13 +89,6 @@
             text: 'Continue',
             preventDoubleClick: true
           }) }}
-          {% if showAddAnother %}
-            {{ govukButton({
-              text: "Add another file",
-              classes: "govuk-button--secondary",
-              name: "addAnother"
-            }) }}
-          {% endif %}
         {% else %}
           {{ govukButton({
             text: 'Upload',


### PR DESCRIPTION
For v1 of the contributions we have decided that we don't need to accept more than one image. This reduces our workload and enables us to ship sooner.

This PR removes the ui to add another image.