### PR TITLE
fix(header): header org name alignment fix

### DIFF
--- a/src/moj/components/header/_header.scss
+++ b/src/moj/components/header/_header.scss
@@ -83,6 +83,10 @@
     &:hover {
       border-color: transparent;
     }
+
+    @include govuk-media-query($until: tablet) {
+      margin-top: govuk-spacing(1);
+    }
   }
 
   &--service-name {


### PR DESCRIPTION
Fixes vertical alignment of the organisation name in header in mobile view.

Before:
<img width="333" height="141" alt="image" src="https://github.com/user-attachments/assets/3c020410-fbae-4fb6-82e3-0e6763c874a6" />

After:
<img width="332" height="142" alt="image" src="https://github.com/user-attachments/assets/92a75705-dfee-4ad1-a54a-6f946e37245a" />
