### PR TITLE
docs: turn off report-only mode for content security policy

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -56,7 +56,7 @@ if (!(isDev || isTest)) {
     helmet({
       contentSecurityPolicy: {
         useDefaults: true,
-        reportOnly: true,
+        reportOnly: false,
         directives: {
           reportUri: SENTRY_CSP_REPORT_URI,
           scriptSrc: [


### PR DESCRIPTION
Fully enables the CSP. No issues have been reported to sentry in two weeks, so it should be fine to enforce the rules
