### PR TITLE
ci: fix pr title linting regex

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -27,7 +27,7 @@ jobs:
           # type: subject
           #
           # Allowed types align with common conventional commit types.
-          PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?(!)?: .+'
+          PATTERN='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?(!)?: .+'
 
           if [[ ! "${PR_TITLE}" =~ ${PATTERN} ]]; then
             echo "::error::PR title must match Conventional Commits (e.g. 'feat: add X' or 'fix(scope): correct Y'). Got: ${PR_TITLE}"


### PR DESCRIPTION
The regex for linting a PR title fails if a scope in parentheses is used.

Bash's `[[ =~ ]]` operator treats the pattern as an ERE (Extended Regular Expression) directly. There is no string escaping layer. So `\\(` is interpreted as a literal backslash + (, not as an escaped parenthesis.

The backslashes do not need to be escaped.

