### PR TITLE
docs: add aria current attribute to side navigation

### DIFF
--- a/app/views/common/partials/side-navigation.njk
+++ b/app/views/common/partials/side-navigation.njk
@@ -24,7 +24,7 @@
 
 
 <li class="app-vertical-nav__item  ">
-  <a class="app-vertical-nav__link" href="/components">View all components</a></li>
+  <a class="app-vertical-nav__link" href="/components/">View all components</a></li>
 
 
 
@@ -389,6 +389,20 @@
 
 <li class="app-vertical-nav__item  ">
   <a class="app-vertical-nav__link" href="/ethics/assessment/">Preparing for a service assessment</a></li>
+
+
+
+
+
+<li class="app-vertical-nav__item  ">
+  <a class="app-vertical-nav__link" href="/ethics/principles/">Ethical principles</a></li>
+
+
+
+
+
+<li class="app-vertical-nav__item  ">
+  <a class="app-vertical-nav__link" href="/ethics/review/">Ethics review</a></li>
 </ul></li>
 
         
@@ -514,7 +528,7 @@
 
 
 <li class="app-vertical-nav__item app-vertical-nav__item--active app-vertical-nav__item--open">
-  <a class="app-vertical-nav__link" href="/contribute/add-new-component/start">Submit a component</a></li>
+  <a class="app-vertical-nav__link" href="/contribute/add-new-component/start" aria-current="page">Submit a component</a></li>
 
         
 

--- a/docs/_includes/macros/nav-list-item/template.njk
+++ b/docs/_includes/macros/nav-list-item/template.njk
@@ -7,7 +7,7 @@
 {% set sortOrder = params.sortChildrenBy if params.sortChildrenBy else "order" %}
 
 <li class="app-vertical-nav__item {{ "app-vertical-nav__item--active" if active }} {{ "app-vertical-nav__item--open" if open }}">
-  <a class="app-vertical-nav__link" href="{{ params.item.url }}">{{ params.item.title }}
+  <a class="app-vertical-nav__link" href="{{ params.item.url }}"{{ " aria-current=\"page\"" | safe if active}}>{{ params.item.title }}
     {%- if params.item.children.length -%}
       <div class="app-vertical-nav__indicator">
         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/docs/components/all.md
+++ b/docs/components/all.md
@@ -2,5 +2,5 @@
 title: View all components
 permalink: false
 order: _
-navUrl: '/components'
+navUrl: '/components/'
 ---


### PR DESCRIPTION
Fixes #1902 

- Adds aria current attribute to the current link in the side nav.
- Tweaks the url of view all components page to have a trailing / so that it is highlighted when that is the current page


