### PR TITLE
ci: making the NPM publish use the new generated token.

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Get next version
         run: npm run ci:dryrun
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
       - run: npm run build:package
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -159,9 +159,9 @@ jobs:
         if: github.event.inputs.mode == 'dryrun'
         run: npm run ci:dryrun
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
       - name: If publish
         if: github.event.inputs.mode == 'publish'
         run: npm run ci:release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}


### PR DESCRIPTION
Making semantic release make use of the automated token during the NPM publish phase.
