### PR TITLE
docs: only remove spaces from the start of a line if they are whitespace

### DIFF
--- a/11ty/filters/dedent-govuk-tab-panel.js
+++ b/11ty/filters/dedent-govuk-tab-panel.js
@@ -6,7 +6,7 @@
  * @param {string} str - The input string containing the HTML of the tab panel.
  * @returns {string} - The dedented string with only the content of the panel modified.
  */
-module.exports = function dedentGovUkTabPanel(str) {
+module.exports = function dedentGovUkTabPanel(str, spaces = 2) {
   const lines = str.split('\n')
   let inPanel = false
   let depth = 0
@@ -39,7 +39,7 @@ module.exports = function dedentGovUkTabPanel(str) {
       }
 
       // For lines inside the panel, remove the first 2 spaces of indentation
-      return line.slice(2)
+      return line.slice(0, spaces).trim() === '' ? line.slice(spaces) : line
     })
     .join('\n')
 }

--- a/11ty/filters/dedent.js
+++ b/11ty/filters/dedent.js
@@ -4,12 +4,14 @@
  *
  * @param {string} str - The input string to be dedented.
  * @param {number} spaces - The number of spaces to remove from the beginning of each line.
- * @param {boolean} [firstLine] - Whether to remove spaces from the first line as well.
  * @returns {string} - The dedented string with the specified number of spaces removed from the beginning of each line.
  */
-module.exports = function dedent(str, spaces, firstLine = true) {
+module.exports = function dedent(str, spaces) {
   return str
     .split('\n')
-    .map((line, index) => (firstLine || index > 0 ? line.slice(spaces) : line))
+    .map((line) => {
+      // remove spaces from the line only if they are whitespace
+      return line.slice(0, spaces).trim() === '' ? line.slice(spaces) : line
+    })
     .join('\n')
 }


### PR DESCRIPTION
This PR fixes an issue with the dedent filters, where it could truncate html tags unintentionally:

<img width="1007" height="476" alt="image" src="https://github.com/user-attachments/assets/5ea63184-1212-457f-bfca-c8cdea7aea40" />

Instead of `firstLine` `lastLine` boolean options.  The filters have been adjusted to only dedent the lines if the spaces to be removed are actually whitespace.  This is much more reliable and should prevent any malformed html.

<img width="1092" height="455" alt="image" src="https://github.com/user-attachments/assets/2061c3d8-8c16-4783-9773-6c757e6fdb8a" />

