### PR TITLE
feat (add another): Add i18n labelling to component to support custom labels and translation 

### DIFF
--- a/docs/components/add-another/_arguments.md
+++ b/docs/components/add-another/_arguments.md
@@ -9,8 +9,8 @@
 | addAnotherButtonText   | string  | No       | Text label for the add another button. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. |
 | itemLegendText         | object  | No       | Text label for the item legend. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number, and the `%{count}` placeholder will be replaced with the total number of items. [GOV.UK pluralisation rules apply to this macro option](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#understanding-pluralisation-rules). |
 | removeButtonText       | string  | No       | Text label for the remove button. Defaults to 'Remove' |
-| removeButtonSuffixText | string  | No       | Text appended to the `removeButtonText`. This is visually hidden in the inline layout. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
-| fieldLabelSuffixText   | string  | No       | Visually hidden text appended to the field labels. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
+| removeButtonSuffixText | string  | No       | Text appended to the `removeButtonText`. This is visually hidden in the inline layout. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
+| fieldLabelSuffixText   | string  | No       | Visually hidden text appended to the field labels. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
 
 
 ### items

--- a/docs/components/add-another/_arguments.md
+++ b/docs/components/add-another/_arguments.md
@@ -6,6 +6,11 @@
 | layout                 | string  | No       | Can be ‘stacked’ or ‘inline’. Defaults to stacked. |
 | classes                | string  | No       | Classes to add to the container. |
 | attributes             | object  | No       | HTML attributes (for example data attributes) to add to the container.|
+| addAnotherButtonText   | string  | No       | Text label for the add another button. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. Defaults to ‘Add another %{itemLabel}’ |
+| itemLegendText         | object  | No       | Text label for the item legend. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number, and the `%{count}` placeholder will be replaced with the total number of items. Defaults to ‘%{itemLabel} %{number} of %{count}’. [GOV.UK pluralisation rules apply to this macro option](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#understanding-pluralisation-rules). |
+| removeButtonText       | string  | No       | Text label for the remove button. Defaults to 'Remove' |
+| removeButtonSuffixText | string  | No       | Text appended to the `removeButtonText`. This is visually hidden in the inline layout. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. Defaults to '%{itemLabel} %{number}' |
+
 
 ### items
 

--- a/docs/components/add-another/_arguments.md
+++ b/docs/components/add-another/_arguments.md
@@ -6,10 +6,11 @@
 | layout                 | string  | No       | Can be ‘stacked’ or ‘inline’. Defaults to stacked. |
 | classes                | string  | No       | Classes to add to the container. |
 | attributes             | object  | No       | HTML attributes (for example data attributes) to add to the container.|
-| addAnotherButtonText   | string  | No       | Text label for the add another button. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. Defaults to ‘Add another %{itemLabel}’ |
-| itemLegendText         | object  | No       | Text label for the item legend. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number, and the `%{count}` placeholder will be replaced with the total number of items. Defaults to ‘%{itemLabel} %{number} of %{count}’. [GOV.UK pluralisation rules apply to this macro option](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#understanding-pluralisation-rules). |
+| addAnotherButtonText   | string  | No       | Text label for the add another button. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. |
+| itemLegendText         | object  | No       | Text label for the item legend. The component will replace the `%{itemLabel}` placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number, and the `%{count}` placeholder will be replaced with the total number of items. [GOV.UK pluralisation rules apply to this macro option](https://frontend.design-system.service.gov.uk/localise-govuk-frontend/#understanding-pluralisation-rules). |
 | removeButtonText       | string  | No       | Text label for the remove button. Defaults to 'Remove' |
-| removeButtonSuffixText | string  | No       | Text appended to the `removeButtonText`. This is visually hidden in the inline layout. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. Defaults to '%{itemLabel} %{number}' |
+| removeButtonSuffixText | string  | No       | Text appended to the `removeButtonText`. This is visually hidden in the inline layout. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
+| fieldLabelSuffixText   | string  | No       | Visually hidden text appended to the field labels. The component will replace the `%{itemLabel} placeholder with the value of the `itemLabel` parameter. The `%{number}` placeholder will be replaced with the item number. |
 
 
 ### items

--- a/docs/components/add-another/examples/datepicker/index.njk
+++ b/docs/components/add-another/examples/datepicker/index.njk
@@ -60,9 +60,6 @@
   items: [
     {
       fieldset: {
-        legend: {
-          text: "Period of absence 1"
-        },
         html: itemHtml
       }
       }

--- a/docs/components/add-another/examples/default/index.njk
+++ b/docs/components/add-another/examples/default/index.njk
@@ -76,18 +76,9 @@ redirect_from: examples/add-another
 <form method="post" action="#">
   {{ mojAddAnother({
     itemLabel: "Participant",
-    addAnotherButtonText: "%{itemLabel} me up, baby!",
-    removeButtonText: "%{itemLabel} %{count} must go!",
-    itemLegendSuffixText: {
-      one: "%{count}",
-      other: "%{count} of %{total}"
-    },
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Participant 1"
-          },
           html: itemHtml
         }
       }

--- a/docs/components/add-another/examples/default/index.njk
+++ b/docs/components/add-another/examples/default/index.njk
@@ -76,6 +76,12 @@ redirect_from: examples/add-another
 <form method="post" action="#">
   {{ mojAddAnother({
     itemLabel: "Participant",
+    addAnotherButtonText: "%{itemLabel} me up, baby!",
+    removeButtonText: "%{itemLabel} %{count} must go!",
+    itemLegendSuffixText: {
+      one: "%{count}",
+      other: "%{count} of %{total}"
+    },
     items: [
       {
         fieldset: {

--- a/docs/components/add-another/examples/errors/index.njk
+++ b/docs/components/add-another/examples/errors/index.njk
@@ -124,25 +124,16 @@ layout: 'layouts/example.njk'
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Person 1"
-          },
           html: firstItemHtml
         }
       },
       {
         fieldset: {
-          legend: {
-            text: "Person 2"
-          },
           html: secondItemHtml
         }
       },
       {
         fieldset: {
-          legend: {
-            text: "Person 3"
-          },
           html: thirdItemHtml
         }
       }

--- a/docs/components/add-another/examples/events/index.njk
+++ b/docs/components/add-another/examples/events/index.njk
@@ -54,9 +54,6 @@
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Expense 1"
-          },
           html: itemHtml
         }
       }
@@ -64,20 +61,20 @@
   }) }}
 
 
-            {{govukInput({
-              id: "expenses-total",
-              name: "expenses-total",
-              classes: "govuk-input--width-10",
-              label: {
-                text: "Total expenditure"
-              },
-                    prefix: {
-        text: "£",
-        attributes: {
-          "aria-hidden": "true",
-          "readonly": "true"
-        }
+  {{ govukInput({
+    id: "expenses-total",
+    name: "expenses-total",
+    classes: "govuk-input--width-10",
+    label: {
+      text: "Total expenditure"
+    },
+    prefix: {
+      text: "£",
+      attributes: {
+        "aria-hidden": "true",
+        "readonly": "true"
       }
-            })}}
+    }
+  }) }}
 
 </form>

--- a/docs/components/add-another/examples/inline-accounts/index.njk
+++ b/docs/components/add-another/examples/inline-accounts/index.njk
@@ -54,9 +54,6 @@
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Account 1"
-          },
           html: itemHtml
         }
       }

--- a/docs/components/add-another/examples/inline-errors/index.njk
+++ b/docs/components/add-another/examples/inline-errors/index.njk
@@ -136,17 +136,11 @@ layout: 'layouts/example.njk'
       items: [
         {
           fieldset: {
-            legend: {
-              text: "person 1"
-            },
             html: firstItemHtml
           }
         },
         {
           fieldset: {
-            legend: {
-              text: "person 1"
-            },
             html: secondItemHtml
           },
           errorMessage: {
@@ -155,9 +149,6 @@ layout: 'layouts/example.njk'
         },
         {
           fieldset: {
-            legend: {
-              text: "person 1"
-            },
             html: thirdItemHtml
           }
         }

--- a/docs/components/add-another/examples/inline-offences/index.njk
+++ b/docs/components/add-another/examples/inline-offences/index.njk
@@ -58,9 +58,6 @@
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Offence 1"
-          },
           html: itemHtml
         }
       }

--- a/docs/components/add-another/examples/stacked-errors/index.njk
+++ b/docs/components/add-another/examples/stacked-errors/index.njk
@@ -161,17 +161,11 @@ title: Add another (example)
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Participant 1 of 2"
-          },
           html: firstItemHtml
         }
       },
       {
         fieldset: {
-          legend: {
-            text: "Participant 2 of 2"
-          },
           html: secondItemHtml
         }
       }

--- a/docs/components/add-another/examples/stacked/index.njk
+++ b/docs/components/add-another/examples/stacked/index.njk
@@ -147,17 +147,11 @@ title: Add another (example)
     items: [
       {
         fieldset: {
-          legend: {
-            text: "Participant 1 of 2"
-          },
           html: firstItemHtml
         }
       },
       {
         fieldset: {
-          legend: {
-            text: "Participant 2 of 2"
-          },
           html: secondItemHtml
         }
       }

--- a/docs/stylesheets/components/_tabs.scss
+++ b/docs/stylesheets/components/_tabs.scss
@@ -124,6 +124,10 @@
     max-width: 100% !important;
   }
 
+  table td {
+    vertical-align: top;
+  }
+
   code {
     background-color: #e9e9e9;
   }

--- a/gulp/build-javascripts.js
+++ b/gulp/build-javascripts.js
@@ -4,6 +4,8 @@ const gulp = require('gulp')
 const { compileScripts } = require('./tasks/scripts')
 
 gulp.task('build:javascripts', async () => {
+  const govukFrontendExternals = [/^govuk-frontend(?:\/.*)?$/]
+
   const modulePaths = await glob('moj/components/**/*.{cjs,js,mjs}', {
     cwd: 'src',
     ignore: ['**/*.spec.{cjs,js,mjs}'],
@@ -32,7 +34,7 @@ gulp.task('build:javascripts', async () => {
 
         // Customise input
         input: {
-          external: ['govuk-frontend']
+          external: govukFrontendExternals
         },
 
         // Customise output
@@ -73,14 +75,17 @@ gulp.task('build:javascripts', async () => {
 
         // Customise input
         input: {
-          external: ['govuk-frontend']
+          external: govukFrontendExternals
         },
 
         // Customise output
         output: {
           file: modulePath.replace('.mjs', '.bundle.js'),
           format: 'umd',
-          globals: { 'govuk-frontend': 'GOVUKFrontend' },
+          globals: {
+            'govuk-frontend': 'GOVUKFrontend',
+            'govuk-frontend/dist/govuk/i18n.mjs': 'GOVUKFrontend'
+          },
           name: 'MOJFrontend'
         }
       })()

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const transformedNodeModules = ['sinon', 'govuk-frontend']
+
 module.exports = {
   modulePathIgnorePatterns: [
     '<rootDir>/dist/',
@@ -23,6 +25,6 @@ module.exports = {
   // Enable Babel transforms for ESM-only node_modules
   // See: https://jestjs.io/docs/ecmascript-modules
   transformIgnorePatterns: [
-    `<rootDir>/node_modules/(?!${['sinon'].join('|')}/)`
+    `<rootDir>/node_modules/(?!${transformedNodeModules.join('|')}/)`
   ]
 }

--- a/src/moj/common/index.mjs
+++ b/src/moj/common/index.mjs
@@ -50,6 +50,20 @@ export function setFocus($element, options = {}) {
 }
 
 /**
+ * Returns the value of the given attribute closest to the given element (including itself)
+ *
+ * @param {Element} $element - The element to start walking the DOM tree up
+ * @param {string} attributeName - The name of the attribute
+ * @returns {string | null} Attribute value
+ */
+export function closestAttributeValue($element, attributeName) {
+  const $closestElementWithAttribute = $element.closest(`[${attributeName}]`)
+  return $closestElementWithAttribute
+    ? $closestElementWithAttribute.getAttribute(attributeName)
+    : null
+}
+
+/**
  * Emit a custom event
  *
  * @template {CompatibleClass} ComponentClass

--- a/src/moj/components/add-another/_itemTemplate.njk
+++ b/src/moj/components/add-another/_itemTemplate.njk
@@ -3,9 +3,13 @@
 {%- from "govuk/components/error-message/macro.njk" import govukErrorMessage -%}
 
 {% set describedBy = item.fieldset.describedBy if item.fieldset.describedBy else "" %}
+
 {% set itemLabel = params.itemLabel | default('Item', true) %}
-{% set defaultRemoveButtonText = "Remove %{itemLabel} %{count}" %}
-{% set removeButtonText = params.removeButtonText or defaultRemoveButtonText | replace('%{itemLabel}', (itemLabel | lower)) | replace('%{count}', index) %}
+{% set defaultRemoveButtonText = "Remove %{itemLabel} %{number}" %}
+{% set removeButtonText = params.removeButtonText or defaultRemoveButtonText | replace('%{itemLabel}', (itemLabel | lower)) | replace('%{number}', index) %}
+
+{% set itemLegend = params.itemLegendText | default('%{itemLabel} %{number}', true) %}
+{% set itemLegendText = itemLegend | replace('%{itemLabel}', itemLabel) | replace('%{number}', index) %}
 
 {#- Setup css classes for the item and legend #}
 {% set classes = ["moj-add-another__item"] %}
@@ -77,11 +81,11 @@ button are side by side, otherwise the remove button is below the content #}
 
 {#- Setup the legend for the fieldset, if one is provided #}
 {% set legendParams = {
-  text: item.fieldset.legend.text,
+  text: itemLegendText,
   html: item.fieldset.legend.html,
   classes: legendClasses,
   isPageHeading: false
-} if item.fieldset.legend else false %}
+} %}
 
 {#- Render the item #}
 <div class="{{ classes }}" {{ govukAttributes(item.attributes) }}>

--- a/src/moj/components/add-another/_itemTemplate.njk
+++ b/src/moj/components/add-another/_itemTemplate.njk
@@ -6,10 +6,11 @@
 
 {% set itemLabel = params.itemLabel | default('Item', true) %}
 {% set defaultRemoveButtonText = "Remove %{itemLabel} %{number}" %}
-{% set removeButtonText = params.removeButtonText or defaultRemoveButtonText | replace('%{itemLabel}', (itemLabel | lower)) | replace('%{number}', index) %}
+{% set removeButtonText = (params.removeButtonText or defaultRemoveButtonText) | replace('%{itemLabel}', (itemLabel | lower)) | replace('%{number}', index) %}
 
-{% set itemLegend = params.itemLegendText | default('%{itemLabel} %{number}', true) %}
-{% set itemLegendText = itemLegend | replace('%{itemLabel}', itemLabel) | replace('%{number}', index) %}
+{% set itemsCount = params.items | length %}
+{% set itemLegendTemplate = ((params.itemLegendText.one if itemsCount == 1 else params.itemLegendText.other) or '%{itemLabel} %{number}') if params.itemLegendText else '%{itemLabel} %{number}' %}
+{% set itemLegendText = itemLegendTemplate | replace('%{itemLabel}', itemLabel) | replace('%{number}', index) | replace('%{count}', itemsCount) %}
 
 {#- Setup css classes for the item and legend #}
 {% set classes = ["moj-add-another__item"] %}

--- a/src/moj/components/add-another/_itemTemplate.njk
+++ b/src/moj/components/add-another/_itemTemplate.njk
@@ -3,6 +3,9 @@
 {%- from "govuk/components/error-message/macro.njk" import govukErrorMessage -%}
 
 {% set describedBy = item.fieldset.describedBy if item.fieldset.describedBy else "" %}
+{% set itemLabel = params.itemLabel | default('Item', true) %}
+{% set defaultRemoveButtonText = "Remove %{itemLabel} %{count}" %}
+{% set removeButtonText = params.removeButtonText or defaultRemoveButtonText | replace('%{itemLabel}', (itemLabel | lower)) | replace('%{count}', index) %}
 
 {#- Setup css classes for the item and legend #}
 {% set classes = ["moj-add-another__item"] %}
@@ -35,7 +38,7 @@ attribute and add an error class to the item #}
 {% set removeButtonHtml %}
   <div class="moj-add-another__remove-button-container">
     {{ govukButton({
-      text: "Remove " + (params.itemLabel | lower) + " " + index,
+      text: removeButtonText,
       classes: "govuk-button--secondary moj-add-another__remove-button",
       name: item.removeButton.name if params.removeButton.name else 'remove',
       value: item.removeButton.value if params.removeButton.value else index-1

--- a/src/moj/components/add-another/add-another.js.spec.mjs
+++ b/src/moj/components/add-another/add-another.js.spec.mjs
@@ -13,9 +13,9 @@ import { AddAnother } from './add-another.mjs'
  * @param {object} [config] - Config to pass to the AddAnother constructor
  * @returns {HTMLElement} The root component element
  */
-function createComponentWithJSConfig(config = {}) {
+function createComponentWithJSConfig(config = {}, rootAttributes = '') {
   const html = outdent`
-    <div data-module="moj-add-another">
+    <div data-module="moj-add-another" ${rootAttributes}>
       <div class="moj-add-another__items">
         <div class="moj-add-another__item">
           <fieldset class="govuk-fieldset moj-add-another__fieldset">
@@ -149,6 +149,83 @@ describe('add another', () => {
       expect(
         removeButton.querySelector('.govuk-visually-hidden')
       ).not.toBeInTheDocument()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // JavaScript config — i18n
+  // ---------------------------------------------------------------------------
+
+  describe('JS config — i18n', () => {
+    let $component
+
+    beforeEach(() => {
+      $component = createComponentWithJSConfig({
+        itemLabel: 'Case',
+        i18n: {
+          removeButtonText: 'Delete',
+          removeButtonSuffixText: 'case %{number}',
+          fieldLabelSuffixText: 'for translated %{itemLabel} %{number}',
+          itemLegendText: {
+            one: 'Translated %{itemLabel} %{number}',
+            other: 'Translated %{itemLabel} %{number} of %{count}'
+          }
+        }
+      })
+    })
+
+    afterEach(() => {
+      document.body.innerHTML = ''
+    })
+
+    test('uses translated field label suffix text', () => {
+      const suffix = $component.querySelector('.moj-add-another__label-suffix')
+      expect(suffix).toBeInTheDocument()
+      expect(suffix).toHaveTextContent('for translated case 1')
+    })
+
+    test('uses translated remove button labels', () => {
+      getByRole($component, 'button', { name: /Add another/ }).click()
+
+      const items = $component.querySelectorAll('.moj-add-another__item')
+      const firstRemove = queryByRole(items[0], 'button', { name: /Delete/ })
+      const secondRemove = queryByRole(items[1], 'button', { name: /Delete/ })
+
+      expect(firstRemove).toHaveAccessibleName('Delete case 1')
+      expect(secondRemove).toHaveAccessibleName('Delete case 2')
+    })
+
+    test('uses translated pluralized legend text as item count changes', () => {
+      const firstLegend = $component.querySelector('legend')
+      expect(firstLegend).toHaveTextContent('Translated Case 1')
+
+      getByRole($component, 'button', { name: /Add another/ }).click()
+      const legends = $component.querySelectorAll('legend')
+
+      expect(legends[0]).toHaveTextContent('Translated Case 1 of 2')
+      expect(legends[1]).toHaveTextContent('Translated Case 2 of 2')
+    })
+
+    test('uses lang locale fallback for pluralized legend selection', () => {
+      const $arComponent = createComponentWithJSConfig(
+        {
+          itemLabel: 'Entry',
+          i18n: {
+            itemLegendText: {
+              one: 'ONE %{itemLabel} %{number} of %{count}',
+              two: 'TWO %{itemLabel} %{number} of %{count}',
+              other: 'OTHER %{itemLabel} %{number} of %{count}'
+            }
+          }
+        },
+        'lang="ar"'
+      )
+
+      getByRole($arComponent, 'button', { name: /Add another/ }).click()
+      const legends = $arComponent.querySelectorAll('legend')
+
+      expect(legends[0]).toHaveTextContent('TWO Entry 1 of 2')
+      expect(legends[1]).toHaveTextContent('TWO Entry 2 of 2')
     })
   })
 })

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -453,10 +453,12 @@ export class AddAnother extends ConfigurableComponent {
     }
 
     if ($suffix && $suffix instanceof HTMLElement) {
-      $suffix.textContent = this.i18n.t('fieldLabelSuffixText', {
+      const $replacementSuffix = $suffix.cloneNode()
+      $replacementSuffix.textContent = this.i18n.t('fieldLabelSuffixText', {
         itemLabel: this.config.itemLabel.toLowerCase(),
         number: index
       })
+      $suffix.replaceWith($replacementSuffix)
     }
   }
 

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -400,11 +400,11 @@ export class AddAnother extends ConfigurableComponent {
    */
   updateRemoveButtons($item, index, itemsCount) {
     const $button = $item.querySelector(`.${this.removeButtonClass}`)
-    const label = this.removeButtonLabelText(index + 1)
+    const labelIndex = index + 1
 
     if (!$button || !($button instanceof HTMLButtonElement)) {
       if (itemsCount > 1 && index === 0) {
-        this.createRemoveButton($item, label)
+        this.createRemoveButton($item, labelIndex)
       }
       return
     }
@@ -412,7 +412,7 @@ export class AddAnother extends ConfigurableComponent {
     if (itemsCount === 1 && index === 0) {
       $button.remove()
     } else {
-      $button.innerHTML = label
+      this.setRemoveButtonContent($button, labelIndex)
     }
   }
 
@@ -492,8 +492,9 @@ export class AddAnother extends ConfigurableComponent {
    * adds it to the item.
    *
    * @param {Element|DocumentFragment} $item - Add another item
+   * @param {number} [labelIndex] - label index
    */
-  createRemoveButton($item, label = 'Remove') {
+  createRemoveButton($item, labelIndex = 1) {
     const $buttonContainer = $item.querySelector(
       `.${this.removeButtonContainerClass}`
     )
@@ -504,7 +505,7 @@ export class AddAnother extends ConfigurableComponent {
       'govuk-button--secondary',
       `${this.removeButtonClass}`
     )
-    $button.innerHTML = label
+    this.setRemoveButtonContent($button, labelIndex)
 
     if ($buttonContainer && $buttonContainer instanceof HTMLElement) {
       $buttonContainer.appendChild($button)
@@ -576,6 +577,50 @@ export class AddAnother extends ConfigurableComponent {
   }
 
   /**
+   * Generates remove button text.
+   *
+   * @returns {string} translated remove button text
+   */
+  removeButtonText() {
+    return this.i18n.t('removeButtonText')
+  }
+
+  /**
+   * Generates remove button suffix text.
+   *
+   * @param {number} labelIndex - the index to include in the remove button label
+   * @returns {string} translated remove button suffix text
+   */
+  removeButtonSuffixText(labelIndex) {
+    return this.i18n.t('removeButtonSuffixText', {
+      itemLabel: this.config.itemLabel.toLowerCase(),
+      number: labelIndex
+    })
+  }
+
+  /**
+   * Sets remove button label content safely without using innerHTML.
+   *
+   * @param {HTMLButtonElement} $button
+   * @param {number} labelIndex
+   */
+  setRemoveButtonContent($button, labelIndex) {
+    const text = this.removeButtonText()
+    const suffix = this.removeButtonSuffixText(labelIndex)
+
+    if (this.config.layout === 'inline') {
+      $button.textContent = `${text} `
+      const $hiddenSuffix = document.createElement('span')
+      $hiddenSuffix.classList.add('govuk-visually-hidden')
+      $hiddenSuffix.textContent = suffix
+      $button.appendChild($hiddenSuffix)
+      return
+    }
+
+    $button.textContent = `${text} ${suffix}`
+  }
+
+  /**
    * Generates the label text for the remove button based on the layout
    * configuration.
    *
@@ -583,23 +628,7 @@ export class AddAnother extends ConfigurableComponent {
    * @returns {string} the label for the remove button based on the layout configuration
    */
   removeButtonLabelText(labelIndex) {
-    if (this.config.layout === 'inline') {
-      return `${this.i18n.t('removeButtonText')} <span class="govuk-visually-hidden">${this.i18n.t(
-        'removeButtonSuffixText',
-        {
-          itemLabel: this.config.itemLabel.toLowerCase(),
-          number: labelIndex
-        }
-      )}</span>`
-    }
-
-    return `${this.i18n.t('removeButtonText')} ${this.i18n.t(
-      'removeButtonSuffixText',
-      {
-        itemLabel: this.config.itemLabel.toLowerCase(),
-        number: labelIndex
-      }
-    )}`
+    return `${this.removeButtonText()} ${this.removeButtonSuffixText(labelIndex)}`
   }
 
   /**

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -844,12 +844,12 @@ export class AddAnother extends ConfigurableComponent {
  */
 
 /**
- * Character count translations
+ * Add another translations
  *
  * @see {@link AddAnother.defaults.i18n}
  * @typedef {object} AddAnotherTranslations
  * @property {TranslationPluralForms} [itemLegendText] - Legend for the item.
- *   %{itemLabel} placeholder with be replaced with the AddAnother.config.itemLabel.
+ *   %{itemLabel} placeholder will be replaced with the AddAnother.config.itemLabel.
  *   %{number} and %{count} placeholders will be replaced with the correct numbers.
  *   This is a GOV.UK design system [pluralised list of
  *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -453,12 +453,10 @@ export class AddAnother extends ConfigurableComponent {
     }
 
     if ($suffix && $suffix instanceof HTMLElement) {
-      const $replacementSuffix = $suffix.cloneNode()
-      $replacementSuffix.textContent = this.i18n.t('fieldLabelSuffixText', {
+      $suffix.textContent = this.i18n.t('fieldLabelSuffixText', {
         itemLabel: this.config.itemLabel.toLowerCase(),
         number: index
       })
-      $suffix.replaceWith($replacementSuffix)
     }
   }
 

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -412,9 +412,9 @@ export class AddAnother extends ConfigurableComponent {
    */
   updateRemoveButtons($item, index, itemsCount) {
     const $button = $item.querySelector(`.${this.removeButtonClass}`)
-    const label = this.removeButtonLabelText(
-      `${this.config.itemLabel.toLowerCase()} ${index + 1}`
-    )
+    const label = this.config.removeButtonText
+      .replace('%{itemLabel}', this.config.itemLabel.toLowerCase())
+      .replace('%{count}', index + 1)
 
     if (!$button || !($button instanceof HTMLButtonElement)) {
       if (itemsCount > 1 && index === 0) {
@@ -746,7 +746,8 @@ export class AddAnother extends ConfigurableComponent {
    * @type {AddAnotherConfig}
    */
   static defaults = Object.freeze({
-    layout: 'stacked'
+    layout: 'stacked',
+    removeButtonText: 'Remove %{itemLabel} %{count}'
   })
 
   /**
@@ -758,7 +759,8 @@ export class AddAnother extends ConfigurableComponent {
     /** @type {const} */ ({
       properties: {
         itemLabel: { type: 'string' },
-        layout: { type: 'string' }
+        layout: { type: 'string' },
+        removeButtonText: { type: 'string' }
       }
     })
   )
@@ -778,6 +780,7 @@ export class AddAnother extends ConfigurableComponent {
  * @typedef {object} AddAnotherConfig
  * @property {string} [itemLabel] - Label for each fieldset
  * @property {AddAnotherLayout} [layout] - layout style for fields
+ * @property {string} [removeButtonText] - Label for remove button
  */
 
 /**

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -621,17 +621,6 @@ export class AddAnother extends ConfigurableComponent {
   }
 
   /**
-   * Generates the label text for the remove button based on the layout
-   * configuration.
-   *
-   * @param {number} labelIndex - the index to include in the remove button label
-   * @returns {string} the label for the remove button based on the layout configuration
-   */
-  removeButtonLabelText(labelIndex) {
-    return `${this.removeButtonText()} ${this.removeButtonSuffixText(labelIndex)}`
-  }
-
-  /**
    * Handles click events on the add button to create a new item and append it
    * to the list of items.
    *

--- a/src/moj/components/add-another/add-another.mjs
+++ b/src/moj/components/add-another/add-another.mjs
@@ -1,6 +1,11 @@
 import { ConfigurableComponent } from 'govuk-frontend'
+import { I18n } from 'govuk-frontend/dist/govuk/i18n.mjs'
 
-import { setFocus, emitEvent } from '../../common/index.mjs'
+import {
+  setFocus,
+  emitEvent,
+  closestAttributeValue
+} from '../../common/index.mjs'
 
 /**
  * @augments {ConfigurableComponent<AddAnotherConfig>}
@@ -73,6 +78,11 @@ export class AddAnother extends ConfigurableComponent {
     if (!($itemsContainer instanceof HTMLElement)) {
       return
     }
+
+    this.i18n = new I18n(this.config.i18n, {
+      // Read the fallback if necessary rather than have it set in the defaults
+      locale: closestAttributeValue(this.$root, 'lang')
+    })
 
     this.$itemsContainer = $itemsContainer
     this.$items = this.getItems()
@@ -304,20 +314,7 @@ export class AddAnother extends ConfigurableComponent {
 
       const $label = $input.closest('.govuk-form-group').querySelector('label')
       if ($label && $label instanceof HTMLLabelElement) {
-        let $labelSuffix = $label.querySelector(`.${this.labelSuffixClass}`)
-
-        if (!$labelSuffix) {
-          $labelSuffix = document.createElement('span')
-          $labelSuffix.classList.add(
-            `${this.labelSuffixClass}`,
-            'govuk-visually-hidden'
-          )
-          $labelSuffix = $label.appendChild($labelSuffix)
-        }
-
-        if ($labelSuffix && $labelSuffix instanceof HTMLElement) {
-          $labelSuffix.textContent = ` for ${this.config.itemLabel.toLowerCase()} ${index + 1}`
-        }
+        this.updateSuffixText($label, index + 1)
       }
     })
   }
@@ -336,16 +333,10 @@ export class AddAnother extends ConfigurableComponent {
         return
       }
 
-      const labelText = $fieldset.getAttribute('data-legend') || ''
-
       const $legend = $fieldset.querySelector('legend')
 
       if ($legend && $legend instanceof HTMLLegendElement) {
-        const hiddenText = document.createElement('span')
-        hiddenText.classList.add('govuk-visually-hidden')
-        hiddenText.textContent = `for ${this.config.itemLabel.toLowerCase()} ${index + 1}`
-        $legend.textContent = `${labelText}`
-        $legend.appendChild(hiddenText)
+        this.updateSuffixText($legend, index + 1)
       }
     })
   }
@@ -365,19 +356,16 @@ export class AddAnother extends ConfigurableComponent {
       return
     }
     const $legend = $fieldset.querySelector('legend')
-    let suffix = ''
 
-    if (itemsCount === 1) {
-      suffix = `${index + 1}`
-    } else {
-      suffix = `${index + 1} of ${itemsCount}`
-    }
+    const legendText = this.i18n.t('itemLegendText', {
+      itemLabel: this.config.itemLabel,
+      number: index + 1,
+      count: itemsCount
+    })
 
     if (!$legend || !($legend instanceof HTMLLegendElement)) {
       return
     }
-
-    const legendText = `${this.config.itemLabel} ${suffix}`
 
     // Replace the legend node rather than mutating text in-place so assistive
     // technologies recalculate the fieldset name after item reindex/removal.
@@ -412,9 +400,7 @@ export class AddAnother extends ConfigurableComponent {
    */
   updateRemoveButtons($item, index, itemsCount) {
     const $button = $item.querySelector(`.${this.removeButtonClass}`)
-    const label = this.config.removeButtonText
-      .replace('%{itemLabel}', this.config.itemLabel.toLowerCase())
-      .replace('%{count}', index + 1)
+    const label = this.removeButtonLabelText(index + 1)
 
     if (!$button || !($button instanceof HTMLButtonElement)) {
       if (itemsCount > 1 && index === 0) {
@@ -447,6 +433,30 @@ export class AddAnother extends ConfigurableComponent {
     const $legend = $item.querySelector('legend')
     if ($legend && $legend instanceof HTMLLegendElement) {
       $legend.appendChild($newItemSuffix)
+    }
+  }
+
+  /**
+   * Updates the visually hidden text of a label to reflect the current index of
+   * the item.
+   *
+   * @param {Element} $element - Add another item
+   * @param {number} index - Add another item index
+   */
+  updateSuffixText($element, index) {
+    let $suffix = $element.querySelector(`.${this.labelSuffixClass}`)
+
+    if (!$suffix) {
+      $suffix = document.createElement('span')
+      $suffix.classList.add(`${this.labelSuffixClass}`, 'govuk-visually-hidden')
+      $suffix = $element.appendChild($suffix)
+    }
+
+    if ($suffix && $suffix instanceof HTMLElement) {
+      $suffix.textContent = this.i18n.t('fieldLabelSuffixText', {
+        itemLabel: this.config.itemLabel.toLowerCase(),
+        number: index
+      })
     }
   }
 
@@ -569,15 +579,27 @@ export class AddAnother extends ConfigurableComponent {
    * Generates the label text for the remove button based on the layout
    * configuration.
    *
-   * @param {string} labelIndex - the index to include in the remove button label
+   * @param {number} labelIndex - the index to include in the remove button label
    * @returns {string} the label for the remove button based on the layout configuration
    */
   removeButtonLabelText(labelIndex) {
     if (this.config.layout === 'inline') {
-      return `Remove <span class="govuk-visually-hidden">${labelIndex}</span>`
+      return `${this.i18n.t('removeButtonText')} <span class="govuk-visually-hidden">${this.i18n.t(
+        'removeButtonSuffixText',
+        {
+          itemLabel: this.config.itemLabel.toLowerCase(),
+          number: labelIndex
+        }
+      )}</span>`
     }
 
-    return `Remove ${labelIndex}`
+    return `${this.i18n.t('removeButtonText')} ${this.i18n.t(
+      'removeButtonSuffixText',
+      {
+        itemLabel: this.config.itemLabel.toLowerCase(),
+        number: labelIndex
+      }
+    )}`
   }
 
   /**
@@ -746,8 +768,17 @@ export class AddAnother extends ConfigurableComponent {
    * @type {AddAnotherConfig}
    */
   static defaults = Object.freeze({
-    layout: 'stacked',
-    removeButtonText: 'Remove %{itemLabel} %{count}'
+    i18n: {
+      removeButtonText: 'Remove',
+      removeButtonSuffixText: '%{itemLabel} %{number}',
+      fieldLabelSuffixText: 'for %{itemLabel} %{number}',
+      itemLegendText: {
+        one: '%{itemLabel} %{number}',
+        other: '%{itemLabel} %{number} of %{count}'
+      }
+    },
+    itemLabel: 'Item',
+    layout: 'stacked'
   })
 
   /**
@@ -758,9 +789,9 @@ export class AddAnother extends ConfigurableComponent {
   static schema = Object.freeze(
     /** @type {const} */ ({
       properties: {
+        i18n: { type: 'object' },
         itemLabel: { type: 'string' },
-        layout: { type: 'string' },
-        removeButtonText: { type: 'string' }
+        layout: { type: 'string' }
       }
     })
   )
@@ -780,7 +811,26 @@ export class AddAnother extends ConfigurableComponent {
  * @typedef {object} AddAnotherConfig
  * @property {string} [itemLabel] - Label for each fieldset
  * @property {AddAnotherLayout} [layout] - layout style for fields
- * @property {string} [removeButtonText] - Label for remove button
+ * @property {AddAnotherTranslations} [i18n=AddAnother.defaults.i18n] - Add another translations
+ */
+
+/**
+ * Character count translations
+ *
+ * @see {@link AddAnother.defaults.i18n}
+ * @typedef {object} AddAnotherTranslations
+ * @property {TranslationPluralForms} [itemLegendText] - Legend for the item.
+ *   %{itemLabel} placeholder with be replaced with the AddAnother.config.itemLabel.
+ *   %{number} and %{count} placeholders will be replaced with the correct numbers.
+ *   This is a GOV.UK design system [pluralised list of
+ *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+ * @property {string} [removeButtonText] - Label for the item remove buttons.
+ * @property {string} [removeButtonSuffixText] - suffix for the item remove buttons.
+ *   The `%{itemLabel}` placeholder will be replaced with the AddAnother.config.itemLabel.
+ *   The `%{number}` placeholder will be replaced with the index of the item.
+ * @property {string} [fieldLabelSuffixText] - hidden suffix for the field labels and legends.
+ *   The `%{itemLabel}` placeholder will be replaced with the AddAnother.config.itemLabel.
+ *   The `%{number}` placeholder will be replaced with the index of the item.
  */
 
 /**
@@ -829,4 +879,5 @@ export class AddAnother extends ConfigurableComponent {
 
 /**
  * @import { Schema } from 'govuk-frontend/dist/govuk/common/configuration.mjs'
+ * @import { TranslationPluralForms } from 'govuk-frontend/dist/govuk/i18n.mjs'
  */

--- a/src/moj/components/add-another/add-another.nunjucks.spec.mjs
+++ b/src/moj/components/add-another/add-another.nunjucks.spec.mjs
@@ -332,6 +332,54 @@ describe('add another', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // i18n text replacement options
+  // ---------------------------------------------------------------------------
+
+  describe('i18n custom text replacements', () => {
+    beforeAll(() => {
+      example = 'i18n custom text replacements'
+    })
+    afterAll(() => {
+      example = 'default'
+    })
+
+    test('renders i18n data attributes on the root element', () => {
+      expect($component).toHaveAttribute(
+        'data-i18n.remove-button-text',
+        'Delete'
+      )
+      expect($component).toHaveAttribute(
+        'data-i18n.field-label-suffix-text',
+        'for translated %{itemLabel} %{number}'
+      )
+      expect($component).toHaveAttribute(
+        'data-i18n.item-legend-text.one',
+        'Translated %{itemLabel} %{number}'
+      )
+      expect($component).toHaveAttribute(
+        'data-i18n.item-legend-text.other',
+        'Translated %{itemLabel} %{number} of %{count}'
+      )
+    })
+
+    test('renders add button text with itemLabel replacement', () => {
+      const addButton = getByRole($component, 'button', {
+        name: 'Create another case'
+      })
+      expect(addButton).toBeInTheDocument()
+    })
+
+    test('applies translated legend and label suffix text after initialisation', () => {
+      const item = $component.querySelector('.moj-add-another__item')
+      const legend = item.querySelector('legend')
+      const suffix = $component.querySelector('.moj-add-another__label-suffix')
+
+      expect(legend).toHaveTextContent('Translated Case 1')
+      expect(suffix).toHaveTextContent('for translated case 1')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Events
   // ---------------------------------------------------------------------------
 

--- a/src/moj/components/add-another/add-another.playwright.spec.js
+++ b/src/moj/components/add-another/add-another.playwright.spec.js
@@ -428,6 +428,68 @@ test.describe('add another', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // i18n text replacements
+  // ---------------------------------------------------------------------------
+
+  test.describe('i18n custom text replacements', () => {
+    test.beforeAll(async () => {
+      example = 'i18n custom text replacements'
+    })
+    test.afterAll(async () => {
+      example = ''
+    })
+
+    test('uses translated add button and initial label suffix text', async () => {
+      const $translatedAddButton = $component.getByRole('button', {
+        name: 'Create another case'
+      })
+      await expect($translatedAddButton).toBeVisible()
+      await expect($items.nth(0).getByLabel('Name')).toHaveAccessibleName(
+        'Name for translated case 1'
+      )
+    })
+
+    test('uses translated remove button and legend text after adding', async () => {
+      const $translatedAddButton = $component.getByRole('button', {
+        name: 'Create another case'
+      })
+      await $translatedAddButton.click()
+
+      const $removeButtons = $component.getByRole('button', { name: /Delete/ })
+      await expect($removeButtons).toHaveCount(2)
+      await expect($removeButtons.nth(0)).toHaveAccessibleName('Delete case 1')
+      await expect($removeButtons.nth(1)).toHaveAccessibleName('Delete case 2')
+
+      await expect($items.nth(0)).toHaveAccessibleName('Translated Case 1 of 2')
+      await expect($items.nth(1)).toHaveAccessibleName(
+        'Translated Case 2 of 2(added)'
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // i18n locale fallback from root lang
+  // ---------------------------------------------------------------------------
+
+  test.describe('i18n locale fallback', () => {
+    test.beforeAll(async () => {
+      example = 'i18n locale fallback'
+    })
+    test.afterAll(async () => {
+      example = ''
+    })
+
+    test('uses lang locale plural rule for legend text selection', async () => {
+      await $addButton.click()
+
+      await expect($items.nth(0)).toHaveAccessibleName('TWO Entry 1 of 2')
+      await expect($items.nth(1)).toHaveAccessibleName(
+        'TWO Entry 2 of 2(added)'
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Focus management
   // ---------------------------------------------------------------------------
 

--- a/src/moj/components/add-another/fixtures.yaml
+++ b/src/moj/components/add-another/fixtures.yaml
@@ -528,3 +528,31 @@ examples:
                        data-id="address[%index%][postcode]"
                        data-label="Postcode">
               </div>
+
+  # 12. i18n custom text replacements
+  - name: i18n custom text replacements
+    options:
+      id: 'i18n-custom-text-add-another'
+      itemLabel: 'Case'
+      addAnotherButtonText: 'Create another %{itemLabel}'
+      removeButtonText: 'Delete'
+      fieldLabelSuffixText: 'for translated %{itemLabel} %{number}'
+      itemLegendText:
+        one: 'Translated %{itemLabel} %{number}'
+        other: 'Translated %{itemLabel} %{number} of %{count}'
+      items:
+        - *singlePersonItem
+
+  # 13. i18n locale plural fallback via root lang
+  - name: i18n locale fallback
+    options:
+      id: 'i18n-locale-fallback-add-another'
+      itemLabel: 'Entry'
+      attributes:
+        lang: 'ar'
+      itemLegendText:
+        one: 'ONE %{itemLabel} %{number} of %{count}'
+        two: 'TWO %{itemLabel} %{number} of %{count}'
+        other: 'OTHER %{itemLabel} %{number} of %{count}'
+      items:
+        - *singlePersonItem

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -27,6 +27,11 @@
   }) }}
 
   {{ govukI18nAttributes({
+    key: 'remove-button-suffix-text',
+    message: params.removeButtonSuffixText
+  }) }}
+
+  {{ govukI18nAttributes({
     key: 'item-legend-text',
     messages: params.itemLegendText
   }) }}

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -18,10 +18,6 @@
   'data-layout': {
     value: params.layout,
     optional: true
-  },
-  'data-remove-button-text': {
-    value: params.removeButtonText,
-    optional: true
   }
   }) }}
 
@@ -31,9 +27,11 @@
   }) }}
 
   {{ govukI18nAttributes({
-    key: 'item-legend-suffix-text',
-    messages: params.itemLegendSuffixText
+    key: 'item-legend-text',
+    messages: params.itemLegendText
   }) }}
+
+  {{ govukAttributes(params.attributes) }}
 {% endset %}
 
 <div class="moj-add-another{{- ' ' + params.classes if params.classes }}"

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -1,23 +1,43 @@
 {%- from "govuk/macros/attributes.njk" import govukAttributes -%}
 {%- from "govuk/components/fieldset/macro.njk" import govukFieldset -%}
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
+{%- from "govuk/macros/i18n.njk" import govukI18nAttributes -%}
 
 {% macro _mojAddAnotherItem(params, item, index) %}
   {%- include "./_itemTemplate.njk" -%}
 {% endmacro %}
 
-{%- set dataAttributes = {
+{% set itemLabel = params.itemLabel | default('Item', true) %}
+{% set defaultAddAnotherButtonText = "Add another %{itemLabel}" %}
+{% set addAnotherButtonText = params.addAnotherButtonText or defaultAddAnotherButtonText %}
+
+{% set attributesHtml %}
+{{ govukAttributes({
   'data-module': 'moj-add-another',
-  'data-item-label': params.itemLabel | default('Item', true),
+  'data-item-label': itemLabel,
   'data-layout': {
     value: params.layout,
     optional: true
+  },
+  'data-remove-button-text': {
+    value: params.removeButtonText,
+    optional: true
   }
-} -%}
+  }) }}
+
+  {{ govukI18nAttributes({
+    key: 'remove-button-text',
+    message: params.removeButtonText
+  }) }}
+
+  {{ govukI18nAttributes({
+    key: 'item-legend-suffix-text',
+    messages: params.itemLegendSuffixText
+  }) }}
+{% endset %}
 
 <div class="moj-add-another{{- ' ' + params.classes if params.classes }}"
-  {{- govukAttributes(dataAttributes) -}}
-  {{- govukAttributes(params.attributes) -}}>
+{{- attributesHtml | safe -}}">
   <div class="moj-add-another__items">
     {% for item in params.items %}
       {% if item.fieldset.html %}
@@ -27,7 +47,7 @@
   </div>
   <div class="moj-add-another__add-button-container">
       {{ govukButton({
-        text: "Add another " ~ (params.itemLabel | default('Item', true) | lower),
+        text:  addAnotherButtonText | replace('%{itemLabel}', (itemLabel | lower)),
         classes: "govuk-button--secondary moj-add-another__add-button"
       }) }}
   </div>

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -44,8 +44,7 @@
   {{ govukAttributes(params.attributes) }}
 {% endset %}
 
-<div class="moj-add-another{{- ' ' + params.classes if params.classes }}"
-{{- attributesHtml | safe -}}">
+<div class="moj-add-another{{- ' ' + params.classes if params.classes }}" {{- attributesHtml | safe -}}>
   <div class="moj-add-another__items">
     {% for item in params.items %}
       {% if item.fieldset.html %}

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -31,6 +31,11 @@
     messages: params.itemLegendText
   }) }}
 
+  {{ govukI18nAttributes({
+    key: 'field-label-suffix-text',
+    message: params.fieldLabelSuffixText
+  }) }}
+
   {{ govukAttributes(params.attributes) }}
 {% endset %}
 

--- a/src/tsconfig.dev.json
+++ b/src/tsconfig.dev.json
@@ -4,7 +4,8 @@
     "**/*.spec.js",
     "**/*.spec.mjs",
     "**/*.spec.helper.mjs",
-    ".eslintrc.js"  ],
+    ".eslintrc.js"
+  ],
   "compilerOptions": {
     "checkJs": true
   }


### PR DESCRIPTION
This pull request adds improved internationalisation (i18n) support and customisation options to the "Add Another" component, making it easier to localise and customise button and legend text. 

It introduces new macro arguments, uses the GOV.UK Frontend i18n utility, and updates both the Nunjucks templates and JavaScript logic to support dynamic and pluralised text. The pull request also refactors examples and tests to demonstrate and verify the new functionality.

**Internationalisation and Customisation Enhancements:**

* Added new macro arguments to the documentation for `addAnotherButtonText`, `itemLegendText`, `removeButtonText`, and `removeButtonSuffixText`, supporting dynamic and localised labels with placeholders and pluralisation rules.
* Updated the Nunjucks template (`_itemTemplate.njk`) to use these new arguments and dynamic placeholders for button and legend text. [[1]](diffhunk://#diff-291d483555c63473b535e75628b8a03ef2778d5f3fc3a19f6c067d715c82de7dR7-R13) [[2]](diffhunk://#diff-291d483555c63473b535e75628b8a03ef2778d5f3fc3a19f6c067d715c82de7dL38-R45) [[3]](diffhunk://#diff-291d483555c63473b535e75628b8a03ef2778d5f3fc3a19f6c067d715c82de7dL77-R88)
* Integrated the GOV.UK Frontend i18n utility (`I18n`) into the JavaScript component, enabling locale-aware pluralisation and translation of button and legend text, and using the closest `lang` attribute for locale detection. [[1]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444R2-R8) [[2]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444R82-R86)
* Refactored JavaScript logic to use i18n for updating legend and button text, and added a new `updateSuffixText` method for maintaining accessible, localised label suffixes. [[1]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444L307-R317) [[2]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444L339-R339) [[3]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444L368-L381) [[4]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444L415-R403) [[5]](diffhunk://#diff-31cba575048b1d74270bf4356a9801d1733ccf49bad3081afd9df0c5e1d23444R439-R462)

**Examples and Tests:**

* Removed hardcoded legend text from all example files, so legends are now generated dynamically via the new i18n-aware logic. [[1]](diffhunk://#diff-85c0da9f2d4dd27f7cef4c15419657ba902984c89206f2f6a412554226b5ccd4L63-L65) [[2]](diffhunk://#diff-c7706701214d6c2ca8598d445a87aaab4ac1bee94e0efa8747b614ad154d6a49L82-L84) [[3]](diffhunk://#diff-ae0f46c785151dc2f15cd265651045f22fbd748cd17d3afb0b9e525f4ae14a75L127-L145) [[4]](diffhunk://#diff-f81200ad061a18daf037a6dbc90563691afccb253af1034ef3b2477da90971b8L57-L59) [[5]](diffhunk://#diff-2d577997a737d8621d1c99c6a80528aff8169735ffb6da5ef296436e177bc54aL57-L59) [[6]](diffhunk://#diff-cbdcfe66ea2990367cf1a1b73b8367c57e28cb11fc1004e38fa095d39917ef5fL139-L149) [[7]](diffhunk://#diff-cbdcfe66ea2990367cf1a1b73b8367c57e28cb11fc1004e38fa095d39917ef5fL158-L160) [[8]](diffhunk://#diff-154bba0652ae0c5a419c0235056ccdc04dd7356a724e09bdcfb797df79f1cc1cL61-L63) [[9]](diffhunk://#diff-ca1e018221a73722ca69f1f798097cf5148bb29a7592259b48b3c2671ff3bfe9L164-L174) [[10]](diffhunk://#diff-dfc726dd76bd018a3fc9aa467836ffd3162a3e470f148dc0f1612b6b06c08047L150-L160)
* Added comprehensive tests for i18n functionality, including pluralisation, custom button/legend text, and locale fallback, to ensure correct behaviour in different languages and configurations.

**Infrastructure and Utility Improvements:**

* Updated the Gulp build process to handle GOV.UK Frontend as an external dependency using a regular expression, ensuring compatibility with the new i18n import. [[1]](diffhunk://#diff-94e8500f3acc126a248f9869b01a31c44596b158a931d56388352e0d84da3e5dR7-R8) [[2]](diffhunk://#diff-94e8500f3acc126a248f9869b01a31c44596b158a931d56388352e0d84da3e5dL35-R37) [[3]](diffhunk://#diff-94e8500f3acc126a248f9869b01a31c44596b158a931d56388352e0d84da3e5dL76-R88)
* Added a new utility function `closestAttributeValue` to retrieve the nearest attribute value (such as `lang`) up the DOM tree, used for locale detection.

These changes greatly improve the flexibility, accessibility, and localisation capabilities of the "Add Another" component.
