### PR TITLE
chore: add schedule to renovate config and remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,1 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
+

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,8 @@
   "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
   "ignoreDeps": ["eslint", "eslint-plugin-promise", "eslint-plugin-n"],
   "labels": ["renovate: dependencies 🗃️"],
+  "enabledManagers": ["npm", "github-actions"],
+  "schedule": ["* 22-23,0-4 * * 1-5"],
   "minimumReleaseAge": "7 days",
   "packageRules": [
     {


### PR DESCRIPTION
- Add explicit github action manager in renovate config
- Add a schedule to renovate
- Remove github action config from dependabot, as we don't need two tools generating the same PR. N.B. didn't remove the dependabot.yml file in case there are org checks that we have one :) 