### PR TITLE
ci: remove permissions for publish semantic release step

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -98,11 +98,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [result]
-    permissions:
-      contents: write # to be able to publish a GitHub release
-      issues: write # to be able to comment on released issues
-      pull-requests: write # to be able to comment on released pull requests
-      id-token: write # to enable use of OIDC for npm provenance
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
the permissions block seems to be supercede or override the admin pat token


