### PR TITLE
fix DatePicker component minDate bug

### DIFF
--- a/src/moj/components/date-picker/date-picker.mjs
+++ b/src/moj/components/date-picker/date-picker.mjs
@@ -314,6 +314,7 @@ export class DatePicker extends ConfigurableComponent {
   setMinAndMaxDatesOnCalendar() {
     if (this.config.minDate) {
       this.minDate = this.formattedDateFromString(this.config.minDate, null)
+      if (this.minDate) this.minDate.setDate(this.minDate.getDate() + 1)
       if (this.minDate && this.currentDate < this.minDate) {
         this.currentDate = this.minDate
       }
@@ -444,7 +445,7 @@ export class DatePicker extends ConfigurableComponent {
     const month = match[3]
     const year = match[4]
 
-    formattedDate = new Date(`${year}-${month}-${day}`)
+    formattedDate = new Date(Number(year), Number(month) - 1, Number(day))
     if (
       formattedDate instanceof Date &&
       Number.isFinite(formattedDate.getTime())
@@ -652,6 +653,11 @@ export class DatePicker extends ConfigurableComponent {
 
     // get the date from the input element
     this.inputDate = this.formattedDateFromString(this.$input.value)
+
+    // move input date to the closest selectable date if it is out of range
+    if (this.minDate && this.minDate > this.inputDate) this.inputDate = new Date(this.minDate)
+    if (this.maxDate && this.maxDate < this.inputDate) this.inputDate = new Date(this.maxDate)
+
     this.currentDate = this.inputDate
     this.currentDate.setHours(0, 0, 0, 0)
 

--- a/src/moj/components/date-picker/template.njk
+++ b/src/moj/components/date-picker/template.njk
@@ -45,6 +45,7 @@
       formGroup: params.formGroup,
       label: params.label,
       hint: params.hint,
-      errorMessage: params.errorMessage
+      errorMessage: params.errorMessage,
+      attributes: params.attributes
     }) }}
 </div>


### PR DESCRIPTION
the minDate property of the DatePicker component has not work consistently because of a discrepancy in javascript date object instantiation method:

<img width="386" height="170" alt="image" src="https://github.com/user-attachments/assets/8550535a-b072-424a-a6df-0bf70d9ca000" />

This PR changes the minDate/maxDate's date instantiate to use `new Date(year, month, day)` (in consistent with the days on the calendar) so that it remains consistent across BST and GMT.

This PR also offset minDate by one day in order to retain the component's existing behaviour (ie, the minDate itself is excluded on the calendar).

A minor enhancement is added to open the calendar dialog to the closest selectable date, if the default day is out of range.