### PR TITLE
docs: use an moj warning alert for pds components tab warning

### DIFF
--- a/11ty/filters/index.js
+++ b/11ty/filters/index.js
@@ -6,6 +6,7 @@ const dedentGovUkTabPanel = require('./dedent-govuk-tab-panel')
 const inspect = require('./inspect')
 const paths = require('./paths')
 const renderMarkdown = require('./render-markdown')
+const renderMarkdownInline = require('./render-markdown-inline')
 const renderNunjucksString = require('./render-nunjucks')
 const rev = require('./rev')
 const timestamp = require('./timestamp')
@@ -17,6 +18,7 @@ const filters = {
   ...paths,
   inspect,
   renderMarkdown,
+  renderMarkdownInline,
   renderNunjucksString,
   rev,
   timestamp,

--- a/11ty/filters/render-markdown-inline.js
+++ b/11ty/filters/render-markdown-inline.js
@@ -1,0 +1,5 @@
+const markdown = require('../config/markdown')
+
+module.exports = function (string) {
+  return `${markdown.renderInline(string)}`
+}

--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -1,3 +1,5 @@
+{%- from "moj/components/alert/macro.njk" import mojAlert -%}
+
 <div class="app-example__new-window">
     <a href="{{ href | url }}" target="_blank">Open this example <span class="govuk-visually-hidden">({{ title }})</span> in a new window</a>
 </div>
@@ -25,7 +27,12 @@
 </ul>
 <div class="app-tabs__panel" id="html-default-{{ id }}" role="tabpanel" aria-labelledby="tab_html-default-{{ id }}">
 {%- if tabWarning -%}
-  <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
+    {{ mojAlert({
+      variant: "warning",
+      title: "Not for use in production",
+      dismissible: false,
+      html: tabWarning | renderMarkdownInline | safe
+    }) }}
 {%- endif -%}
 <div class="app-example__code" data-module="app-copy">
 
@@ -37,7 +44,12 @@
 </div>
 <div class="app-tabs__panel" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
 {%- if tabWarning -%}
-  <div class="app-example__warning">{{ tabWarning | renderMarkdown | safe }}</div>
+    {{ mojAlert({
+      variant: "warning",
+      title: "Not for use in production",
+      dismissible: false,
+      html: tabWarning | renderMarkdownInline | safe
+    }) }}
 {%- endif -%}
 {%- set argsContent %}
 


### PR DESCRIPTION
Users were not noticing/reading the warning about using the PDS components code examples in production. 

This PR updates the warning paragraph to use an MOJ Alert component in order to draw more attention to it.

**Before:**
<img width="1043" height="237" alt="image" src="https://github.com/user-attachments/assets/07017e1e-3387-4264-93e9-4874653c5986" />

**After:**
<img width="1039" height="276" alt="image" src="https://github.com/user-attachments/assets/df6abcd1-4065-403c-8e9d-73596cb3946f" />
