### PR TITLE
docs: fix code block indentation on tabbed templates

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: npm run setup
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium --with-deps
       - name: Build package
         run: ENV=test npm run build:package
       - name: Build docs

--- a/11ty/filters/dedent-govuk-tab-panel.js
+++ b/11ty/filters/dedent-govuk-tab-panel.js
@@ -1,0 +1,45 @@
+/**
+ * Dedent the content of a govuk-tabs__panel by 2 spaces, but only for lines
+ * inside the panel. This filter is required because the indenting causes our
+ * code examples to be indented by 2 extra spaces.
+ *
+ * @param {string} str - The input string containing the HTML of the tab panel.
+ * @returns {string} - The dedented string with only the content of the panel modified.
+ */
+module.exports = function dedentGovUkTabPanel(str) {
+  const lines = str.split('\n')
+  let inPanel = false
+  let depth = 0
+
+  return lines
+    .map((line) => {
+      const trimmed = line.trimStart()
+
+      // Check for the start of a govuk-tabs__panel
+      if (!inPanel) {
+        if (trimmed.startsWith('<div class="govuk-tabs__panel')) {
+          inPanel = true
+          depth = 0
+        }
+        return line
+      }
+
+      // Count the number of opening and closing divs to track nesting depth
+      const opens = (trimmed.match(/<div[\s>]/g) || []).length
+      const closes = (trimmed.match(/<\/div>/g) || []).length
+
+      depth += opens - closes
+
+      // If we've closed the initial panel div, we're done dedenting and can
+      // return the line as is
+      if (depth < 0) {
+        inPanel = false
+        depth = 0
+        return line
+      }
+
+      // For lines inside the panel, remove the first 2 spaces of indentation
+      return line.slice(2)
+    })
+    .join('\n')
+}

--- a/11ty/filters/dedent.js
+++ b/11ty/filters/dedent.js
@@ -1,0 +1,6 @@
+module.exports = function dedent(str, spaces, firstLine = true) {
+  return str
+    .split('\n')
+    .map((line, index) => (firstLine || index > 0 ? line.slice(spaces) : line))
+    .join('\n')
+}

