### PR TITLE
docs: copy button link edits

### DIFF
--- a/docs/components/copy-button/_designs.md
+++ b/docs/components/copy-button/_designs.md
@@ -14,7 +14,7 @@ A Figma design has been added for this component. There may be more links and re
 
 ### Figma
 
-If you work for MOJ, [view the ‘copy button’ component in the MOJ Figma Kit]([#](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MOJ-Figma-Kit?m=auto&node-id=14256-5&t=IhMYITDelNzdmReS-1)).
+If you work for MOJ, [view the ‘copy button’ component in the MOJ Figma Kit](https://www.figma.com/design/N2xqOFkyehXwcD9DxU1gEq/MOJ-Figma-Kit?m=auto&node-id=14256-5&t=IhMYITDelNzdmReS-1).
 
 If you work outside MOJ, go to the [MOJ Figma Kit on the Figma community platform](https://www.figma.com/community/file/1543193133973726850/moj-design-system-figma-kit).
 

--- a/docs/components/copy-button/copy-button.11tydata.js
+++ b/docs/components/copy-button/copy-button.11tydata.js
@@ -1,6 +1,6 @@
 export default {
   githuburl:
-    'https://github.com/ministryofjustice/moj-frontend/discussions/categories/experimental-components-pages-and-patterns',
+    'https://github.com/ministryofjustice/moj-frontend/discussions/2132',
   tabCollection: 'copy-button',
   blockTitle: 'Copy button'
 }


### PR DESCRIPTION
Description of the change: added github discussion link and fixed figma component link