### PR TITLE
Feature/connected service 1963 hover state

### DIFF
--- a/src/moj/components/domain-specific/probation/header/_header.scss
+++ b/src/moj/components/domain-specific/probation/header/_header.scss
@@ -19,10 +19,18 @@
       border-bottom-color: $colour;
     }
 
+    &::after {
+      background-color: $colour;
+    }
+
     &:hover {
       &::before {
         border-right-color: $colour;
         border-bottom-color: $colour;
+      }
+
+      &::after {
+        background-color: $colour;
       }
     }
   }


### PR DESCRIPTION
The contrast for the hover state of the open menu for the header is not high enough

Identify the bug
It was flagged up during accessibility assesment.

Description of the change
This change introduced a hover state for the opened menu of the header for the PDS-header component. And to avoid duplication, it introduced a shared mixin to use with the focus-visible state.

Possible drawbacks
failing css generation

Verification process
I ran npm run build:package with the change

Release notes
Not applicable