### PR TITLE
docs(content-style-guide): add 'removed' tag to content style guide updates

### DIFF
--- a/docs/_includes/layouts/style-guide-updates.njk
+++ b/docs/_includes/layouts/style-guide-updates.njk
@@ -15,7 +15,16 @@
           {%- for entry in collections['style-guide-update'] -%}
             {% set link = '<a class="govuk-!-font-weight-bold" href="/content-standards/style-guide#'+entry.data.anchor+'">'+entry.data.title+'</a>' %}
             {% set tagText = entry.data.type | upperFirst %}
-            {% set tagClass='govuk-tag govuk-tag--green' if entry.data.type | lower === 'new' else 'govuk-tag govuk-tag--blue' %}
+
+            {% set tagClass = '' %}
+            {% if entry.data.type | lower === 'removed' %}
+              {% set tagClass = 'govuk-tag govuk-tag--red' %}
+            {% elif entry.data.type | lower === 'new' %}
+              {% set tagClass = 'govuk-tag govuk-tag--green' %}
+            {% else %}
+              {% set tagClass = 'govuk-tag govuk-tag--blue' %}
+            {% endif %}
+
             {% set entryContent = entry.content | renderMarkdown  %}
 
             {% set row = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -39785,7 +39785,7 @@
     },
     "package": {
       "name": "@ministryofjustice/frontend",
-      "version": "7.1.1",
+      "version": "8.0.0",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"


### PR DESCRIPTION
Adds the ability to mark updates as a removal by setting the `type` frontmatter to 'Removed'.
```
---
title: CRN (case reference number)
anchor: crn-%28case-reference-number%29
type: Removed
date: 2026-05-12
---

Removed information about CRN format. 
```
<img width="1029" height="1108" alt="image" src="https://github.com/user-attachments/assets/864e1d9e-f6f6-4fb6-8771-621ad7de9275" />
