### PR TITLE
fix minDate bug (#1884)

### DIFF
--- a/src/moj/components/date-picker/date-picker.mjs
+++ b/src/moj/components/date-picker/date-picker.mjs
@@ -314,7 +314,6 @@ export class DatePicker extends ConfigurableComponent {
   setMinAndMaxDatesOnCalendar() {
     if (this.config.minDate) {
       this.minDate = this.formattedDateFromString(this.config.minDate, null)
-      if (this.minDate) this.minDate.setDate(this.minDate.getDate() + 1)
       if (this.minDate && this.currentDate < this.minDate) {
         this.currentDate = this.minDate
       }
@@ -322,7 +321,6 @@ export class DatePicker extends ConfigurableComponent {
 
     if (this.config.maxDate) {
       this.maxDate = this.formattedDateFromString(this.config.maxDate, null)
-
       if (this.maxDate && this.currentDate > this.maxDate) {
         this.currentDate = this.maxDate
       }
@@ -654,10 +652,16 @@ export class DatePicker extends ConfigurableComponent {
 
     // get the date from the input element
     this.inputDate = this.formattedDateFromString(this.$input.value)
-
-    // move input date to the closest selectable date if it is out of range
-    if (this.minDate && this.minDate > this.inputDate) this.inputDate = new Date(this.minDate)
-    if (this.maxDate && this.maxDate < this.inputDate) this.inputDate = new Date(this.maxDate)
+    // move current date to the closest selectable date if it is out of range
+    if (this.minDate && this.minDate > this.inputDate) {
+      this.inputDate = new Date(this.minDate.getTime())
+    }
+    if (this.maxDate && this.maxDate < this.inputDate) {
+      this.inputDate = new Date(this.maxDate.getTime())
+    }
+    if (this.minDate && this.maxDate && this.minDate > this.maxDate) {
+      console.error('min date is after max date. No dates will be selectable')
+    }
 
     this.currentDate = this.inputDate
     this.currentDate.setHours(0, 0, 0, 0)

--- a/src/moj/components/date-picker/date-picker.spec.mjs
+++ b/src/moj/components/date-picker/date-picker.spec.mjs
@@ -646,7 +646,7 @@ describe('button menu JS API', () => {
     })
 
     test('future minDate sets currentDate to minDate', () => {
-      const minDate = dayjs().add(1, 'week').startOf('day')
+      const minDate = dayjs().add(1, 'year').startOf('day')
       const datePicker = new DatePicker(component, {
         minDate: minDate.format('D/M/YYYY')
       })
@@ -732,7 +732,7 @@ describe('button menu JS API', () => {
           excludedDates: `${datesToExclude[0].format('D/M/YYYY')}-${datesToExclude[datesToExclude.length - 1].format('D/M/YYYY')}`
         })
 
-        // expect(datePicker.excludedDates.length).toEqual(3);
+        expect(datePicker.excludedDates).toHaveLength(3)
         expect(datePicker.excludedDates).toStrictEqual(
           datesToExclude.map((date) => date.toDate())
         )

--- a/src/moj/components/date-picker/template.njk
+++ b/src/moj/components/date-picker/template.njk
@@ -45,7 +45,6 @@
       formGroup: params.formGroup,
       label: params.label,
       hint: params.hint,
-      errorMessage: params.errorMessage,
-      attributes: params.attributes
+      errorMessage: params.errorMessage
     }) }}
 </div>


### PR DESCRIPTION
Fixes #923 

BREAKING CHANGE: The minDate property of the DatePicker component has not worked consistently because of a discrepancy in javascript date object instantiation method.  This PR changes the minDate/maxDate's date instantiation to use `new Date(year, month, day)`  so that it remains consistent across BST and GMT. It also ensures that the `minDate` passed is always selectable in the same way as `maxDate`.

Enhancement: If the `minDate` is in the future, the calendar dialog will now open to the first selectable date.
