### PR TITLE
fix(pagination): fix page count totals in aria labels

### DIFF
--- a/docs/examples/pagination/index.njk
+++ b/docs/examples/pagination/index.njk
@@ -9,19 +9,19 @@ arguments: pagination
 {{ mojPagination({
   items: [{
     text: "1",
-    href: "/page=1"
+    href: "#"
   }, {
     text: "2",
-    href: "/page=2",
+    href: "#",
     selected: true
   }, {
     text: "3",
-    href: "/page=3"
+    href: "#"
   }, {
     type: "dots"
   }, {
     text: "5",
-    href: "/page=5"
+    href: "#"
   }],
   results: {
     count: 30,

--- a/src/moj/components/pagination/template.njk
+++ b/src/moj/components/pagination/template.njk
@@ -12,9 +12,9 @@
         <li class="moj-pagination__item moj-pagination__item--dots">…</li>
       {% else %}
         {%- if item.selected %}
-          <li class="moj-pagination__item moj-pagination__item--active" aria-label="Page {{ item.text }} of {{ params.items | length }}" aria-current="page">{{ item.text }}</li>
+          <li class="moj-pagination__item moj-pagination__item--active" aria-label="Page {{ item.text }} of {{ (params.items | last).text }}" aria-current="page">{{ item.text }}</li>
         {% else %}
-          <li class="moj-pagination__item"><a class="moj-pagination__link" href="{{ item.href }}" aria-label="Page {{ item.text }} of {{ params.items | length }}">{{ item.text }}</a></li>
+          <li class="moj-pagination__item"><a class="moj-pagination__link" href="{{ item.href }}" aria-label="Page {{ item.text }} of {{ (params.items | last).text }}">{{ item.text }}</a></li>
         {% endif -%}
       {% endif -%}
     {% endfor -%}


### PR DESCRIPTION
Previously the page count tataks used `items.length` to calculate the last page number.  If the items array contains 'dots' elemnts the length will be incorrect.  This PR adjusts to use the text (number) of the last item in the array as the total pages count which should always be correct.

Fixes #1161 
