### PR TITLE
fix(date picker): fix enter key not submitting parent form

### DIFF
--- a/src/moj/components/date-picker/date-picker.mjs
+++ b/src/moj/components/date-picker/date-picker.mjs
@@ -159,9 +159,9 @@ export class DatePicker extends ConfigurableComponent {
       }
     })
 
-    document.body.addEventListener('mouseup', (event) =>
+    document.body.addEventListener('mouseup', (event) => {
       this.backgroundClick(event)
-    )
+    })
 
     // populates calendar with initial dates, avoids Wave errors about null buttons
     this.updateCalendar()
@@ -192,10 +192,10 @@ export class DatePicker extends ConfigurableComponent {
       for (let j = 0; j < 7; j++) {
         // create cell (day)
         const $cell = document.createElement('td')
-        const $dateButton = document.createElement('button')
-
-        $cell.appendChild($dateButton)
         $row.appendChild($cell)
+        const $dateButton = document.createElement('button')
+        $dateButton.setAttribute('type', 'button')
+        $cell.appendChild($dateButton)
 
         const calendarDay = new DSCalendarDay($dateButton, dayCount, i, j, this)
         this.calendarDays.push(calendarDay)
@@ -229,7 +229,7 @@ export class DatePicker extends ConfigurableComponent {
   dialogTemplate(titleId) {
     return `<div class="moj-datepicker__dialog-header">
             <div class="moj-datepicker__dialog-navbuttons">
-              <button class="moj-datepicker__button moj-js-datepicker-prev-year">
+              <button type="button" class="moj-datepicker__button moj-js-datepicker-prev-year">
                 <span class="govuk-visually-hidden">Previous year</span>
                 <svg width="44" height="40" viewBox="0 0 44 40" fill="none" fill="none" focusable="false" aria-hidden="true" role="img">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M23.1643 20L28.9572 14.2071L27.5429 12.7929L20.3358 20L27.5429 27.2071L28.9572 25.7929L23.1643 20Z" fill="currentColor"/>
@@ -237,7 +237,7 @@ export class DatePicker extends ConfigurableComponent {
                 </svg>
               </button>
 
-              <button class="moj-datepicker__button moj-js-datepicker-prev-month">
+              <button type="button" class="moj-datepicker__button moj-js-datepicker-prev-month">
                 <span class="govuk-visually-hidden">Previous month</span>
                 <svg width="44" height="40" viewBox="0 0 44 40" fill="none" focusable="false" aria-hidden="true" role="img">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M20.5729 20L25.7865 14.2071L24.5137 12.7929L18.0273 20L24.5137 27.2071L25.7865 25.7929L20.5729 20Z" fill="currentColor"/>
@@ -248,14 +248,14 @@ export class DatePicker extends ConfigurableComponent {
             <h2 id="${titleId}" class="moj-datepicker__dialog-title moj-js-datepicker-month-year" aria-live="polite">June 2020</h2>
 
             <div class="moj-datepicker__dialog-navbuttons">
-              <button class="moj-datepicker__button moj-js-datepicker-next-month">
+              <button type="button" class="moj-datepicker__button moj-js-datepicker-next-month">
                 <span class="govuk-visually-hidden">Next month</span>
                 <svg width="44" height="40" viewBox="0 0 44 40" fill="none"  focusable="false" aria-hidden="true" role="img">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M23.4271 20L18.2135 14.2071L19.4863 12.7929L25.9727 20L19.4863 27.2071L18.2135 25.7929L23.4271 20Z" fill="currentColor"/>
                 </svg>
               </button>
 
-              <button class="moj-datepicker__button moj-js-datepicker-next-year">
+              <button type="button" class="moj-datepicker__button moj-js-datepicker-next-year">
                 <span class="govuk-visually-hidden">Next year</span>
                 <svg width="44" height="40" viewBox="0 0 44 40" fill="none" fill="none" focusable="false" aria-hidden="true" role="img">
                   <path fill-rule="evenodd" clip-rule="evenodd" d="M20.8357 20L15.0428 14.2071L16.4571 12.7929L23.6642 20L16.4571 27.2071L15.0428 25.7929L20.8357 20Z" fill="currentColor"/>
@@ -841,7 +841,6 @@ class DSCalendarDay {
     this.column = column
     this.$button = $button
     this.picker = picker
-
     this.date = new Date()
     this.$button.addEventListener('keydown', this.keyPress.bind(this))
     this.$button.addEventListener('click', this.click.bind(this))

--- a/src/moj/components/date-picker/date-picker.spec.mjs
+++ b/src/moj/components/date-picker/date-picker.spec.mjs
@@ -36,17 +36,19 @@ function createComponent(params = {}) {
   const html =
     params.html ??
     outdent`
-      <div class="moj-datepicker" data-module="moj-date-picker"${attributes}>
-        <div class="govuk-form-group">
-          <label class="govuk-label" for="date">
-            Date
-          </label>
-          <div id="date-hint" class="govuk-hint">
-            For example, 17/5/2024.
+      <form aria-label="form" action="">
+        <div class="moj-datepicker" data-module="moj-date-picker"${attributes}>
+          <div class="govuk-form-group">
+            <label class="govuk-label" for="date">
+              Date
+            </label>
+            <div id="date-hint" class="govuk-hint">
+              For example, 17/5/2024.
+            </div>
+            <input class="govuk-input moj-js-datepicker-input " id="date" name="date" type="text" aria-describedby="date-hint" autocomplete="off">
           </div>
-          <input class="govuk-input moj-js-datepicker-input " id="date" name="date" type="text" aria-describedby="date-hint" autocomplete="off">
         </div>
-      </div>
+      </form>
     `
 
   document.body.insertAdjacentHTML('afterbegin', html)
@@ -558,6 +560,17 @@ describe('Date picker with defaults', () => {
       expect(dialog).not.toBeVisible()
       expect(input).toHaveValue(`19/5/2024`)
       expect(calendarButton).toHaveFocus()
+    })
+
+    test('return button submits parent form', async () => {
+      const form = screen.queryByRole('form')
+      let submitted = false
+      form.addEventListener('submit', () => {
+        submitted = true
+      })
+      await user.click(input)
+      await user.keyboard('[Enter]')
+      expect(submitted).toBe(true)
     })
   })
 


### PR DESCRIPTION
fix #1591

Fixes an issue where presing <kbd>Enter</kbd> anywhere in a form containing a datepicker would not submit the form as it should.

Some of the buttons within the datepicker did not have `type="button"` so were being activated by the <kbd>Enter</kbd> press as they were the first "submit" button in the form.

