### PR TITLE
ci: add pr title linting action to enforce conventional commit message structure

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,20 @@
+name: 'Lint PR title'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      # - synchronize (if you use required Actions)
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds an action to enforce conventional commit message conventions on the PR title.
  
This action will lint PR titles and prevent merge if the PR title does not conform.  

Combined with the Github setting to default to using the PR title for the commit title for squash-merges, this should prevent commits getting to main with incorrect commit message titles.

