### PR TITLE
docs: update PDS header content 'how to use'

### DIFF
--- a/docs/probation/components/pds-header/_how-to-use.md
+++ b/docs/probation/components/pds-header/_how-to-use.md
@@ -22,6 +22,8 @@ The MOJ crown logo and ‘Probation Digital Services’ text link to either:
 
 MPoP is the Probation Digital Services homepage.
 
+The 'Account' text links to the 'Your account details' page on HMPPS Auth.
+
 ### Using the header component in production
 
 The [Probation Digital Services GitHub repository](https://github.com/ministryofjustice/hmpps-probation-frontend-component-api) contains a readme file with instructions on how to implement the component in your service.


### PR DESCRIPTION
**CONTENT CHANGE**

Add content on the 'How to use' tab.

Add new para at the end of the 'Links' section.

Change from:
_The MOJ crown logo and ‘Probation Digital Services’ text link to either:_

_Manage people on probation (MPoP), for users with access to it
your service’s homepage, for users with no access to MPoP_

_MPoP is the Probation Digital Services homepage._

Change to:
_The MOJ crown logo and ‘Probation Digital Services’ text link to either:_

_Manage people on probation (MPoP), for users with access to it
your service’s homepage, for users with no access to MPoP_

_MPoP is the Probation Digital Services homepage._

_The 'Account' text links to the 'Your account details' page on HMPPS Auth._


Ticket: https://github.com/ministryofjustice/moj-frontend/issues/2261
