### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     },
     {
       "groupName": "Build",
+      "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
         "@babel/*",
         "@rollup/*",
@@ -28,18 +29,20 @@
       ]
     },
     {
-      "addLabels": ["preview: request"],
       "groupName": "Documentation",
+      "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
         "@11ty/eleventy",
         "@11ty/eleventy-*",
         "highlight.js",
         "markdown-it",
         "markdown-it-*"
-      ]
+      ],
+      "addLabels": ["preview: request"]
     },
     {
       "groupName": "Lint",
+      "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
         "@typescript-eslint/*",
         "eslint-*",
@@ -49,7 +52,7 @@
       ]
     },
     {
-      "addLabels": ["preview: request"],
+      "matchUpdateTypes": ["minor", "patch"],
       "groupName": "Release",
       "matchPackageNames": [
         "@commitlint/*",
@@ -58,15 +61,18 @@
         "cz-*",
         "semantic-release",
         "semantic-release-*"
-      ]
+      ],
+      "addLabels": ["preview: request"]
     },
     {
-      "addLabels": ["preview: request"],
-      "groupName": "Production",
-      "matchDepTypes": ["dependencies", "peerDependencies"]
+      "groupName": "Production!",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchDepTypes": ["dependencies", "peerDependencies"],
+      "addLabels": ["preview: request"]
     },
     {
       "groupName": "Test",
+      "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
         "@playwright/*",
         "@testing-library/*",
@@ -81,7 +87,19 @@
     },
     {
       "groupName": "Tools",
+      "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": ["concurrently", "gulp", "gulp-*", "nodemon"]
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "autoApprove": true,
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["preview: request"],
+      "autoApprove": false,
+      "automerge": false
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
This PR updates the renovate config to ensure major version updates are not grouped. Grouping major updates together is problematic if one of the updates fails.  It is safer to handle major updates 1 by 1.  

This will lead to more PRs, but this config change also switches to autoapprove and automerge PRs for  minor or patch version updates (as long as all checks pass). This should mean that the only renovate PRs that  need manual intervention are minor and patch updates that cause a failure, and major versions.

N.B. The change to the 'Production' label is to invalidate renovates cache so that the old PR's get removed and new ones created.