--- a/11ty/filters/dedent.js
+++ b/11ty/filters/dedent.js
@@ -1,3 +1,12 @@
+/**
+ * Removes the specified number of spaces from the beginning of each line in a
+ * string.
+ *
+ * @param {string} str - The input string to be dedented.
+ * @param {number} spaces - The number of spaces to remove from the beginning of each line.
+ * @param {boolean} [firstLine] - Whether to remove spaces from the first line as well.
+ * @returns {string} - The dedented string with the specified number of spaces removed from the beginning of each line.
+ */
 module.exports = function dedent(str, spaces, firstLine = true) {
   return str
     .split('\n')

--- a/11ty/filters/index.js
+++ b/11ty/filters/index.js
@@ -2,6 +2,7 @@ const { upperFirst } = require('lodash')
 
 const capitaliseAcronyms = require('./capitalise-acronyms')
 const dedent = require('./dedent')
+const dedentGovUkTabPanel = require('./dedent-govuk-tab-panel')
 const inspect = require('./inspect')
 const paths = require('./paths')
 const renderMarkdown = require('./render-markdown')
@@ -12,6 +13,7 @@ const timestamp = require('./timestamp')
 const filters = {
   capitaliseAcronyms,
   dedent,
+  dedentGovUkTabPanel,
   ...paths,
   inspect,
   renderMarkdown,

--- a/11ty/filters/index.js
+++ b/11ty/filters/index.js
@@ -1,6 +1,7 @@
 const { upperFirst } = require('lodash')
 
 const capitaliseAcronyms = require('./capitalise-acronyms')
+const dedent = require('./dedent')
 const inspect = require('./inspect')
 const paths = require('./paths')
 const renderMarkdown = require('./render-markdown')
@@ -10,6 +11,7 @@ const timestamp = require('./timestamp')
 
 const filters = {
   capitaliseAcronyms,
+  dedent,
   ...paths,
   inspect,
   renderMarkdown,

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -30,16 +30,17 @@
 <div class="app-example__code" data-module="app-copy">
 
 ```html
-
 {{ htmlCode | safe  }}
 ```
 
-</div></div>
+</div>
+</div>
 <div class="app-tabs__panel" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
 {%- if tabWarning -%}
   <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
 {%- endif -%}
 {%- set argsContent %}
+
   {% include arguments ignore missing %}
 {%- endset %}
 {% if argsContent | trim %}
@@ -55,21 +56,21 @@
 <div class="app-example__code" data-module="app-copy">
 
 ```njk
-
 {{ nunjucksCode | safe }}
 ```
 
-</div></div>
+</div>
+</div>
 {% if jsCode %}
   <div class="app-tabs__panel" id="js-default-{{ id }}" role="tabpanel" aria-labelledby="tab_js-default-{{ id }}">
     <div class="app-example__code" data-module="app-copy">
 
 ```js
-
 {{ jsCode | safe }}
 ```
 
-</div></div>
+</div>
+</div>
 {% endif %}
 {% if figmaLink %}
   <div class="app-tabs__panel" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -5,47 +5,43 @@
   <iframe class="app-example__frame" scrolling="auto" frameborder="0" height="{{ height }}" src="{{ href | url }}" title="{{ title }}" data-module="moj-iframe-resizer"></iframe>
 </div>
 <div class="app-tabs" data-module="app-tabs">
-  <ul class="app-tabs__list" role="tablist">
-    <li class="app-tabs__list-item" role="presentation">
-      <a class="app-tabs__tab" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "html" }}>HTML <span class="govuk-visually-hidden">({{ title }})</span></a>
-    </li>
-    <li class="app-tabs__list-item" role="presentation">
-      <a class="app-tabs__tab" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "nunjucks" }}>Nunjucks <span class="govuk-visually-hidden">({{ title }})</span></a>
-    </li>
-    {%- if jsCode -%}
-    <li class="app-tabs__list-item" role="presentation">
-      <a class="app-tabs__tab" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "javascript" }}>JavaScript <span class="govuk-visually-hidden">({{ title }})</span></a>
-    </li>
-    {%- endif -%}
-    {%- if figmaLink -%}
-    <li class="app-tabs__list-item" role="presentation">
-      <a class="app-tabs__tab" href="#figma-default-{{ id }}" role="tab" id="tab_figma-default-{{ id }}" aria-controls="figma-default-{{ id }}">Figma</a>
-    </li>
-    {%- endif -%}
-  </ul>
-
-  <div class="app-tabs__panel" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
-    {%- if tabWarning -%}
-      <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
-    {%- endif -%}
-
-    <div class="app-example__code" data-module="app-copy">
+<ul class="app-tabs__list" role="tablist">
+  <li class="app-tabs__list-item" role="presentation">
+    <a class="app-tabs__tab" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "html" }}>HTML <span class="govuk-visually-hidden">({{ title }})</span></a>
+  </li>
+  <li class="app-tabs__list-item" role="presentation">
+    <a class="app-tabs__tab" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "nunjucks" }}>Nunjucks <span class="govuk-visually-hidden">({{ title }})</span></a>
+  </li>
+  {%- if jsCode -%}
+  <li class="app-tabs__list-item" role="presentation">
+    <a class="app-tabs__tab" href="#js-default-{{ id }}" role="tab" id="tab_js-default-{{ id }}" aria-controls="js-default-{{ id }}" {{ 'aria-selected=true' if showTab | lower === "javascript" }}>JavaScript <span class="govuk-visually-hidden">({{ title }})</span></a>
+  </li>
+  {%- endif -%}
+  {%- if figmaLink -%}
+  <li class="app-tabs__list-item" role="presentation">
+    <a class="app-tabs__tab" href="#figma-default-{{ id }}" role="tab" id="tab_figma-default-{{ id }}" aria-controls="figma-default-{{ id }}">Figma</a>
+  </li>
+  {%- endif -%}
+</ul>
+<div class="app-tabs__panel" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
+{%- if tabWarning -%}
+  <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
+{%- endif -%}
+<div class="app-example__code" data-module="app-copy">
 
 ```html
-{{ htmlCode | safe }}
+
+{{ htmlCode | safe  }}
 ```
-    </div>
-  </div>
 
-  <div class="app-tabs__panel" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
-    {%- if tabWarning -%}
-      <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
-    {%- endif -%}
-
+</div></div>
+<div class="app-tabs__panel" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
+{%- if tabWarning -%}
+  <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
+{%- endif -%}
 {%- set argsContent %}
   {% include arguments ignore missing %}
 {%- endset %}
-
 {% if argsContent | trim %}
   <details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
@@ -53,35 +49,28 @@
         Nunjucks macro options
       </span>
     </summary>
-    <div class="govuk-details__text">
-
-      {{ argsContent }}
-
-    </div>
+    <div class="govuk-details__text">{{ argsContent }}</div>
   </details>
