### PR TITLE
Code contribution changes

### DIFF
--- a/docs/stylesheets/components/_prose.scss
+++ b/docs/stylesheets/components/_prose.scss
@@ -142,7 +142,8 @@
 /// * Consolas - Font for older Windows versions
 /// * Liberation Mono - Font for Linux used by GitHub
 pre,
-code {
+code,
+.font-monospace {
   // font family in a separate variable to avoid syntax errors when passing
   // to the common typography mixin
   $app-code-font: ui-monospace, menlo, "Cascadia Mono", "Segoe UI Mono", consolas, "Liberation Mono", monospace;

--- a/helpers/mockSessionData/sessionData.js
+++ b/helpers/mockSessionData/sessionData.js
@@ -49,7 +49,7 @@ module.exports = {
     componentCodeAvailable: 'yes'
   },
   '/component-code-details': {
-    componentCodeLanguage: 'Other',
+    componentCodeLanguage: 'other',
     componentCodeLanguageOther: 'Nunjucks',
     componentCodeUsage:
       'In lacus ipsum, molestie nec sapien vitae, tincidunt tristique nisi. Integer a lacus quis nisl mollis fringilla. Nullam blandit imperdiet mauris, ac feugiat ante. Vestibulum nec semper nulla, ut ultricies massa. Curabitur lacinia tortor augue, sed varius leo viverra non. Fusce vitae libero ac orci elementum vestibulum eu et libero. In rhoncus laoreet nisi, sit amet rutrum tellus. Ut ut dui in metus sodales molestie eu ut purus.\r\n\r\n',
@@ -70,7 +70,7 @@ module.exports = {
     figmaLinkAdditionalInformation: 'only link'
   },
   '/component-code-details/1': {
-    componentCodeLanguage: 'CSS',
+    componentCodeLanguage: 'css',
     componentCodeUsage: 'Some CSS',
     componentCode: 'style'
   }

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "watch": ["app.js", "config.js", "routes/*.js"],
+  "watch": ["app.js", "config.js", "routes/*.js", "helpers/*.js", "middleware/*.js"],
   "ignore": ["**/*.spec.*"],
   "signal": "SIGINT"
 }

--- a/views/community/pages/component-code-details.njk
+++ b/views/community/pages/component-code-details.njk
@@ -82,6 +82,7 @@
         name: "componentCode",
         id: "component-code",
         maxlength: 10000,
+        classes: 'font-monospace',
         rows: 30,
         label: {
           text: "Add the code",


### PR DESCRIPTION
Updates to the community space related to code details:
* Make the code input monospace
* On cya page only show either the codeLanguage field _or_ the codeLanguageOther field depending on the value of codeLanguage (if it is 'other' only show the CodeLanguageOther field)
* Update the display value for code fields to 'Code provided'
* Update the action for code fields to 'Review & Change'
