### PR TITLE
Update example shortcode

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -62,51 +62,7 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.setLibrary('md', md)
 
-  eleventyConfig.addShortcode('example', function (exampleHref, height) {
-    let { data, content: nunjucksCode } = matter(
-      fs
-        .readFileSync(
-          path.join(__dirname, 'docs', exampleHref, 'index.njk'),
-          'utf8'
-        )
-        .trim()
-    )
-
-    nunjucksCode = nunjucksCode.split('<!--no include-->')[0].trim()
-
-    const rawHtmlCode = nunjucksEnv.renderString(nunjucksCode)
-
-    const htmlCode = beautifyHTML(rawHtmlCode.trim(), {
-      indent_size: 2,
-      end_with_newline: true,
-      max_preserve_newlines: 1,
-      unformatted: ['code', 'pre', 'em', 'strong']
-    })
-
-    let jsCode = ''
-    try {
-      jsCode = fs
-        .readFileSync(
-          path.join(__dirname, 'docs', exampleHref, 'script.js'),
-          'utf8'
-        )
-        .trim()
-    } catch {}
-
-    return nunjucksEnv.render('example.njk', {
-      href: exampleHref,
-      id: exampleHref.replace(/\//g, '-'),
-      arguments: data.arguments,
-      figmaLink: data.figma_link,
-      title: data.title,
-      height,
-      nunjucksCode,
-      htmlCode,
-      jsCode
-    })
-  })
-
-  eleventyConfig.addShortcode('exampleNew', function (params) {
+  eleventyConfig.addShortcode('example', function (params) {
     let templateFile = ''
     try {
       templateFile = fs

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -14,7 +14,7 @@
     </li>
     {%- if jsCode -%}
     <li class="app-tabs__list-item" role="presentation">
-      <a class="app-tabs__tab" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}">JavaScript <span class="govuk-visually-hidden">({{ title }})</span></a>
+      <a class="app-tabs__tab" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "javascript" }}>JavaScript <span class="govuk-visually-hidden">({{ title }})</span></a>
     </li>
     {%- endif -%}
     {%- if figmaLink -%}

--- a/docs/archive/banner.md
+++ b/docs/archive/banner.md
@@ -12,7 +12,7 @@ excerpt: "Use the banner component to display a prominent message and related ac
 Use the [alert](/components/alert) to display a notification to users.
 {% endbanner %}
 
-{% example "/examples/banner", 225 %}
+{% example template="/examples/banner", height=225 %}
 
 ## When to use
 
@@ -34,16 +34,16 @@ It can be configured with and without icons and in different colours for success
 
 This is the default style and should be used when the user performs an action successfully.
 
-{% example "/examples/banner-success", 175 %}
+{% example template="/examples/banner-success", height=175 %}
 
 ### Warning
 
 Use this variant when you want to warn the user that something went wrong.
 
-{% example "/examples/banner-warning", 175 %}
+{% example template="/examples/banner-warning", height=175 %}
 
 ### Information
 
 Use this variant when you want to tell users some information.
 
-{% example "/examples/banner-information", 175 %}
+{% example template="/examples/banner-information", height=175 %}

--- a/docs/archive/currency-input.md
+++ b/docs/archive/currency-input.md
@@ -11,7 +11,7 @@ excerpt: "The currency input component helped users enter an amount of money in 
 You should use [prefixes and suffixes](https://design-system.service.gov.uk/components/text-input/#prefixes-and-suffixes) in the GOV.UK Design System to help users enter things like currencies.
 {% endbanner %}
 
-{% example "/examples/currency-input", 200 %}
+{% example template="/examples/currency-input", height=200 %}
 
 ## When to use
 

--- a/docs/archive/form-validator.md
+++ b/docs/archive/form-validator.md
@@ -14,7 +14,7 @@ You must validate forms on the server-side. If you require client-side validatio
 For more complex validation, use an accessible validation library.
 {% endbanner %}
 
-{% example "/examples/form-validator", 1000 %}
+{% example template="/examples/form-validator", height=1000 %}
 
 ## When to use
 

--- a/docs/archive/password-reveal.md
+++ b/docs/archive/password-reveal.md
@@ -12,7 +12,7 @@ excerpt: "Use the password reveal component to let users check their password sa
 This component was archived because the [GOV.UK Design System password input](https://design-system.service.gov.uk/components/password-input/) enables users to check their password safely. There’s also the [GOV.UK Design System ‘Ask users for passwords’ pattern](https://design-system.service.gov.uk/patterns/passwords/).
 {% endbanner %}
 
-{% example "/examples/password-reveal", 210 %}
+{% example template="/examples/password-reveal", height=210 %}
 
 ## When to use
 

--- a/docs/archive/rich-text-editor.md
+++ b/docs/archive/rich-text-editor.md
@@ -13,7 +13,7 @@ This component is not sufficiently accessible to be used in live services.
 You should use an accessible rich text editor.
 {% endbanner %}
 
-{% example "/examples/rich-text-editor", 300 %}
+{% example template="/examples/rich-text-editor", height=300 %}
 
 ## When to use
 
@@ -36,4 +36,4 @@ You can also add bold, underline and italic buttons but these styles should be u
 
 You can customise the formatting options shown in the toolbar with the `data-toolbar` attribute.
 
-{% example "/examples/rich-text-editor-formatting", 300 %}
+{% example template="/examples/rich-text-editor-formatting", height=300 %}

--- a/docs/archive/task-list.md
+++ b/docs/archive/task-list.md
@@ -13,4 +13,4 @@ This page has been archived as a [task list](https://design-system.service.gov.u
 
 A coded example of a task list is below, which is not yet in the GOV.UK Design System. There is also a [coded example of a task list page](https://govuk-prototype-kit.herokuapp.com/docs/templates/task-list) in the GOV.UK Prototype Kit.
 
-{% example "/examples/task-list", 600 %}
+{% example template="/examples/task-list", height=600 %}

--- a/docs/components/add-another.md
+++ b/docs/components/add-another.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/686
 excerpt: "Use this component when users need to add similar information a couple of times, such as several names for a single application."
 ---
 
-{% example "/examples/add-another", 664 %}
+{% example template="/examples/add-another", height=664 %}
 
 ## When to use
 

--- a/docs/components/alert.md
+++ b/docs/components/alert.md
@@ -11,7 +11,7 @@ lede: "The alert component uses visual design to display a notification to users
 {% tabs "paginate" %}
 {% tab "Overview" %}
 
-{% example "/examples/alert" %}
+{% example template="/examples/alert", height=540 %}
 
 ## Overview
 
@@ -28,7 +28,7 @@ There are 4 variants of the alert:
 
 ### Information alert
 
-{% example "/examples/alert-information" %}
+{% example template="/examples/alert-information", height=150 %}
 
 The information alert draws a user's attention to something important about a page or service. It has a blue border, and an information icon made up of a blue circle with a white letter 'i'.
 
@@ -52,7 +52,7 @@ Do not use this component for a serious issue or to prevent something going wron
 
 ### Success alert
 
-{% example "/examples/alert-success" %}
+{% example template="/examples/alert-success", height=150 %}
 
 The success alert displays a single message after a user has completed a task. It has a green border, and a success icon made up of a green tick.
 
@@ -77,7 +77,7 @@ You may not need to display the alert if something else confirms success, for ex
 
 ### Warning alert
 
-{% example "/examples/alert-warning" %}
+{% example template="/examples/alert-warning", height=150 %}
 
 The warning alert tells users about something to prevent them from making a mistake. Use it sparingly to avoid alert fatigue. It has an orange border, and a warning icon made up of an orange triangle with a white exclamation mark.
 
@@ -97,7 +97,7 @@ Do not use this component if the information is about something other than a war
 
 ### Error alert
 
-{% example "/examples/alert-error" %}
+{% example template="/examples/alert-error", height=150 %}
 
 The error alert shows the user that something has gone wrong. It pauses the user without interrupting them. It can appear before or after a user input. It has a red border, and an error icon made up of a red octagon with a white 'X'.
 
@@ -153,7 +153,7 @@ The alert content needs to make sense on its own. This ensures that the message 
 
 ### Dismissing the alert
 
-{% example "/examples/alert-dismissible" %}
+{% example template="/examples/alert-dismissible", height=150 %}
 
 The alert can stay on the page (be persistent) or be dismissed by the user. Dismissing it helps users to manage tasks and keep their interfaces clear. It's particularly helpful for the success alert, where there's nothing more for the user to do.
 

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/687
 excerpt: "Use the badge component to highlight small details like an urgent case."
 ---
 
-{% example "/examples/badge", 125 %}
+{% example template="/examples/badge", height=125 %}
 
 ## When to use
 
@@ -24,9 +24,9 @@ There's also the ['Tag' component in the GOV.UK Design System](https://design-sy
 
 The default, neutral badge is blue. Alternative styles are also available, for example, green and red.
 
-{% example "/examples/badge-complete", 125 %}
+{% example template="/examples/badge-complete", height=125 %}
 
-{% example "/examples/badge-urgent", 125 %}
+{% example template="/examples/badge-urgent", height=125 %}
 
 ## Additional styles
 

--- a/docs/components/button-menu.md
+++ b/docs/components/button-menu.md
@@ -11,7 +11,7 @@ lede: "The button menu is a versatile component that allows users to view tasks 
 {% tabs "paginate" %}
 {% tab "Overview" %}
 
-{% example "/examples/button-menu", 250 %}
+{% example template="/examples/button-menu", height=250 %}
 
 ## Overview
 
@@ -81,17 +81,17 @@ Placing the menu on the right may stop it from obscuring other items on the scre
 
 ### Left-aligned menu items
 
-{% example "/examples/button-menu-left-aligned", 275 %}
+{% example template="/examples/button-menu-left-aligned", height=275 %}
 
 ### Right-aligned menu items
 
-{% example "/examples/button-menu-right-aligned", 275 %}
+{% example template="/examples/button-menu-right-aligned", height=275 %}
 
 ### Grouping buttons
 
 You can add a button menu alongside a link or GOV.UK button. This code has correct spacing and creates a better user experience for people on mobile devices.
 
-{% example "/examples/button-menu-grouped", 275 %}
+{% example template="/examples/button-menu-grouped", height=275 %}
 
 ### Button colour
 

--- a/docs/components/date-picker.md
+++ b/docs/components/date-picker.md
@@ -12,7 +12,7 @@ lede: "The date picker component enables users to select a date from a calendar.
 {% tabs "paginate" %}
 {% tab "Overview" %}
 
-{% example "/examples/date-picker", 590 %}
+{% example template="/examples/date-picker", height=590 %}
 
 ## Overview
 
@@ -72,7 +72,7 @@ You can exclude (or disable) options from the date picker, such as:
 - specific dates, such as bank holidays
 - past or future dates
 
-{% example "/examples/date-picker-excluded-dates", 590 %}
+{% example template="/examples/date-picker-excluded-dates", height=590 %}
 
 You need to add server-side validation for when users enter an unavailable date directly into the text field (rather than use the calendar). This will show them an error message.
 
@@ -84,7 +84,7 @@ If there are not many available dates, users will have to navigate a lot to find
 
 Follow the [GOV.UK Design System guidance on error messages](https://design-system.service.gov.uk/components/error-message/).
 
-{% example "/examples/date-picker-error", 590 %}
+{% example template="/examples/date-picker-error", height=590 %}
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/docs/components/filter.md
+++ b/docs/components/filter.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/197
 excerpt: "Use the filter component to help users filter a list of items, such as a list of cases or search results."
 ---
 
-{% example "/examples/filter", 1000 %}
+{% example template="/examples/filter", height=1000 %}
 
 ## When to use
 

--- a/docs/components/header.md
+++ b/docs/components/header.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/246
 excerpt: "Use the header component for any service or system not on GOV.UK like internal staff."
 ---
 
-{% example "/examples/header", 150 %}
+{% example template="/examples/header", height=150 %}
 
 ## When to use
 

--- a/docs/components/identity-bar.md
+++ b/docs/components/identity-bar.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/704
 excerpt: "Use the identity bar component to give users context of where they are within a service such as viewing a case."
 ---
 
-{% example "/examples/identity-bar", 150 %}
+{% example template="/examples/identity-bar", height=150 %}
 
 ## Overview
 
@@ -33,16 +33,16 @@ There's also the:
 
 You can use buttons to display tasks which relate to the identity bar.
 
-{% example "/examples/identity-bar-menu", 150 %}
+{% example template="/examples/identity-bar-menu", height=150 %}
 
 ### Displaying a menu of tasks
 
 You can use the [button menu](/components/button-menu/) to display tasks which relate to the identity bar.
 
-{% example "/examples/identity-bar-menu-toggle", 300 %}
+{% example template="/examples/identity-bar-menu-toggle", height=300 %}
 
 ### Displaying primary and secondary tasks
 
 You can use the [button menu](/components/button-menu/) alongside a [GOV.UK button](https://design-system.service.gov.uk/components/button/) (or link) to show tasks of differing importance which relate to the identity bar. This code has correct spacing and creates a better user experience for people on mobile devices.
 
-{% example "/examples/identity-bar-secondary-toggle", 300 %}
+{% example template="/examples/identity-bar-secondary-toggle", height=300 %}

--- a/docs/components/interruption-card.md
+++ b/docs/components/interruption-card.md
@@ -11,7 +11,7 @@ lede: "The interruption card component pauses a user’s journey with important 
 {% tabs "paginate" %}
 {% tab "Overview" %}
 
-{% example "/examples/interruption-card", 590 %}
+{% example template="/examples/interruption-card", height=590 %}
 
 ## Overview
 

--- a/docs/components/messages.md
+++ b/docs/components/messages.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/705
 excerpt: "Use this component in your service to display a list of messages in chronological order between different people or systems. "
 ---
 
-{% example "/examples/messages", 500 %}
+{% example template="/examples/messages", height=500 %}
 
 ## When to use
 

--- a/docs/components/multi-file-upload.md
+++ b/docs/components/multi-file-upload.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/264
 excerpt: "Use the multi file upload component to help users upload multiple files at the same time, on a regular basis."
 ---
 
-{% example "/examples/multi-file-upload", 550 %}
+{% example template="/examples/multi-file-upload", height=550 %}
 
 ## When to use
 
@@ -62,14 +62,14 @@ When JavaScript is not available, users will be presented with a [file upload co
 
 When the user selects the upload button, the page will refresh with the valid files being shown in the feedback area.
 
-{% example "/examples/multi-file-upload-no-js", 485 %}
+{% example template="/examples/multi-file-upload-no-js", height=485 %}
 
 When there are multiple files with errors, you must put:
 
 - separate error messages in the [error summary from the GOV.UK Design System](https://design-system.service.gov.uk/components/error-summary/) — each one must link to the multi file upload
 - all [error messages next to the field](https://design-system.service.gov.uk/components/error-message/) separated by a line break (`<br>`)
 
-{% example "/examples/multi-file-upload-no-js-errors", 775 %}
+{% example template="/examples/multi-file-upload-no-js-errors", height=775 %}
 
 If the form contains other questions and the user selects the upload button:
 

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/206
 excerpt: "Use the multi select component to let users select multiple items in a list."
 ---
 
-{% example "/examples/multi-select", 650 %}
+{% example template="/examples/multi-select", height=650 %}
 
 ## When to use
 

--- a/docs/components/notification-badge.md
+++ b/docs/components/notification-badge.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/706
 excerpt: "The notification badge lets the user know that there is new information to view, like unread messages, and how many of them there are."
 ---
 
-{% example "/examples/notification-badge", 125 %}
+{% example template="/examples/notification-badge", height=125 %}
 
 ## When to use
 

--- a/docs/components/organisation-switcher.md
+++ b/docs/components/organisation-switcher.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/239
 excerpt: "Use the organisation switcher component to let users navigate between different organisations or accounts, for example, switching between prisons."
 ---
 
-{% example "/examples/organisation-switcher", 125 %}
+{% example template="/examples/organisation-switcher", height=125 %}
 
 ## When to use
 

--- a/docs/components/page-header-actions.md
+++ b/docs/components/page-header-actions.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/707
 excerpt: "Use the page header actions component for certain actions."
 ---
 
-{% example "/examples/page-header-actions", 150 %}
+{% example template="/examples/page-header-actions", height=150 %}
 
 ## When to use
 

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -12,7 +12,7 @@ The [Pagination component](https://design-system.service.gov.uk/components/pagin
 You should use the GOV.UK version if it fits your needs.
 {% endbanner %}
 
-{% example "/examples/pagination", 125 %}
+{% example template="/examples/pagination", height=125 %}
 
 ## When to use
 
@@ -26,4 +26,4 @@ Don't show pagination if there's only one page.
 
 ### Just previous and next buttons
 
-{% example "/examples/pagination-prev-next", 125 %}
+{% example template="/examples/pagination-prev-next", height=125 %}

--- a/docs/components/primary-navigation.md
+++ b/docs/components/primary-navigation.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/710
 excerpt: "Use the primary navigation component to let users navigate and search your service."
 ---
 
-{% example "/examples/primary-navigation", 150 %}
+{% example template="/examples/primary-navigation", height=150 %}
 
 ## When to use
 
@@ -26,7 +26,7 @@ Do not put calls to action in the primary navigation. For example, ‘Create cas
 
 If your service can search anything, use an inline search form.
 
-{% example "/examples/primary-navigation-inline-search", 180 %}
+{% example template="/examples/primary-navigation-inline-search", height=180 %}
 
 ### Toggle search
 
@@ -34,4 +34,4 @@ If your service can only search for certain things, use a toggle search form.
 
 You must tell users what they are searching for in the form hint text, and how they can search using the `data-toggle-button.text` attribute.
 
-{% example "/examples/primary-navigation-toggle-search", 250 %}
+{% example template="/examples/primary-navigation-toggle-search", height=250 %}

--- a/docs/components/scrollable-pane.md
+++ b/docs/components/scrollable-pane.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/711
 excerpt: "Use the scrollable pane component when you have content (typically a table) which unavoidably overflows the page."
 ---
 
-{% exampleNew  template="/examples/scrollable-pane", height=470, showTab="nunjucks" %}
+{% example template="/examples/scrollable-pane", height=470 %}
 
 ## When to use
 

--- a/docs/components/search.md
+++ b/docs/components/search.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/712
 excerpt: "Use the search component to let users search by word or phrase."
 ---
 
-{% example "/examples/search", 200 %}
+{% example template="/examples/search", height=200 %}
 
 ## When to use
 

--- a/docs/components/side-navigation.md
+++ b/docs/components/side-navigation.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/713
 excerpt: "Use the side navigation component to let users navigate sub sections in a system or service."
 ---
 
-{% example "/examples/side-navigation", 250 %}
+{% example template="/examples/side-navigation", height=250 %}
 
 ## When to use
 
@@ -24,7 +24,7 @@ The component can be configured to group navigation items into sections
 
 ### Sections
 
-{% example "/examples/side-navigation-sections", 480 %}
+{% example template="/examples/side-navigation-sections", height=480 %}
 
 ## Accessibility issues
 

--- a/docs/components/sortable-table.md
+++ b/docs/components/sortable-table.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/269
 excerpt: "Use the sortable table component to let users sort columns in ascending or descending order."
 ---
 
-{% example "/examples/sortable-table", 450 %}
+{% example template="/examples/sortable-table", height=450 %}
 
 ## When to use
 

--- a/docs/components/sub-navigation.md
+++ b/docs/components/sub-navigation.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/714
 excerpt: "Use the sub navigation component to let users navigate sub sections in a system or service."
 ---
 
-{% example "/examples/sub-navigation", 150 %}
+{% example template="/examples/sub-navigation", height=150 %}
 
 ## When to use
 

--- a/docs/components/ticket-panel.md
+++ b/docs/components/ticket-panel.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/715
 excerpt: "Break up content or actions into visually distinct groups of information."
 ---
 
-{% example "/examples/ticket-panel", 300 %}
+{% example template="/examples/ticket-panel", height=300 %}
 
 Break up content or actions into visually distinct groups of information.
 

--- a/docs/components/timeline.md
+++ b/docs/components/timeline.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/716
 excerpt: "Use the timeline component to show a linear record of what’s happened."
 ---
 
-{% example "/examples/timeline", 454 %}
+{% example template="/examples/timeline", height=454 %}
 
 ## When to use
 

--- a/docs/javascripts/tabs.mjs
+++ b/docs/javascripts/tabs.mjs
@@ -67,8 +67,7 @@ export class Tabs extends Component {
 
       panel.setAttribute('role', 'tabpanel')
       panel.setAttribute('aria-labelledby', tab.id)
-      console.log(tab.getAttribute('aria-selected'))
-      if (tab.getAttribute('aria-selected') === "false") {
+      if (tab.getAttribute('aria-selected') === 'false') {
         panel.classList.add(this.cssHide)
       }
     })

--- a/docs/patterns/filter-a-list.md
+++ b/docs/patterns/filter-a-list.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/717
 excerpt: "Use this pattern to help users refine a set of items either in a list or a set of search results."
 ---
 
-{% example "/examples/patterns/filter-a-list", 1050 %}
+{% example template="/examples/patterns/filter-a-list", height=1050 %}
 
 ## When to use
 

--- a/docs/patterns/get-help.md
+++ b/docs/patterns/get-help.md
@@ -6,7 +6,7 @@ githuburl: https://github.com/ministryofjustice/moj-frontend/discussions/718
 excerpt: "Help users get help from within the digital service."
 ---
 
-{% example "/examples/patterns/get-help", 250 %}
+{% example template="/examples/patterns/get-help", height=250 %}
 
 ## When to use
 

--- a/docs/patterns/upload-files.md
+++ b/docs/patterns/upload-files.md
@@ -35,7 +35,7 @@ How you help users upload files depends on whether they need to upload:
 
 Use the [file upload component in the GOV.UK Design System](https://design-system.service.gov.uk/components/file-upload/) to let users upload a single file.
 
-{% example "/examples/patterns/upload-files", 350 %}
+{% example template="/examples/patterns/upload-files", height=350 %}
 
 Once users have uploaded their file, let them check it’s the right one by showing a preview.
 
@@ -43,13 +43,13 @@ For files where a preview might be difficult to check, consider how you can help
 
 For example, if the file is a spreadsheet, you could show its contents in a table.
 
-{% example "/examples/patterns/upload-files-check", 950 %}
+{% example template="/examples/patterns/upload-files-check", height=950 %}
 
 ### Let users upload additional files
 
 If users need the option to upload more than one file, include an additional screen asking if they want to upload another.
 
-{% example "/examples/patterns/upload-files-another", 600 %}
+{% example template="/examples/patterns/upload-files-another", height=600 %}
 
 ### Deleting a file
 
@@ -57,11 +57,11 @@ What happens when a user deletes a file depends on whether the list contains 1 f
 
 If there's multiple files in the list, display a success message at the top of the page.
 
-{% example "/examples/patterns/upload-files-delete-multiple", 690 %}
+{% example template="/examples/patterns/upload-files-delete-multiple", height=690 %}
 
 If there's 1 file in the list, take users to the upload screen with a success message at the top of the page.
 
-{% example "/examples/patterns/upload-files-delete-one", 420 %}
+{% example template="/examples/patterns/upload-files-delete-one", height=420 %}
 
 ### Let users upload multiple files at once
 


### PR DESCRIPTION
This PR updates the example shortcode to take named arguments. This makes it easier to use, as arguments can be provided in any order and omitted. It also makes the shortcode easier to read and understand in the markdown files.

**Before:** `{% example "/examples/banner", 225 %}`

**After:** `{% example template="/examples/banner", height=225 %}`

The motivation for doing this was adding a third (and maybe fourth, later) argument.  At this point named args are basically essential to make the shortcode usable.

An argument `showTab` can be passed to the shortcode, which allows setting one of the tabs to be open on load. A feature we were wanting in the notification badge docs.

`{% example template="/examples/banner", height=225, showTab="html" %}`