-{% endif %}
-
-    <div class="app-example__code" data-module="app-copy">
+{% endif -%}
+<div class="app-example__code" data-module="app-copy">
 
 ```njk
+
 {{ nunjucksCode | safe }}
 ```
 
-    </div>
-  </div>
-
+</div></div>
 {% if jsCode %}
   <div class="app-tabs__panel" id="js-default-{{ id }}" role="tabpanel" aria-labelledby="tab_js-default-{{ id }}">
     <div class="app-example__code" data-module="app-copy">
 
 ```js
+
 {{ jsCode | safe }}
 ```
 
-    </div>
-  </div>
+</div></div>
 {% endif %}
-
 {% if figmaLink %}
   <div class="app-tabs__panel" id="figma-default-{{ id }}" role="tabpanel" aria-labelledby="tab_figma-default-{{ id }}">
     {%- if figmaTabContent -%}
@@ -94,7 +83,6 @@ If you work for MOJ, you can <a href="{{ figmaLink }}">view this component in th
 
 <p class="govuk-body govuk-!-margin-0">If you work outside MOJ, read the guidance on <a href="/prototyping/setting-up-figma-prototypes/#non-moj-staff-tab">setting up Figma prototypes for non-MOJ staff</a>.</p>
 {% endif %}
-
-  </div>
+</div>
 {% endif %}
 </div>

--- a/docs/_includes/layouts/partials/content-tabs.njk
+++ b/docs/_includes/layouts/partials/content-tabs.njk
@@ -29,5 +29,11 @@
   {{- govukTabs({
     items: items,
     classes: 'app-layout-tabs no-govuk-tabs-styles'
-  }) | dedent(2, false) | safe -}}
+  }) | dedent(2, false) | dedentGovUkTabPanel | safe -}}
+  {# We need to undo the indentation that the govukTabs macro adds so our code
+  blocks are indented correctly:
+  - dedent(2, false) removes 2 spaces from the entire output except the first
+  line
+  - dedentGovUkTabPanel removes 2 spaces from lines within the govuk-tabs__panel
+  divs #}
 {% endif %}

--- a/docs/_includes/layouts/partials/content-tabs.njk
+++ b/docs/_includes/layouts/partials/content-tabs.njk
@@ -29,5 +29,5 @@
   {{- govukTabs({
     items: items,
     classes: 'app-layout-tabs no-govuk-tabs-styles'
-  }) -}}
+  }) | dedent(2, false) | safe -}}
 {% endif %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
         "@ministryofjustice/hmpps-npm-script-allowlist": "0.0.4",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@rollup/plugin-babel": "^6.1.0",
         "@rollup/plugin-commonjs": "^28.0.9",
         "@rollup/plugin-node-resolve": "^16.0.3",
@@ -7260,13 +7260,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -31382,13 +31382,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -31401,9 +31401,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@ministryofjustice/hmpps-npm-script-allowlist": "0.0.4",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@rollup/plugin-babel": "^6.1.0",
     "@rollup/plugin-commonjs": "^28.0.9",
     "@rollup/plugin-node-resolve": "^16.0.3",


### PR DESCRIPTION
This PR fixes an issue with our example code blocks on tabbed documentation pages where the indentation is incorrect.  The whole block is indented too far, and the second line onwards is indented more than the first. This affects all code blocks, no matter what language.

<img width="1000" height="723" alt="image" src="https://github.com/user-attachments/assets/4794fed6-d952-4693-a387-e182c30381ab" />

The issue that was causing this was partly indentation issues within the `example.njk` file. But also an issue caused by the govuk-tabs macro - the [govuk tabs macro](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/components/tabs/template.njk) includes indentation in its macro e.g.

```
{{- _tabPanel(params, item, loop.index) | trim | indent(2, true) }}
```

Because the code examples are within a `<pre>` tag all whitespace is preserved meaning the code output retains these extra indents. 

This PR adds a general `dedent` filter which we apply to the whole output of the tabs macro. Another more specific macro `dedentGovUKTabsPanel` is then required to handle removing the indentation of the html within the tab panels.

**Result**
<img width="1020" height="720" alt="image" src="https://github.com/user-attachments/assets/482d7b31-2d17-4b50-bfa8-b5dc8e626e8f" />
<img width="996" height="745" alt="image" src="https://github.com/user-attachments/assets/f79a49dc-5a51-4d37-b5ba-ed2b09b698f4" />
