### PR TITLE
ci(preview): update label config for preview deploy and cleanup

### DIFF
--- a/.github/workflows/branch-preview-cleanup.yml
+++ b/.github/workflows/branch-preview-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'preview:active')
+    if: contains(github.event.pull_request.labels.*.name, 'preview: active 👀')
     steps:
       - run: |
           echo "${KUBE_CERT}" > ca.crt
@@ -35,4 +35,4 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       - uses: actions/checkout@v4
       - name: Remove preview:active label
-        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview:active"
+        run: gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview: active 👀"

--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'preview:request') || contains(github.event.pull_request.labels.*.name, 'preview:active')
+    if: contains(github.event.pull_request.labels.*.name, 'preview: request') || contains(github.event.pull_request.labels.*.name, 'preview: active 👀')
     steps:
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
@@ -53,5 +53,5 @@ jobs:
         run: |
           echo -e "🚀 Deployed to preview environment! If this is the first deploy, you may have to wait a few minutes for your preview site to be ready on the following URL:\n\n https://moj-frontend-pr-${{ github.event.pull_request.number }}.apps.live.cloud-platform.service.justice.gov.uk\n\n**Username:** \`preview\`, **Password:** \`moj\`" > comment.txt
           gh pr comment ${{ github.event.pull_request.number }} --body-file comment.txt
-          gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview:request"
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "preview:active"
+          gh pr edit ${{ github.event.pull_request.number }} --remove-label "preview: request"
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "preview: active 👀"


### PR DESCRIPTION
Updates the github actions for deploying and cleaning up branch preview sites to use the new github labels.