### PR TITLE
docs: minor text tweaks - adding curlies around component names

### DIFF
--- a/docs/components/calendar.md
+++ b/docs/components/calendar.md
@@ -25,7 +25,7 @@ An accessible, scalable calendar component (whole page - not a date picker).
 Used in Visit Someone in Prison to display available times for a prison visit. Soon to be used in Manage People on Probation and another service in LAA to book appointments.
 
 ### Contribute to this component
-You can help develop this component by adding information to the [calendar Github discussion]({{ githuburl }}). This helps other people to use it in their service.
+You can help develop this component by adding information to the [‘calendar’ Github discussion]({{ githuburl }}). This helps other people to use it in their service.
 
 {% endtab %}
 
@@ -33,12 +33,12 @@ You can help develop this component by adding information to the [calendar Githu
 
 ## Designs
 
-A Figma design has been added for this component. There may be more links and resources in the [calendar Github discussion]({{ githuburl }}).
+A Figma design has been added for this component. There may be more links and resources in the [‘calendar’ Github discussion]({{ githuburl }}).
 
 
 ### Figma
 
-If you work for MoJ, [view the calendar component in the MoJ Figma Kit](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?node-id=12870-22).
+If you work for MoJ, [view the ‘calendar’ component in the MoJ Figma Kit](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?node-id=12870-22).
 
 If you work outside MoJ, go to the [MoJ Figma Kit on the Figma community platform](https://www.figma.com/community/file/1543193133973726850/moj-design-system-figma-kit).
 
@@ -53,7 +53,7 @@ If you have design files that are relevant to this component you can add them to
 
 ## Accessibility
 
-Accessibility findings have been added for this component. There may be more findings in the [calendar Github discussion]({{ githuburl }}).
+Accessibility findings have been added for this component. There may be more findings in the [‘calendar’ Github discussion]({{ githuburl }}).
 
 
 ### External audit
@@ -82,7 +82,7 @@ No issues discovered
 
 ## Contribute accessibility findings
 
-    If you have accessibility findings that are relevant to this component you can add them to the [Github discussion]({{ githuburl }}). This helps other people to use it in their service.
+If you have accessibility findings that are relevant to this component you can add them to the [Github discussion]({{ githuburl }}). This helps other people to use it in their service.
 
 {% endtab %}
 
@@ -92,11 +92,11 @@ No issues discovered
 
 No code was included when this contribution was added.
 
-You can use the [calendar Github discussion]({{ githuburl }}) to:
+You can use the [‘calendar’ Github discussion]({{ githuburl }}) to:
 
-* view other code blocks  
+* view other code blocks
 * add relevant code
 
+<p></p>
 {% endtab %}
-
 {% endtabs %}

--- a/docs/components/inset-text-highlighted.md
+++ b/docs/components/inset-text-highlighted.md
@@ -25,7 +25,7 @@ A blue variable version of the inset text component
 To highlight guidance to internal users as part of a service. We hypothesised that the warning component felt too urgent and the inset text could be easily missed or ignored in this context. Users are time-poor and expected to read through a fair bit of guidance. This component was being used by the DVLA to highlight content to users. This guidance inset has tested well and especially with users with access needs, they remarked that it helped them break down the content visually to process the content easier.
 
 ### Contribute to this component
-You can help develop this component by adding information to the [inset text (highlighted) Github discussion]({{ githuburl }}). This helps other people to use it in their service.
+You can help develop this component by adding information to the [‘inset text (highlighted)’ Github discussion]({{ githuburl }}). This helps other people to use it in their service.
 
 {% endtab %}
 
@@ -35,7 +35,7 @@ You can help develop this component by adding information to the [inset text (hi
 
 A Figma design was not included when this component was added.
 
-There may be more information in the [inset text (highlighted) Github discussion]({{ githuburl }}). You can also view the component image in the overview.
+There may be more information in the [‘inset text (highlighted)’ Github discussion]({{ githuburl }}). You can also view the component image in the overview.
 
 ## Contribute a Figma link
 
@@ -47,7 +47,7 @@ If you have a Figma link for this component (or a component like it) you can add
 
 ## Accessibility
 
-Accessibility findings have been added for this component. There may be more findings in the [inset text (highlighted) Github discussion]({{ githuburl }}).
+Accessibility findings have been added for this component. There may be more findings in the [‘inset text (highlighted)’ Github discussion]({{ githuburl }}).
 
 
 ### External audit
@@ -76,7 +76,7 @@ If you have accessibility findings that are relevant to this component you can a
 
 ## Code
 
-Code has been added for this component. There may be other code blocks in the [inset text (highlighted) Github discussion]({{ githuburl }}).
+Code has been added for this component. There may be other code blocks in the [‘inset text (highlighted)’ Github discussion]({{ githuburl }}).
 
 
 ### Code block 1: Nunjucks

--- a/docs/components/interruption-card.md
+++ b/docs/components/interruption-card.md
@@ -113,6 +113,7 @@ There’s also the:
 - [GOV.UK Design System panel](https://design-system.service.gov.uk/components/panel/)
 - [GOV.UK Design System notification banner](https://design-system.service.gov.uk/components/notification-banner/)
 
+<p></p>
 {% endtab %}
 
 {% tab "How to use" %}

--- a/docs/components/progress-tracker.md
+++ b/docs/components/progress-tracker.md
@@ -29,7 +29,7 @@ This differs from a timeline in that it does not log events and grow. It is a pr
 On the Make and register LPA product we support the tracker with banners above detailing connected events and directions to dated comms from Notify.
 
 ### Contribute to this component
-You can help develop this component by adding information to the [progress tracker Github discussion]({{ githuburl }}). This helps other people to use it in their service.
+You can help develop this component by adding information to the [‘progress tracker’ Github discussion]({{ githuburl }}). This helps other people to use it in their service.
 
 {% endtab %}
 
@@ -37,12 +37,12 @@ You can help develop this component by adding information to the [progress track
 
 ## Designs
 
-A Figma design has been added for this component. There may be more links and resources in the [progress tracker Github discussion]({{ githuburl }}).
+A Figma design has been added for this component. There may be more links and resources in the [‘progress tracker’ Github discussion]({{ githuburl }}).
 
 
 ### Figma
 
-If you work for MoJ, [view the progress tracker component in the MoJ Figma Kit](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?node-id=12629-923).
+If you work for MoJ, [view the ‘progress tracker’ component in the MoJ Figma Kit](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MoJ-Figma-Kit?node-id=12629-923).
 
 If you work outside MoJ, go to the [MoJ Figma Kit on the Figma community platform](https://www.figma.com/community/file/1543193133973726850/moj-design-system-figma-kit).
 
@@ -57,7 +57,7 @@ If you have design files that are relevant to this component you can add them to
 
 ## Accessibility
 
-Accessibility findings have been added for this component. There may be more findings in the [progress tracker Github discussion]({{ githuburl }}).
+Accessibility findings have been added for this component. There may be more findings in the [‘progress tracker’ Github discussion]({{ githuburl }}).
 
 
 ### External audit
@@ -87,7 +87,7 @@ If you have accessibility findings that are relevant to this component you can a
 
 ## Code
 
-Code has been added for this component. There may be other code blocks in the [progress tracker Github discussion]({{ githuburl }}).
+Code has been added for this component. There may be other code blocks in the [‘progress tracker’ Github discussion]({{ githuburl }}).
 
 
 ### Code block 1: HTML


### PR DESCRIPTION
Adds curly quotes around the component name in the new experimental components.

"fixes" a weird bug with li's containing p tags if they are the last thing in a tab shortcode. This is a bit of a hack, but it works!
