### PR TITLE
docs: fix missing contributorname in header for experimental components

### DIFF
--- a/docs/_includes/macros/status-label/template.njk
+++ b/docs/_includes/macros/status-label/template.njk
@@ -5,7 +5,7 @@
     {%- if params.contributorTeam %}
       by {{ params.contributorName | default("someone") }} in ‘{{ params.contributorTeam }}’
     {%- elif params.contributorName %}
-      by {{ contributorName  }}
+      by {{ params.contributorName  }}
     {% endif %}
   {% endif %}
   {%- if params.statusDate %}


### PR DESCRIPTION
adds missing `params.` to make the contributor name appear when there isn't a team name
