### PR TITLE
ci: add package dist diffing actions

### DIFF
--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -11,7 +11,8 @@ set -ex
 # Default the base branch to main to allow running locally quickly
 base="${1:-main}"
 # Default the head to the current branch or commit SHA when detached
-head=$(git branch --show-current 2>/dev/null || git rev-parse HEAD)
+head=$(git branch --show-current 2>/dev/null)
+head=${head:-$(git rev-parse HEAD)}
 # And the output folder to the current working directory
 output_folder="${2:-$(pwd)}"
 

--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -21,6 +21,7 @@ mkdir -p .cache/diff/dist
 # Switch to base branch and build dist
 git checkout "$base"
 npm ci --ignore-scripts
+npm run build:package #needed to create the /package/moj/assets dir
 npm run build:dist
 
 # Normalise versioned filenames (e.g. moj-frontend-1.0.0.min.js -> moj-frontend.min.js)
@@ -42,6 +43,7 @@ git commit --allow-empty -m "Build dist output for '$base'" --no-verify
 
 # Build dist for original HEAD
 npm ci --ignore-scripts
+npm run build:package #needed to create the /package/moj/assets/ dir
 npm run build:dist
 
 # Normalise versioned filenames

--- a/bin/package-diff.sh
+++ b/bin/package-diff.sh
@@ -11,7 +11,8 @@ set -ex
 # Default the base branch to main to allow running locally quickly
 base="${1:-main}"
 # Default the head to the current branch or commit SHA when detached
-head=$(git branch --show-current 2>/dev/null || git rev-parse HEAD)
+head=$(git branch --show-current 2>/dev/null)
+head=${head:-$(git rev-parse HEAD)}
 # And the output folder to the current working directory
 output_folder="${2:-$(pwd)}"
 


### PR DESCRIPTION
Fixes for issues encountered when running in GH Actions:

1. Need to run build:package before build:dist or package/moj/assets dir doesn't exist
The script only commits changes in /dist, so this doesn't affect the diffing

2. In GitHub Actions, actions/checkout checks out the repo in detached HEAD
state. In this state, `git branch --show-current` exits with code 0 but
produces no output, so the `||` fallback to `git rev-parse HEAD` never
runs, leaving the `head` variable empty and causing `git checkout` to
fail.

Fix by using shell parameter expansion (`${head:-...}`) to substitute
the fallback when the value is empty, regardless of exit code.
