### PR TITLE
chore(renovate): update renovate config to match new repo labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
   "ignoreDeps": ["eslint", "eslint-plugin-promise", "eslint-plugin-n"],
-  "labels": ["dependencies"],
+  "labels": ["renovate: dependencies 🗃️"],
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {
@@ -80,5 +80,6 @@
     }
   ],
   "rangeStrategy": "bump",
+  "stopUpdatingLabel": "renovate: stop-updating 🚫",
   "updateInternalDeps": true
 }


### PR DESCRIPTION
After updating all the labels for the repo, we need to adjust the renovate config to apply the right label to new PRs, and respond to the correct stop updating label
