### PR TITLE
Personal detail sharing fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -287,9 +287,8 @@ const config = {
     ignoreFields: []
   },
   SHARE_YOUR_DETAILS: {
-    addNameToComponentPage: 'Add name and email address to component page',
-    addTeamNameWhenRequested: 'Only share name and email when requested',
-    doNotSharePersonalDetails: 'Do not share personal details'
+    addNameToComponentPage: 'add my name to the component page',
+    addTeamNameToComponentPage: 'add my team name to the component page',
   }
 }
 

--- a/helpers/check-your-answers.js
+++ b/helpers/check-your-answers.js
@@ -13,11 +13,12 @@ const {
   humanReadableLabel: humanReadableLabelText,
   replaceAcronyms,
   truncateText,
-  sanitizeText
+  sanitizeText,
+  ucFirst
 } = require('./text-helper')
 
 const maxWords = 10000
-const shareYourDetailsKeys = Object.keys(shareYourDetails)
+// const shareYourDetailsKeys = Object.keys(shareYourDetails)
 
 /**
  * Converts a text label to a human-readable format using a predefined mapping.
@@ -90,13 +91,16 @@ const listHTML = (values) => {
  * @returns {string} - The replaced value(s) as an HTML list.
  */
 const shareYourDetailsValueReplacement = (value) => {
-  const values = Array.isArray(value) ? value : [value]
+  let values = Array.isArray(value) ? value : [value]
+  values = values.filter((v) => v) // Remove empty values
+
+  if(values.length === 0) {
+    return "Do not share my details"
+  }
+
   return listHTML(
-    values.map((value) => {
-      if (shareYourDetailsKeys.includes(value)) {
-        return shareYourDetails[value]
-      }
-      return value
+    Object.entries(shareYourDetails).map(([key, value]) => {
+      return ucFirst(`${(!values.includes(key) ? 'do not ' : '')}${value}`)
     })
   )
 }
@@ -166,7 +170,7 @@ const extractFieldData = (field, session, options = {}) => {
     )
   }
 
-  console.log(parsedSession)
+  // console.log(parsedSession)
 
   // Collect all entries that match the field pattern (e.g., /foo, /foo/1, /foo/2)
   const fieldPattern = new RegExp(`^${fieldPath}(?:/\\d+)?$`)
@@ -311,7 +315,7 @@ const checkYourAnswers = (session) => {
       answers: answersFromSession(section.data, session, canRemove)
     })
   })
-  console.log(answers)
+  // console.log(answers)
   return answers
 }
 

--- a/helpers/check-your-answers.js
+++ b/helpers/check-your-answers.js
@@ -67,7 +67,7 @@ const answersFromSession = (data, session, canRemove) => {
       answers.push(...extractFieldData(form, session, defaultConfig))
     }
   })
-  console.log(answers)
+  // console.log(answers)
   return answers
 }
 

--- a/helpers/mockSessionData/sessionData.js
+++ b/helpers/mockSessionData/sessionData.js
@@ -59,7 +59,7 @@ module.exports = {
     fullName: 'test test',
     emailAddress: 'test@test.com',
     teamName: 'The A Team',
-    shareYourDetails: ['addNameToComponentPage', 'addTeamNameWhenRequested']
+    shareYourDetails: ['addNameToComponentPage', 'addTeamNameToComponentPage']
   },
   checkYourAnswers: false,
   '/figma': {

--- a/helpers/text-helper.js
+++ b/helpers/text-helper.js
@@ -30,6 +30,12 @@ const urlToTitleCase = (str) => {
     .join(' ')
 }
 
+const ucFirst = (str) => {
+  if (!str) return str;
+
+  return str[0].toUpperCase() + str.slice(1);
+}
+
 const truncateText = (text, maxWords) => {
   try {
     const words = String(text).split(' ')
@@ -55,5 +61,6 @@ module.exports = {
   urlToTitleCase,
   replaceAcronyms,
   truncateText,
-  sanitizeText
+  sanitizeText,
+  ucFirst
 }

--- a/routes/add-component.js
+++ b/routes/add-component.js
@@ -128,17 +128,17 @@ router.get('/start', (req, res) => {
   })
 })
 
+// Confirmation page
+router.get('/confirmation', (req, res) => {
+  res.render('confirmation')
+})
+
 router.all('*', sessionStarted) // Check that we have a session in progress
 
 router.post('/start',
   verifyCsrf,
   (req, res) => {
   res.redirect('/contribute/add-new-component/component-details')
-})
-
-// Confirmation page
-router.get('/confirmation', (req, res) => {
-  res.render('confirmation')
 })
 
 // Remove form page

--- a/views/community/pages/your-details.njk
+++ b/views/community/pages/your-details.njk
@@ -72,7 +72,7 @@
         value: formData.teamName
       }) }}
 
-      <input type="hidden" name="shareYourDetails" value="" />
+      <input type="hidden" name="shareYourDetails" />
 
       {{ govukCheckboxes({
         name: "shareYourDetails",

--- a/views/community/pages/your-details.njk
+++ b/views/community/pages/your-details.njk
@@ -16,8 +16,7 @@
 {% endif %}
 
 {% set addNameToComponentPage = "addNameToComponentPage" in shareYourDetails %}
-{% set addTeamNameToComponentPage = "addTeamNameWhenRequested" in shareYourDetails %}
-{% set doNotSharePersonalDetailsChecked = "doNotSharePersonalDetails" in shareYourDetails %}
+{% set addTeamNameToComponentPage = "addTeamNameToComponentPage" in shareYourDetails %}
 
 {% block content %}
 
@@ -73,6 +72,8 @@
         value: formData.teamName
       }) }}
 
+      <input type="hidden" name="shareYourDetails" value="" />
+
       {{ govukCheckboxes({
         name: "shareYourDetails",
         id: 'share-your-details',
@@ -92,7 +93,7 @@
             checked: addNameToComponentPage
           },
           {
-            value: "addTeamNameWhenRequested",
+            value: "addTeamNameToComponentPage",
             text: "Add my team name to the component page",
             checked: addTeamNameToComponentPage
           }


### PR DESCRIPTION
Updates for the share details presentation on the CYA page
* Update the key for `TeamName` option
* Ensure `shareYourDetails` gets submitted even when no item is checked
* Update the labels that are displayed on the CYA page.  
