### PR TITLE
ci: add scripts to diff changes to package or dist outputs

### DIFF
--- a/.github/workflows/diff-change-to-dist.yml
+++ b/.github/workflows/diff-change-to-dist.yml
@@ -1,0 +1,143 @@
+name: Diff changes to dist
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'gulp/**'
+      - 'gulpfile.js'
+      - 'postcss.config.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.browserslistrc'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  generate-diff:
+    name: Generate diff
+    runs-on: ubuntu-latest
+
+    # Skip when token write permissions are unavailable on forks
+    if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Need full history to checkout the base branch to compare
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Set up git identity
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Set up diff drivers
+        run: |
+          npm install -g js-beautify
+          git config diff.minjs.textconv "js-beautify --editorconfig --type js"
+          git config diff.mincss.textconv "js-beautify --editorconfig --type css"
+
+      - name: Generate diff
+        run: |
+          bin/dist-diff.sh origin/${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE
+
+      - name: Save dist diffs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Dist diff
+          path: .cache/diff/dist/*.diff
+          if-no-files-found: ignore
+
+      - name: Add comment to PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+
+            const issueNumber = ${{ github.event.pull_request.number }}
+            const commit = '${{ github.event.pull_request.head.sha }}'
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+            async function getExistingComment(marker) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              })
+              return comments.find(({ body }) => body?.includes(marker))
+            }
+
+            async function upsertComment(marker, title, body) {
+              const fullBody = `<!-- ${marker} -->\n## ${title}\n\n${body}\n\n---\n[Action run](${runUrl}) for ${commit}`
+              const existing = await getExistingComment(marker)
+              const params = { issue_number: issueNumber, owner: context.repo.owner, repo: context.repo.repo }
+              if (existing) {
+                await github.rest.issues.updateComment({ ...params, comment_id: existing.id, body: fullBody })
+              } else {
+                await github.rest.issues.createComment({ ...params, body: fullBody })
+              }
+            }
+
+            async function deleteComment(marker) {
+              const existing = await getExistingComment(marker)
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id
+                })
+              }
+            }
+
+            async function commentDiff({ path, title, marker, skipEmpty }) {
+              let diffText = ''
+              try { diffText = fs.readFileSync(path, 'utf8') } catch {}
+
+              if (!diffText && skipEmpty) {
+                console.log(`Skipping comment for ${path} (empty diff)`)
+                await deleteComment(marker)
+                return
+              }
+
+              const body = diffText
+                ? `\`\`\`diff\n${diffText}\n\`\`\``
+                : 'No diff changes found.'
+
+              try {
+                await upsertComment(marker, title, body)
+              } catch {
+                await upsertComment(marker, title, `The diff could not be posted as a comment. You can download it from the [workflow artifacts](${runUrl}#artifacts).`)
+              }
+            }
+
+            const diffs = [
+              {
+                path: '${{ github.workspace }}/.cache/diff/dist/js.diff',
+                title: 'JavaScript changes to dist',
+                marker: 'moj-frontend/dist/js.diff'
+              },
+              {
+                path: '${{ github.workspace }}/.cache/diff/dist/css.diff',
+                title: 'Stylesheets changes to dist',
+                marker: 'moj-frontend/dist/css.diff'
+              },
+              {
+                path: '${{ github.workspace }}/.cache/diff/dist/other.diff',
+                title: 'Other changes to dist',
+                marker: 'moj-frontend/dist/other.diff',
+                skipEmpty: true
+              }
+            ]
+
+            for (const diff of diffs) {
+              await commentDiff(diff)
+            }

--- a/.github/workflows/diff-change-to-package.yml
+++ b/.github/workflows/diff-change-to-package.yml
@@ -1,0 +1,145 @@
+name: Diff changes to npm package
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'gulp/**'
+      - 'gulpfile.js'
+      - 'postcss.config.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.browserslistrc'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  generate-diff:
+    name: Generate diff
+    runs-on: ubuntu-latest
+
+    # Skip when token write permissions are unavailable on forks
+    if: ${{ github.event.pull_request && !github.event.pull_request.head.repo.fork }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0 # Need full history to checkout the base branch to compare
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Set up git identity
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Set up diff drivers
+        run: |
+          npm install -g js-beautify
+          git config diff.minjs.textconv "js-beautify --editorconfig --type js"
+          git config diff.mincss.textconv "js-beautify --editorconfig --type css"
+
+      - name: Generate diff
+        run: |
+          bin/package-diff.sh ${{ github.event.pull_request.base.ref }} $GITHUB_WORKSPACE
+
+      - name: Save npm package diffs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: Package diff
+          path: .cache/diff/package/*.diff
+          if-no-files-found: ignore
+
+      - name: Add comment to PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs')
+
+            const issueNumber = ${{ github.event.pull_request.number }}
+            const commit = '${{ github.event.pull_request.head.sha }}'
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+            async function getExistingComment(marker) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                issue_number: issueNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              })
+              return comments.find(({ body }) => body?.includes(marker))
+            }
+
+            async function upsertComment(marker, title, body) {
+              const fullBody = `<!-- ${marker} -->\n## ${title}\n\n${body}\n\n---\n[Action run](${runUrl}) for ${commit}`
+              const existing = await getExistingComment(marker)
+              const params = { issue_number: issueNumber, owner: context.repo.owner, repo: context.repo.repo }
+              if (existing) {
+                await github.rest.issues.updateComment({ ...params, comment_id: existing.id, body: fullBody })
+              } else {
+                await github.rest.issues.createComment({ ...params, body: fullBody })
+              }
+            }
+
+            async function deleteComment(marker) {
+              const existing = await getExistingComment(marker)
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  issue_number: issueNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id
+                })
+              }
+            }
+
+            async function commentDiff({ path, title, marker, skipEmpty }) {
+              let diffText = ''
+              try { diffText = fs.readFileSync(path, 'utf8') } catch {}
+
+              if (!diffText && skipEmpty) {
+                console.log(`Skipping comment for ${path} (empty diff)`)
+                await deleteComment(marker)
+                return
+              }
+
+              const body = diffText
+                ? `\`\`\`diff\n${diffText}\n\`\`\``
+                : 'No diff changes found.'
+
+              try {
+                await upsertComment(marker, title, body)
+              } catch {
+                await upsertComment(marker, title, `The diff could not be posted as a comment. You can download it from the [workflow artifacts](${runUrl}#artifacts).`)
+              }
+            }
+
+            const diffs = [
+              {
+                path: '${{ github.workspace }}/.cache/diff/package/js.diff',
+                title: 'JavaScript changes to npm package',
+                marker: 'moj-frontend/package/js.diff',
+                skipEmpty: true
+              },
+              {
+                path: '${{ github.workspace }}/.cache/diff/package/css.diff',
+                title: 'Stylesheets changes to npm package',
+                marker: 'moj-frontend/package/css.diff',
+                skipEmpty: true
+              },
+              {
+                path: '${{ github.workspace }}/.cache/diff/package/other.diff',
+                title: 'Other changes to npm package',
+                marker: 'moj-frontend/package/other.diff',
+                skipEmpty: true
+              }
+            ]
+
+            for (const diff of diffs) {
+              await commentDiff(diff)
+            }

--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -ex
+
+# Computes the diff of `dist` between a provided base reference (branch, tag, commit SHA)
+# and the current HEAD by building on both branches.
+# Since dist/ is gitignored, a fresh build is required for each branch.
+# It outputs the resulting diff files in the provided workspace folder.
+#
+# Usage: `bin/dist-diff.sh <base-reference> <workspace-folder>`
+
+# Default the base branch to main to allow running locally quickly
+base="${1:-main}"
+# Default the head to the current branch or commit SHA when detached
+head=$(git branch --show-current 2>/dev/null || git rev-parse HEAD)
+# And the output folder to the current working directory
+output_folder="${2:-$(pwd)}"
+
+rm -Rf .cache/diff/dist
+mkdir -p .cache/diff/dist
+
+# Switch to base branch and build dist
+git checkout "$base"
+npm ci --ignore-scripts
+npm run build:dist
+
+# Normalise versioned filenames (e.g. moj-frontend-1.0.0.min.js -> moj-frontend.min.js)
+# so that git diff compares file content rather than showing delete + add when the version changes
+for f in dist/*.min.js; do
+  [ -f "$f" ] && mv "$f" dist/moj-frontend.min.js
+done
+for f in dist/*.min.css; do
+  [ -f "$f" ] && mv "$f" dist/moj-frontend.min.css
+done
+
+# Switch back to original HEAD
+# The built dist/ files remain in place because dist/ is gitignored
+git checkout "$head"
+
+# Commit build output from base branch
+git add --force dist/
+git commit --allow-empty -m "Build dist output for '$base'" --no-verify
+
+# Build dist for original HEAD
+npm ci --ignore-scripts
+npm run build:dist
+
+# Normalise versioned filenames
+for f in dist/*.min.js; do
+  [ -f "$f" ] && mv "$f" dist/moj-frontend.min.js
+done
+for f in dist/*.min.css; do
+  [ -f "$f" ] && mv "$f" dist/moj-frontend.min.css
+done
+
+# Commit build output from original HEAD
+git add --force dist/
+git commit --allow-empty -m "Build dist output for '$head'" --no-verify
+
+# Diff the minified JS file
+git diff HEAD^ -- dist/moj-frontend.min.js \
+  > "$output_folder/.cache/diff/dist/js.diff"
+
+# Diff the minified CSS file
+git diff HEAD^ -- dist/moj-frontend.min.css \
+  > "$output_folder/.cache/diff/dist/css.diff"
+
+# Diff the rest of the files, excluding source maps, minified files, and the release zip
+# See https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+git diff -M05 HEAD^ -- dist \
+  ":(exclude)dist/*.min.*" \
+  ":(exclude)dist/*.map" \
+  ":(exclude)dist/release.zip" \
+  > "$output_folder/.cache/diff/dist/other.diff"

--- a/bin/package-diff.sh
+++ b/bin/package-diff.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -ex
+
+# Computes the diff of `package` between a provided base reference (branch, tag, commit SHA)
+# and the current HEAD by building on both branches.
+# Since package/ is gitignored, a fresh build is required for each branch.
+# It outputs the resulting diff files in the provided workspace folder.
+#
+# Usage: `bin/package-diff.sh <base-reference> <workspace-folder>`
+
+# Default the base branch to main to allow running locally quickly
+base="${1:-main}"
+# Default the head to the current branch or commit SHA when detached
+head=$(git branch --show-current 2>/dev/null || git rev-parse HEAD)
+# And the output folder to the current working directory
+output_folder="${2:-$(pwd)}"
+
+rm -Rf .cache/diff/package
+mkdir -p .cache/diff/package
+
+# Switch to base branch and build package
+git checkout "$base"
+npm ci --ignore-scripts
+npm run build:package
+
+# Switch back to original HEAD
+# The built package/ files remain in place because package/ is gitignored
+git checkout "$head"
+
+# Commit build output from base branch
+git add --force package/
+git commit --allow-empty -m "Build package output for '$base'" --no-verify
+
+# Build package for original HEAD
+npm ci --ignore-scripts
+npm run build:package
+
+# Commit build output from original HEAD
+git add --force package/
+git commit --allow-empty -m "Build package output for '$head'" --no-verify
+
+# Diff the minified JS file
+git diff HEAD^ -- package/moj/moj-frontend.min.js \
+  > "$output_folder/.cache/diff/package/js.diff"
+
+# Diff the minified CSS file
+git diff HEAD^ -- package/moj/moj-frontend.min.css \
+  > "$output_folder/.cache/diff/package/css.diff"
+
+# Diff the rest of the files, excluding source maps and minified files
+# See https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+git diff -M05 HEAD^ -- package \
+  ":(exclude)package/**/*.min.*" \
+  ":(exclude)package/**/*.map" \
+  > "$output_folder/.cache/diff/package/other.diff"


### PR DESCRIPTION
Based heavily on these files from GOV.UK:
https://github.com/alphagov/govuk-frontend/blob/main/.github/workflows/diff-change-to-dist.yaml
https://github.com/alphagov/govuk-frontend/blob/main/.github/workflows/diff-change-to-package.yaml
And with some help from Claude.

These workflows check for changes to the output files in dist / package. We want to ensure that doing things like updating dependencies isn't affecting the output of the build

