### PR TITLE
docs: add csp nonce to main application js module

### DIFF
--- a/docs/_includes/layouts/base.njk
+++ b/docs/_includes/layouts/base.njk
@@ -63,6 +63,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="{{ 'javascripts/application.min.js' | rev }}"></script>
+  <script {%- if cspNonce %} nonce="{{ cspNonce }}"{% endif %} type="module" src="{{ 'javascripts/application.min.js' | rev }}"></script>
   <script {%- if cspNonce %} nonce="{{ cspNonce }}"{% endif %} type="module" src="https://www.googletagmanager.com/gtag/js?id=G-VTGX4YLSVL"></script>
 {% endblock %}


### PR DESCRIPTION
Adds a CSP nonce to the application.js file. This was triggering CSP error in Sentry
