### PR TITLE
docs: fix footer width

### DIFF
--- a/docs/stylesheets/components/_footer.scss
+++ b/docs/stylesheets/components/_footer.scss
@@ -1,7 +1,9 @@
 @use "../moj-frontend" as *;
+@use "../settings/app";
 
 .govuk-footer--docs {
   .govuk-width-container {
+    max-width: calc(app.$sidebar-width + app.$content-width - govuk-spacing(9));
     margin-right: govuk-spacing(4);
     margin-left: govuk-spacing(4);
   }


### PR DESCRIPTION
Adding `max-width` to footer to ensure width of footer matches width of content and sidebar.

Before:
![image](https://github.com/user-attachments/assets/76eaad01-22b6-4b9f-8270-61553a4fdff7)

After:
![image](https://github.com/user-attachments/assets/a75f1ac9-18c5-424f-b175-253e4879cc9d)
