### PR TITLE
docs: update status attribution sentence

### DIFF
--- a/docs/_includes/macros/status-label/template.njk
+++ b/docs/_includes/macros/status-label/template.njk
@@ -1,16 +1,16 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set statusAttribution -%}
-  {%- if params.status == "Experimental" %}
-    {%- if params.contributorTeam %}
-      by {{ params.contributorName | default("someone") }} in ‘{{ params.contributorTeam }}’
-    {%- elif params.contributorName %}
-      by {{ params.contributorName  }}
-    {% endif %}
-  {% endif %}
   {%- if params.statusDate %}
     in {{ params.statusDate }}
   {%- endif %}.
+  {%- if params.status == "Experimental" %}
+    {%- if params.contributorTeam %}
+       Contributed by {{ params.contributorName | default("someone") }} in ‘{{ params.contributorTeam }}’.
+    {%- elif params.contributorName %}
+       Contributed by {{ params.contributorName  }}.
+    {% endif %}
+  {% endif %}
 {%- endset %}
 
 {% set typeSingular = params.type -%}

--- a/docs/stylesheets/components/_status.scss
+++ b/docs/stylesheets/components/_status.scss
@@ -12,8 +12,9 @@
 }
 
 .app-status-message {
-  &,
+  text-wrap: pretty;
 
+  &,
   // A specific selector to override .app-prose-scope
   .app-prose-scope & {
     color: $govuk-secondary-text-colour;


### PR DESCRIPTION
Changes the status attribution message to put the contributor at the end, and separate out addition date from contrubution date.

**Before**
Added by Steve Smith in 'CAS2' in November 2020

**After**
Added in November 2025. Contributed by Steve Smith in 'CAS2'.
