### PR TITLE
fix: Removed `node_modules/` prefix in vendor styles to be compatible with monorepos

### DIFF
--- a/src/moj/vendor/govuk-frontend/_base.scss
+++ b/src/moj/vendor/govuk-frontend/_base.scss
@@ -1,4 +1,4 @@
-@forward "node_modules/govuk-frontend/dist/govuk/base" with (
+@forward "govuk-frontend/dist/govuk/base" with (
   $govuk-suppressed-warnings: (
     "govuk-typography-scale-14"
   )

--- a/src/moj/vendor/govuk-frontend/_base.scss
+++ b/src/moj/vendor/govuk-frontend/_base.scss
@@ -1,1 +1,1 @@
-@forward "node_modules/govuk-frontend/dist/govuk/base" with ($govuk-suppressed-warnings: ());
+@forward "govuk-frontend/dist/govuk/base" with ($govuk-suppressed-warnings: ());


### PR DESCRIPTION
### Identify the bug

Fixes #1781

### Description of the change

One @forward import in the govuk-frontend vendor dependency includes a superfluous `node_modules/` prefix which makes assumptions on the location of dependencies and breaks monorepo support where dependencies are usually installed in the root directory, i.e. `../../node_modules/`.

### Alternative designs

n/a

### Possible drawbacks

n/a

### Verification process

Installed patched version locally.

### Release notes

- Resolved compatibility when installing in monorepos