### PR TITLE
docs: fix tag sorting on style guide updates page

### DIFF
--- a/docs/_includes/layouts/style-guide-updates.njk
+++ b/docs/_includes/layouts/style-guide-updates.njk
@@ -29,7 +29,7 @@
 
             {% set row = [
                 { html: link },
-                { html: govukTag({ text: tagText, classes: tagClass})},
+                { html: govukTag({ text: tagText, classes: tagClass}), attributes: { 'data-sort-value': tagText } },
                 { html: entryContent },
                 { html: entry.date | mojDate('date') | replace(' ', '&nbsp;'), attributes: { 'data-sort-value': entry.date | timestamp } }
             ] %}


### PR DESCRIPTION
Adds a `data-sort-value` attribute to the 'Type' column on the content style guide updates page in order to ensure tags are sorted based on the tag text not the html content.
