### PR TITLE
fix(multifileupload): remove invalid calls to xhr.responseText (#1922)

### DIFF
--- a/src/moj/components/multi-file-upload/multi-file-upload.mjs
+++ b/src/moj/components/multi-file-upload/multi-file-upload.mjs
@@ -225,7 +225,7 @@ export class MultiFileUpload extends ConfigurableComponent {
       this.$status.textContent = xhr.response.success.messageText
 
       $actions.append(this.getDeleteButton(xhr.response.file))
-      this.config.hooks.exitHook(this, file, xhr, xhr.responseText)
+      this.config.hooks.exitHook(this, file, xhr, xhr.statusText)
     }
 
     const onError = () => {
@@ -238,7 +238,7 @@ export class MultiFileUpload extends ConfigurableComponent {
       $message.innerHTML = this.getErrorHtml(error)
       this.$status.textContent = error.message
 
-      this.config.hooks.errorHook(this, file, xhr, xhr.responseText, error)
+      this.config.hooks.errorHook(this, file, xhr, xhr.statusText, error)
     }
 
     xhr.addEventListener('load', onLoad)
@@ -293,7 +293,7 @@ export class MultiFileUpload extends ConfigurableComponent {
       const $rowDelete = $rows.find(($row) => $row.contains($button))
       if ($rowDelete) $rowDelete.remove()
 
-      this.config.hooks.deleteHook(this, undefined, xhr, xhr.responseText)
+      this.config.hooks.deleteHook(this, undefined, xhr, xhr.statusText)
     })
 
     xhr.open('POST', this.config.deleteUrl)


### PR DESCRIPTION
Currently the calls to the callback functions use `xhr.responseText` which throws an error due to the `responseType` being 'json'.  This error was introduced when migrating from jQuery which always has `responseText` available.  Looking at the type definitions, and the parameter in v4.02 before the migration from jQuery (https://github.com/ministryofjustice/moj-frontend/blob/1fb9f79d123096cc5d49f65bb5c49de71bb5fe9b/src/moj/components/multi-file-upload/multi-file-upload.mjs#L172) it appears that this argument was intended to be `statusText`.