### PR TITLE
docs: fix menu styles for high contrast modes

### DIFF
--- a/docs/stylesheets/components/_vertical-nav.scss
+++ b/docs/stylesheets/components/_vertical-nav.scss
@@ -73,7 +73,8 @@
   &:focus,
   &:focus-visible {
     border-color: $govuk-text-colour;
-    outline: none;
+    outline: 2px solid transparent;
+    outline-offset: 0;
     color: $govuk-text-colour;
     background-color: $govuk-focus-colour;
   }
@@ -82,6 +83,23 @@
   &:focus-visible:hover {
     color: govuk-colour("white");
     background-color: $moj-button-menu-hover-color;
+  }
+
+  @media (forced-colors: active) {
+    padding-left: govuk-spacing(4);
+    border-left: 0;
+    color: LinkText;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus,
+    &:focus-visible {
+      /* padding-left: govuk-spacing(4) - 4px; */
+
+      /* border-left: 4px solid transparent; */
+    }
   }
 }
 
@@ -115,7 +133,7 @@
 
   &:focus-visible {
     border-color: $govuk-text-colour;
-    outline: none;
+    outline: 2px solid transparent;
     color: $govuk-text-colour;
     background-color: $govuk-focus-colour;
   }
@@ -123,6 +141,23 @@
   &:focus-visible:hover {
     color: govuk-colour("white");
     background-color: $moj-button-menu-hover-color;
+  }
+
+  @media (forced-colors: active) {
+    padding-left: govuk-spacing(4);
+    border-left: 0;
+    color: LinkText;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    &:focus,
+    &:focus-visible {
+      /* padding-left: govuk-spacing(4) - 4px; */
+
+      /* border-left: 4px solid transparent; */
+    }
   }
 }
 
@@ -143,7 +178,7 @@
   &:focus,
   &:focus-visible {
     border-color: $govuk-text-colour;
-    outline: none;
+    outline: 2px solid transparent;
     color: $govuk-text-colour;
     background-color: $govuk-focus-colour;
   }
@@ -151,6 +186,12 @@
   &:focus:hover,
   &:focus-visible:hover {
     background-color: $moj-button-menu-color;
+  }
+
+  @media (forced-colors: active) {
+    padding-left: govuk-spacing(4) - 4px;
+    border-left: 4px solid CanvasText;
+    background: none;
   }
 }
 


### PR DESCRIPTION
Fixes issues with high contrast styles in the side nav for the design system site.

Before:
<img width="684" height="637" alt="image" src="https://github.com/user-attachments/assets/a1888a01-a278-4a18-bcca-cc09ee018fb3" />


After:
<img width="897" height="680" alt="image" src="https://github.com/user-attachments/assets/8537e9ce-9748-49b4-8a97-e6e6bae9868b" />

