### PR TITLE
fix(interruption card): fix specificity conflicts from govuk-frontend

### DIFF
--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -29,6 +29,7 @@ gulp.task('docs:copy-assets', () => {
 gulp.task('docs:copy-stylesheets', () => {
   return gulp
     .src([
+      'node_modules/@ministryofjustice/frontend/moj/moj-frontend.min.css?(.map)'
       // 'node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.css?(.map)'
     ])
     .pipe(gulp.dest('public/stylesheets'))

--- a/gulp/docs.js
+++ b/gulp/docs.js
@@ -29,7 +29,6 @@ gulp.task('docs:copy-assets', () => {
 gulp.task('docs:copy-stylesheets', () => {
   return gulp
     .src([
-      'node_modules/@ministryofjustice/frontend/moj/moj-frontend.min.css?(.map)'
       // 'node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.css?(.map)'
     ])
     .pipe(gulp.dest('public/stylesheets'))

--- a/src/moj/components/interruption-card/_interruption-card.scss
+++ b/src/moj/components/interruption-card/_interruption-card.scss
@@ -11,9 +11,21 @@
   max-width: 960px;
 }
 
-.moj-interruption-card__heading,
-.moj-interruption-card__body {
+// govuk-heading-l styles with colour set to white
+.moj-interruption-card__heading {
+  display: block;
+  margin-top: 0;
   color: govuk-colour("white");
+  @include govuk-font($size: 36, $weight: bold);
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+// govuk-body-l styles with colour set to white
+.moj-interruption-card__body {
+  margin-top: 0;
+  color: govuk-colour("white");
+  @include govuk-font($size: 24);
+  @include govuk-responsive-margin(6, "bottom");
 }
 
 // If $govuk-global-styles is true, we need to override the color and size on elements

--- a/src/moj/components/interruption-card/template.njk
+++ b/src/moj/components/interruption-card/template.njk
@@ -1,8 +1,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 <div class="moj-interruption-card">
     <div class="moj-interruption-card__content">
-        <h1 class="govuk-heading-l moj-interruption-card__heading">{{- params.heading -}}</h1>
-        <div class="govuk-body-l moj-interruption-card__body">{{ caller() }}</div>
+        <h1 class="moj-interruption-card__heading">{{- params.heading -}}</h1>
+        <div class="moj-interruption-card__body">{{ caller() }}</div>
         <div class="govuk-button-group moj-interruption-card__actions">
             {% if params.primaryAction.style == "link" %}
                 <a class="govuk-link govuk-link--inverse"


### PR DESCRIPTION
There had been reports of both the heading and the body text appearing black.

This was likley due to the `.govuk-heading-l` and `.govuk-body-l` classes
having the same specificity as the `.moj-interruption-card__heading` and
`.moj-interruption-card__body` classes.

To resolve this, the `.govuk-` classes have been removed, and their styles
directly included in the `.moj-` classes. This means govuk styles cannot
override the component styles.  This also has the added advantage that
the text sizing is now baked-in to the component, and users will not be
tempted to change the `.govuk-body-l` class for another size class.
