### PR TITLE
docs: fix spacing above h3s and h4s below examples

### DIFF
--- a/docs/stylesheets/components/_tabs.scss
+++ b/docs/stylesheets/components/_tabs.scss
@@ -8,16 +8,23 @@
   border-top: 0;
   background: govuk-colour("white");
 
-  // additional spacing for H2s
   & + h2:not([class]) {
     margin-top: govuk-spacing(8);
   }
 
-  & + * {
+  & + h3:not([class]) {
+    margin-top: govuk-spacing(6);
+  }
+
+  & + h4:not([class]) {
     margin-top: govuk-spacing(4);
   }
 
   & + p {
+    margin-top: govuk-spacing(4);
+  }
+
+  & + * {
     margin-top: govuk-spacing(4);
   }
 }


### PR DESCRIPTION
This PR fixes a couple of minor spacing issues left over from the spacing updates a few weeks ago.

Before:
<img width="1086" height="822" alt="image" src="https://github.com/user-attachments/assets/2d419b0b-31f9-4cb8-8232-f79b8bb2dfe8" />

After:
<img width="1148" height="834" alt="image" src="https://github.com/user-attachments/assets/8f33c0bd-3f6c-4894-ae3e-70d4d80ead3e" />
