### PR TITLE
ci: update preview cleanup trigger to pull_request_target

### DIFF
--- a/.github/workflows/branch-preview-cleanup.yml
+++ b/.github/workflows/branch-preview-cleanup.yml
@@ -1,7 +1,7 @@
 name: Cleanup branch preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 env:


### PR DESCRIPTION
If a pull request is closed without being merged. The preview cleanup action wasn't running.  

Apparently the solution to this is to switch from the `pull_request` trigger to `pull_request_target`
