### PR TITLE
feat(add another): add id attribute for component

### DIFF
--- a/src/moj/components/add-another/add-another.nunjucks.spec.mjs
+++ b/src/moj/components/add-another/add-another.nunjucks.spec.mjs
@@ -85,6 +85,24 @@ describe('add another', () => {
       expect(addButton).toBeInTheDocument()
     })
 
+    test('adds id to the component and derived attributes to the add button', () => {
+      expect($component).toHaveAttribute('id', 'default-add-another')
+
+      const addButton = getByRole($component, 'button', {
+        name: 'Add another person'
+      })
+
+      expect(addButton).toHaveAttribute(
+        'id',
+        'default-add-another-add-another-button'
+      )
+      expect(addButton).toHaveAttribute(
+        'name',
+        'default-add-another-add-another'
+      )
+      expect(addButton).toHaveValue('add-another-person')
+    })
+
     test('sets type="button" on the add button to prevent form submission', () => {
       const addButton = getByRole($component, 'button', {
         name: 'Add another person'
@@ -389,6 +407,7 @@ describe('add another', () => {
         name: 'Create another case'
       })
       expect(addButton).toBeInTheDocument()
+      expect(addButton).toHaveValue('create-another-case')
     })
 
     test('applies translated legend and label suffix text after initialisation', () => {

--- a/src/moj/components/add-another/template.njk
+++ b/src/moj/components/add-another/template.njk
@@ -49,7 +49,7 @@
   {{ govukAttributes(params.attributes) }}
 {% endset %}
 
-<div class="moj-add-another{{- ' ' + params.classes if params.classes }}" {{- attributesHtml | safe -}}>
+<div {{ ('id="' + params.id + '"') | safe if params.id }} class="moj-add-another{{- ' ' + params.classes if params.classes }}" {{- attributesHtml | safe -}}>
   <div class="moj-add-another__items">
     {% for item in params.items %}
       {% if item.fieldset.html %}
@@ -58,8 +58,11 @@
     {% endfor %}
   </div>
   <div class="moj-add-another__add-button-container">
-      {{ govukButton({
-        text:  addAnotherButtonText | replace('%{itemLabel}', (itemLabel | lower)),
+  {{ govukButton({
+        id: (params.id + "-add-another-button" ) if params.id,
+        name: (params.id + "-add-another" ) if params.id,
+        value: (addAnotherButtonText | replace('%{itemLabel}', itemLabel) | replace(" ", "-") | lower) if params.id,
+        text: addAnotherButtonText | replace('%{itemLabel}', (itemLabel | lower)),
         classes: "govuk-button--secondary moj-add-another__add-button"
       }) }}
   </div>


### PR DESCRIPTION
If an `id` option is passed to the component then it is added to the root element.  The id  will also be used to add `id`, `name` and `value` attributes to the add another button.  This enables the button to be identified by the server and allows the button to be targeted by error messages when implementing a no-javascript fallback.

The following nunjucks code

```njk
{{ mojAddAnother({
    id: "add-participants",
    itemLabel: "Participant",
    items: [
      ...
    ]
  }) }}
```

would result in the following html

```html
<div id="add-participants" class="moj-add-another" data-module="moj-add-another" data-item-label="Participant" data-moj-add-another-init="">
  <div class="moj-add-another__items">
    ...
  </div>
  <div class="moj-add-another__add-button-container">
    <button type="button"
            id="add-participants-add-another-button"
            class="govuk-button govuk-button--secondary moj-add-another__add-button"
            name="add-participants-add-another" 
            value="add-another-participant" 
            data-module="govuk-button"        
            data-govuk-button-init="">
      Add another participant
    </button>
  </div>
</div>
```
