### PR TITLE
docs: add mime type checking to file uploads

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -29,6 +29,13 @@ const config = {
     'justice.gov.uk',
     'publicguardian.gov.uk'
   ],
+  ALLOWED_COMPONENT_IMAGE_MIME_TYPES: new Set([
+    'image/jpeg',
+    'image/bmp',
+    'image/png',
+    'image/tiff',
+    'application/pdf'
+  ]),
   HTML_SANITIZATION_OPTIONS: {
     allowedTags: [
       // Document structure
@@ -504,6 +511,12 @@ const config = {
       type: 'success',
       title: 'Your email address has been confirmed',
       text: 'You can now submit a component'
+    },
+    uploadFileTooLarge: {
+      text: 'The selected file must be smaller than 10MB'
+    },
+    uploadFileInvalidType: {
+      text: 'The selected file must be a JPG, BMP, PNG, TIF or PDF'
     },
     componentImageUploaded: (filename) => {
       return {

--- a/app/middleware/component-session.js
+++ b/app/middleware/component-session.js
@@ -157,11 +157,16 @@ const errorTemplateVariables = (
 }
 
 const validateFormDataFileUpload = (err, req, res, next) => {
-  if (err?.code === 'LIMIT_FILE_SIZE') {
+  if (err?.code === 'LIMIT_FILE_SIZE' || err?.code === 'LIMIT_FILE_TYPE') {
+    const fieldName = err.field || 'componentImage'
     const errorMessage = 'The selected file must be smaller than 10MB'
+    const invalidTypeErrorMessage =
+      'The selected file must be a JPG, BMP, PNG, TIF or PDF'
     const formErrors = {}
-    formErrors[err.field] = { text: errorMessage }
-    const errors = [{ message: errorMessage, path: [err.field] }]
+    const message =
+      err?.code === 'LIMIT_FILE_SIZE' ? errorMessage : invalidTypeErrorMessage
+    formErrors[fieldName] = { text: message }
+    const errors = [{ message, path: [fieldName] }]
     const errorList = transformErrorsToErrorList(errors)
     const template = getTemplate(req)
     res

--- a/app/middleware/component-session.js
+++ b/app/middleware/component-session.js
@@ -7,6 +7,7 @@ const {
   MAX_ADD_ANOTHER: maxAddAnother,
   ADD_NEW_COMPONENT_ROUTE,
   ALLOWED_EMAIL_DOMAINS: allowedDomains,
+  ALLOWED_COMPONENT_IMAGE_MIME_TYPES,
   COMPONENT_FORM_PAGES: formPages,
   MESSAGES,
   HTML_SANITIZATION_OPTIONS
@@ -156,25 +157,104 @@ const errorTemplateVariables = (
   }
 }
 
-const validateFormDataFileUpload = (err, req, res, next) => {
-  if (err?.code === 'LIMIT_FILE_SIZE' || err?.code === 'LIMIT_FILE_TYPE') {
-    const fieldName = err.field || 'componentImage'
-    const errorMessage = 'The selected file must be smaller than 10MB'
-    const invalidTypeErrorMessage =
-      'The selected file must be a JPG, BMP, PNG, TIF or PDF'
-    const formErrors = {}
-    const message =
-      err?.code === 'LIMIT_FILE_SIZE' ? errorMessage : invalidTypeErrorMessage
-    formErrors[fieldName] = { text: message }
-    const errors = [{ message, path: [fieldName] }]
-    const errorList = transformErrorsToErrorList(errors)
-    const template = getTemplate(req)
-    res
-      .status(400)
-      .render(template, errorTemplateVariables(req, formErrors, errorList))
-  } else {
-    next()
+const renderFileUploadError = (req, res, fieldName, message) => {
+  const formErrors = {}
+  formErrors[fieldName] = { text: message }
+  const errors = [{ message, path: [fieldName] }]
+  const errorList = transformErrorsToErrorList(errors)
+  const template = getTemplate(req)
+  res
+    .status(400)
+    .render(template, errorTemplateVariables(req, formErrors, errorList))
+}
+
+const detectMimeTypeFromFileSignature = (buffer) => {
+  if (!Buffer.isBuffer(buffer)) {
+    return null
   }
+
+  const startsWithBytes = (bytes) =>
+    bytes.every((byte, index) => buffer[index] === byte)
+
+  if (startsWithBytes([0xff, 0xd8, 0xff])) {
+    return 'image/jpeg'
+  }
+
+  if (startsWithBytes([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return 'image/png'
+  }
+
+  if (startsWithBytes([0x42, 0x4d])) {
+    return 'image/bmp'
+  }
+
+  if (
+    startsWithBytes([0x49, 0x49, 0x2a, 0x00]) ||
+    startsWithBytes([0x4d, 0x4d, 0x00, 0x2a])
+  ) {
+    return 'image/tiff'
+  }
+
+  if (startsWithBytes([0x25, 0x50, 0x44, 0x46, 0x2d])) {
+    return 'application/pdf'
+  }
+
+  return null
+}
+
+const validateFormDataFileSignature = (req, res, next) => {
+  if (!req.file) {
+    return next()
+  }
+
+  const detectedMimeType = detectMimeTypeFromFileSignature(req.file.buffer)
+  if (
+    !detectedMimeType ||
+    !ALLOWED_COMPONENT_IMAGE_MIME_TYPES.has(detectedMimeType)
+  ) {
+    const error = new Error('Invalid file type')
+    error.code = 'LIMIT_FILE_TYPE'
+    error.field = req.file.fieldname || 'componentImage'
+    return next(error)
+  }
+
+  next()
+}
+
+const validateFormDataFileSize = (err, req, res, next) => {
+  if (!err) {
+    return next()
+  }
+
+  if (err.code === 'LIMIT_FILE_SIZE') {
+    const fieldName = err.field || 'componentImage'
+    return renderFileUploadError(
+      req,
+      res,
+      fieldName,
+      MESSAGES.uploadFileTooLarge.text
+    )
+  }
+
+  next(err)
+}
+
+const validateFormDataFileType = (err, req, res, next) => {
+  if (!err) {
+    return next()
+  }
+
+  if (err.code === 'LIMIT_FILE_TYPE') {
+    const fieldName = err.field || 'componentImage'
+    return renderFileUploadError(
+      req,
+      res,
+      fieldName,
+      MESSAGES.uploadFileInvalidType.text
+    )
+  }
+
+  next(err)
 }
 
 /**
@@ -486,7 +566,9 @@ module.exports = {
   removeFromSession,
   sessionStarted,
   sessionVerified,
-  validateFormDataFileUpload,
+  validateFormDataFileSignature,
+  validateFormDataFileSize,
+  validateFormDataFileType,
   validateComponentImagePage,
   saveFileToRedis,
   clearSkippedPageData,

--- a/app/middleware/component-session.spec.js
+++ b/app/middleware/component-session.spec.js
@@ -1276,7 +1276,7 @@ describe('validateFormDataFileUpload', () => {
     validateFormDataFileUpload(err, req, res, next)
     expect(next).toHaveBeenCalled()
   })
-  it('calls next if error code is not LIMIT_FILE_SIZE', () => {
+  it('calls next if error code is not upload validation error', () => {
     const err = {
       code: 'AN_ERROR'
     }
@@ -1305,6 +1305,52 @@ describe('validateFormDataFileUpload', () => {
       formErrors: {
         componentImage: {
           text: 'The selected file must be smaller than 10MB'
+        }
+      },
+      page: {
+        fields: {
+          componentImage: {
+            hint: 'The file must be a JPG, BMP, PNG, TIF or PDF, and smaller than 10MB.',
+            label: 'Upload a file'
+          }
+        },
+        removable: false,
+        showOnCya: true,
+        title: 'Component image'
+      },
+      showAddAnother: false,
+      submitUrl: undefined
+    }
+
+    validateFormDataFileUpload(err, req, res, next)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.render).toHaveBeenCalledWith('component-image', expectedArgs)
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it('renders the template with unsupported file type errors', () => {
+    const err = {
+      code: 'LIMIT_FILE_TYPE',
+      field: 'componentImage'
+    }
+    req.params = { page: 'component-image' }
+    const expectedArgs = {
+      addAnother: 1,
+      backLink: false,
+      csrfToken: undefined,
+      errorList: [
+        {
+          href: '#component-image',
+          text: 'The selected file must be a JPG, BMP, PNG, TIF or PDF'
+        }
+      ],
+      file: undefined,
+      formData: undefined,
+      formErrorStyles: null,
+      formErrors: {
+        componentImage: {
+          text: 'The selected file must be a JPG, BMP, PNG, TIF or PDF'
         }
       },
       page: {

--- a/app/middleware/component-session.spec.js
+++ b/app/middleware/component-session.spec.js
@@ -22,7 +22,9 @@ const {
   removeFromSession,
   sessionStarted,
   sessionVerified,
-  validateFormDataFileUpload,
+  validateFormDataFileSignature,
+  validateFormDataFileSize,
+  validateFormDataFileType,
   validateComponentImagePage,
   saveFileToRedis,
   clearSkippedPageData,
@@ -1260,7 +1262,7 @@ describe('validateFormData', () => {
   })
 })
 
-describe('validateFormDataFileUpload', () => {
+describe('validateFormDataFileSize', () => {
   let req, res, next
   beforeEach(() => {
     req = {}
@@ -1273,17 +1275,17 @@ describe('validateFormDataFileUpload', () => {
   })
   it('calls next if no error', () => {
     const err = undefined
-    validateFormDataFileUpload(err, req, res, next)
+    validateFormDataFileSize(err, req, res, next)
     expect(next).toHaveBeenCalled()
   })
-  it('calls next if error code is not upload validation error', () => {
+  it('passes error through if error code is not LIMIT_FILE_SIZE', () => {
     const err = {
       code: 'AN_ERROR'
     }
-    validateFormDataFileUpload(err, req, res, next)
-    expect(next).toHaveBeenCalled()
+    validateFormDataFileSize(err, req, res, next)
+    expect(next).toHaveBeenCalledWith(err)
   })
-  it('renders the template with errors', () => {
+  it('renders the template with size limit errors', () => {
     const err = {
       code: 'LIMIT_FILE_SIZE',
       field: 'componentImage'
@@ -1322,13 +1324,79 @@ describe('validateFormDataFileUpload', () => {
       submitUrl: undefined
     }
 
-    validateFormDataFileUpload(err, req, res, next)
+    validateFormDataFileSize(err, req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(400)
     expect(res.render).toHaveBeenCalledWith('component-image', expectedArgs)
     expect(next).not.toHaveBeenCalled()
   })
+})
 
+describe('validateFormDataFileSignature', () => {
+  let req, res, next
+  beforeEach(() => {
+    req = {}
+    res = {}
+    next = jest.fn()
+    jest.clearAllMocks()
+  })
+
+  it('calls next when no file is present', () => {
+    validateFormDataFileSignature(req, res, next)
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('calls next when file signature is valid', () => {
+    req.file = {
+      fieldname: 'componentImage',
+      mimetype: 'image/jpeg',
+      buffer: Buffer.from([0xff, 0xd8, 0xff, 0xdb])
+    }
+
+    validateFormDataFileSignature(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  it('passes a LIMIT_FILE_TYPE error when file signature is invalid', () => {
+    req.file = {
+      fieldname: 'componentImage',
+      mimetype: 'image/jpeg',
+      buffer: Buffer.from('# Not an image\nSome markdown text', 'utf8')
+    }
+
+    validateFormDataFileSignature(req, res, next)
+
+    const [error] = next.mock.calls[0]
+    expect(error).toBeInstanceOf(Error)
+    expect(error.code).toBe('LIMIT_FILE_TYPE')
+    expect(error.field).toBe('componentImage')
+  })
+})
+
+describe('validateFormDataFileType', () => {
+  let req, res, next
+  beforeEach(() => {
+    req = {}
+    res = {
+      render: jest.fn(),
+      status: jest.fn(() => res)
+    }
+    next = jest.fn()
+    jest.clearAllMocks()
+  })
+  it('calls next if no error', () => {
+    const err = undefined
+    validateFormDataFileType(err, req, res, next)
+    expect(next).toHaveBeenCalled()
+  })
+  it('passes error through if error code is not LIMIT_FILE_TYPE', () => {
+    const err = {
+      code: 'AN_ERROR'
+    }
+    validateFormDataFileType(err, req, res, next)
+    expect(next).toHaveBeenCalledWith(err)
+  })
   it('renders the template with unsupported file type errors', () => {
     const err = {
       code: 'LIMIT_FILE_TYPE',
@@ -1368,7 +1436,7 @@ describe('validateFormDataFileUpload', () => {
       submitUrl: undefined
     }
 
-    validateFormDataFileUpload(err, req, res, next)
+    validateFormDataFileType(err, req, res, next)
 
     expect(res.status).toHaveBeenCalledWith(400)
     expect(res.render).toHaveBeenCalledWith('component-image', expectedArgs)

--- a/app/routes/add-component.js
+++ b/app/routes/add-component.js
@@ -57,9 +57,27 @@ const {
   getDetailsForPrEmail
 } = require('../middleware/process-submission-data')
 const verifyCsrf = require('../middleware/verify-csrf')
+const ALLOWED_COMPONENT_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/bmp',
+  'image/png',
+  'image/tiff',
+  'application/pdf'
+])
+
 const upload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 10 * 1024 * 1024 } // 10MB
+  limits: { fileSize: 10 * 1024 * 1024 }, // 10MB
+  fileFilter: (req, file, cb) => {
+    if (ALLOWED_COMPONENT_IMAGE_MIME_TYPES.has(file.mimetype)) {
+      return cb(null, true)
+    }
+
+    const error = new Error('Invalid file type')
+    error.code = 'LIMIT_FILE_TYPE'
+    error.field = file.fieldname
+    cb(error)
+  }
 })
 const router = express.Router()
 const checkYourAnswersPath = 'check-your-answers'

--- a/app/routes/add-component.js
+++ b/app/routes/add-component.js
@@ -9,7 +9,8 @@ const {
   COMPONENT_FORM_PAGES,
   ADD_NEW_COMPONENT_ROUTE,
   MESSAGES,
-  ENV
+  ENV,
+  ALLOWED_COMPONENT_IMAGE_MIME_TYPES
 } = require('../config')
 const ApplicationError = require('../helpers/application-error')
 const { checkYourAnswers } = require('../helpers/check-your-answers')
@@ -28,7 +29,9 @@ const {
   removeFromSession,
   sessionStarted,
   sessionVerified,
-  validateFormDataFileUpload,
+  validateFormDataFileSignature,
+  validateFormDataFileSize,
+  validateFormDataFileType,
   saveFileToRedis,
   clearSkippedPageData,
   checkEmailDomain,
@@ -57,13 +60,6 @@ const {
   getDetailsForPrEmail
 } = require('../middleware/process-submission-data')
 const verifyCsrf = require('../middleware/verify-csrf')
-const ALLOWED_COMPONENT_IMAGE_MIME_TYPES = new Set([
-  'image/jpeg',
-  'image/bmp',
-  'image/png',
-  'image/tiff',
-  'application/pdf'
-])
 
 const upload = multer({
   storage: multer.memoryStorage(),
@@ -525,9 +521,11 @@ router.post(
   validatePageParams,
   upload.single('componentImage'),
   verifyCsrf,
+  validateFormDataFileSignature,
   saveFileToRedis,
   canAddAnother,
-  validateFormDataFileUpload,
+  validateFormDataFileSize,
+  validateFormDataFileType,
   getBackLink,
   validateFormData,
   (req, res, next) => {

--- a/app/tests/e2e/03.component-image.spec.js
+++ b/app/tests/e2e/03.component-image.spec.js
@@ -35,6 +35,15 @@ test('unsupported file type', async () => {
   ])
 })
 
+test('disguised markdown file renamed to jpg', async () => {
+  await testPage.uploadFile('test-image-fake.jpg')
+  await testPage.clickUpload()
+
+  await testPage.expectErrorSummaryWithMessages([
+    'The selected file must be a JPG, BMP, PNG, TIF or PDF'
+  ])
+})
+
 test('file ok', async () => {
   const filename = 'test-image.png'
 

--- a/app/tests/e2e/03.component-image.spec.js
+++ b/app/tests/e2e/03.component-image.spec.js
@@ -26,6 +26,15 @@ test('file too large', async () => {
   ])
 })
 
+test('unsupported file type', async () => {
+  await testPage.uploadFile('test-image.txt')
+  await testPage.clickUpload()
+
+  await testPage.expectErrorSummaryWithMessages([
+    'The selected file must be a JPG, BMP, PNG, TIF or PDF'
+  ])
+})
+
 test('file ok', async () => {
   const filename = 'test-image.png'
 

--- a/app/tests/e2e/test-files/test-image-fake.jpg
+++ b/app/tests/e2e/test-files/test-image-fake.jpg
@@ -1,0 +1,3 @@
+# Heading
+
+This is markdown content disguised as a jpg file.

--- a/app/tests/e2e/test-files/test-image.txt
+++ b/app/tests/e2e/test-files/test-image.txt
@@ -1,0 +1,1 @@
+not an image


### PR DESCRIPTION
This pull request introduces stricter validation for component image uploads. We now verify the file size, file type, and protect against mime-type spoofing with magic byte checks. 

This addresses FE5 from the MOJ Threat Modelling sheet
