### PR TITLE
docs: fix template var replacement in review issue creation

### DIFF
--- a/app/helpers/text-helper.js
+++ b/app/helpers/text-helper.js
@@ -87,6 +87,32 @@ const titleize = (str) => {
   return ucFirst(str.toLowerCase())
 }
 
+const stripFrontmatter = (str) => {
+  return str.replace(/---[\s\S]*?---/, '').trim()
+}
+
+/**
+ * Replaces placeholders in a template string with values
+ *
+ * @param {string} templateString - string with placeholder values
+ * @param {object} replacements - format {placeholder: replacementValue}
+ * @param {string} [openingTag] - identifier for start of replacement
+ * @param {string} [closingTag] - identifier for end of replacement
+ */
+const replaceTemplateVars = (
+  templateString,
+  replacements,
+  openingTag = '__',
+  closingTag = '__'
+) => {
+  for (const [placeholder, value] of Object.entries(replacements)) {
+    // console.log(`replacing __${placeholder}__ with ${value}`)
+    const pattern = new RegExp(`${openingTag}${placeholder}${closingTag}`, 'g')
+    templateString = templateString.replaceAll(pattern, value)
+  }
+  return templateString
+}
+
 module.exports = {
   humanReadableLabel,
   urlToTitleCase,
@@ -94,5 +120,7 @@ module.exports = {
   sanitizeText,
   ucFirst,
   camelToKebab,
-  titleize
+  titleize,
+  stripFrontmatter,
+  replaceTemplateVars
 }

--- a/app/helpers/text-helper.spec.js
+++ b/app/helpers/text-helper.spec.js
@@ -5,7 +5,9 @@ const {
   truncateText,
   sanitizeText,
   camelToKebab,
-  titleize
+  titleize,
+  stripFrontmatter,
+  replaceTemplateVars
 } = require('./text-helper')
 
 describe('ucFirst', () => {
@@ -62,5 +64,52 @@ describe('titleize', () => {
   })
   it('returns an empty string if called with a falsy val', () => {
     expect(titleize(undefined)).toBe('')
+  })
+})
+
+describe('stripFrontmatter', () => {
+  it('strips frontmatter', () => {
+    const str = `---
+key: value
+---
+This is content
+`
+    expect(stripFrontmatter(str)).toBe('This is content')
+  })
+  it('strips empty frontmatter', () => {
+    const str = `---
+---
+This is content
+`
+    expect(stripFrontmatter(str)).toBe('This is content')
+  })
+})
+
+describe('replaceTemplateVars', () => {
+  it('replaces a value in a single line string', () => {
+    const str = 'My name is __NAME__'
+    const replacements = { NAME: 'Bob' }
+    expect(replaceTemplateVars(str, replacements)).toBe('My name is Bob')
+  })
+  it('replaces values in a multi line string', () => {
+    const str = 'My name is __NAME__\r\nMy age is __AGE__'
+    const replacements = { NAME: 'Bob', AGE: 25 }
+    expect(replaceTemplateVars(str, replacements)).toBe(
+      'My name is Bob\r\nMy age is 25'
+    )
+  })
+  it('allows for tag customisation', () => {
+    const str = 'My name is {{NAME}}\r\nMy age is {{AGE}}'
+    const replacements = { NAME: 'Bob', AGE: 25 }
+    expect(replaceTemplateVars(str, replacements, '{{', '}}')).toBe(
+      'My name is Bob\r\nMy age is 25'
+    )
+  })
+  it('allows doesnt replace if tags dont match', () => {
+    const str = 'My name is __NAME__\r\nMy age is __AGE__'
+    const replacements = { NAME: 'Bob', AGE: 25 }
+    expect(replaceTemplateVars(str, replacements, '{{', '}}')).toBe(
+      'My name is __NAME__\r\nMy age is __AGE__'
+    )
   })
 })


### PR DESCRIPTION
Fixes issue with template vars not being replace within the issue template.  Extracted the methods to do this to the text helpers file in order to add tests.
