### PR TITLE
docs: update the js path for example shortcode to enable js…

### DIFF
--- a/11ty/shortcodes/example.js
+++ b/11ty/shortcodes/example.js
@@ -61,12 +61,13 @@ module.exports = function (params) {
 
   let jsCode = ''
   try {
-    jsCode = fs
-      .readFileSync(
-        path.join(__dirname, 'docs', params.template, 'script.js'),
-        'utf8'
-      )
-      .trim()
+    const jsPath = path.resolve(
+      this.eleventy.env.root,
+      path.dirname(this.page.inputPath),
+      params.template,
+      'script.js'
+    )
+    jsCode = fs.readFileSync(jsPath, 'utf8').trim()
   } catch {}
 
   return nunjucksEnv.render('example.njk', {


### PR DESCRIPTION
… tab to show

The path to search for a script.js file was incorrect.  This meant no examples were showing a JavaScript tab. This pr fixes the path and enables the tab to show

Before:
<img width="1024" height="1028" alt="image" src="https://github.com/user-attachments/assets/9357dadc-6862-42e4-ba14-226c846be5b0" />

After:
<img width="1051" height="1139" alt="image" src="https://github.com/user-attachments/assets/ad19492c-7587-4091-baa6-670278c2d8f8" />
