### PR TITLE
fix: Offering to add a class name to the PDS header component

### DIFF
--- a/docs/probation/components/pds-header/_arguments.md
+++ b/docs/probation/components/pds-header/_arguments.md
@@ -4,6 +4,7 @@
 | ----------------- | ------ | -------- | --------------------------------------------------------------------------------------------- |
 | environmentName | string | No      | Tag label showing the current environment. Hidden if value is `PRODUCTION`. |
 | environmentNameColour      | string | No      | Custom colour for the environment tag, overriding the default.                |
+| classname | string | No | Optional class name to apply to the main header element.                |
 | name        | string  | Yes       | The display name of the user.                           |
 | manageDetailsLink  | string | Yes       | URL linking to the user account management page.   |
 | servicesLink  | string | No | URL linking to a services page when JavaScript is disabled |

--- a/docs/probation/components/pds-header/_arguments.md
+++ b/docs/probation/components/pds-header/_arguments.md
@@ -4,7 +4,7 @@
 | ----------------- | ------ | -------- | --------------------------------------------------------------------------------------------- |
 | environmentName | string | No      | Tag label showing the current environment. Hidden if value is `PRODUCTION`. |
 | environmentNameColour      | string | No      | Custom colour for the environment tag, overriding the default.                |
-| classname | string | No | Optional class name to apply to the main header element.                |
+| classes | string | No | Optional class name to apply to the main header element.                |
 | name        | string  | Yes       | The display name of the user.                           |
 | manageDetailsLink  | string | Yes       | URL linking to the user account management page.   |
 | servicesLink  | string | No | URL linking to a services page when JavaScript is disabled |

--- a/src/moj/components/domain-specific/probation/header/template.njk
+++ b/src/moj/components/domain-specific/probation/header/template.njk
@@ -13,7 +13,7 @@
 </svg>
 {% endset %}
 
-<header class="probation-common-header govuk-!-display-none-print {% if className %}{{ className }}{% endif %}" role="banner" data-module="pds-header">
+<header class="probation-common-header govuk-!-display-none-print {% if classes %}{{ classes }}{% endif %}" role="banner" data-module="pds-header">
   <div class="govuk-clearfix">
     <div class="govuk-width-container probation-common-header__title">
       <a class="probation-common-header__link probation-common-header__title__organisation-name" href="{{ params.titleLink | default("#") }}">

--- a/src/moj/components/domain-specific/probation/header/template.njk
+++ b/src/moj/components/domain-specific/probation/header/template.njk
@@ -13,7 +13,7 @@
 </svg>
 {% endset %}
 
-<header class="probation-common-header govuk-!-display-none-print" role="banner" data-module="pds-header">
+<header class="probation-common-header govuk-!-display-none-print {% if className %}{{ className }}{% endif %}" role="banner" data-module="pds-header">
   <div class="govuk-clearfix">
     <div class="govuk-width-container probation-common-header__title">
       <a class="probation-common-header__link probation-common-header__title__organisation-name" href="{{ params.titleLink | default("#") }}">


### PR DESCRIPTION
Description of the change
This PR introduces the className attribute to PDS components.
The component has been updated to accept and render a className parameter. 
