### PR TITLE
feat(multi-file-upload): add CSRF protection support for multi-file upload

### DIFF
--- a/docs/components/multi-file-upload/index.md
+++ b/docs/components/multi-file-upload/index.md
@@ -55,6 +55,22 @@ new MultiFileUpload($multiFileUpload, {
 })
 ```
 
+### CSRF protection
+
+If your server requires a CSRF token on AJAX requests, pass it via the
+`csrfToken` config option. The token is sent as a request header on every
+upload and delete request. You can override the header name by passing a value
+to the `csrfHeaderName` config option. The default is `X-CSRF-Token`.
+
+```mjs
+new MultiFileUpload($multiFileUpload, {
+  uploadUrl: '/ajax-upload-url',
+  deleteUrl: '/ajax-delete-url',
+  csrfToken: 'your-csrf-token',
+  csrfHeaderName: 'X-XSRF-Token'
+})
+```
+
 ### When JavaScript is not available
 
 When JavaScript is not available, users will be presented with a [file upload component](https://design-system.service.gov.uk/components/file-upload/) and upload button.

--- a/src/moj/components/multi-file-upload/multi-file-upload.mjs
+++ b/src/moj/components/multi-file-upload/multi-file-upload.mjs
@@ -254,6 +254,9 @@ export class MultiFileUpload extends ConfigurableComponent {
     })
 
     xhr.open('POST', this.config.uploadUrl)
+    if (this.config.csrfToken) {
+      xhr.setRequestHeader(this.config.csrfHeaderName, this.config.csrfToken)
+    }
     xhr.responseType = 'json'
 
     xhr.send(formData)
@@ -298,6 +301,10 @@ export class MultiFileUpload extends ConfigurableComponent {
 
     xhr.open('POST', this.config.deleteUrl)
     xhr.setRequestHeader('Content-Type', 'application/json')
+    if (this.config.csrfToken) {
+      xhr.setRequestHeader(this.config.csrfHeaderName, this.config.csrfToken)
+    }
+
     xhr.responseType = 'json'
 
     xhr.send(
@@ -341,6 +348,7 @@ export class MultiFileUpload extends ConfigurableComponent {
    * @type {MultiFileUploadConfig}
    */
   static defaults = Object.freeze({
+    csrfHeaderName: 'X-CSRF-Token',
     uploadStatusText: 'Uploading files, please wait',
     dropzoneHintText: 'Drag and drop files here or',
     dropzoneButtonText: 'Choose files',
@@ -363,6 +371,8 @@ export class MultiFileUpload extends ConfigurableComponent {
   static schema = Object.freeze(
     /** @type {const} */ ({
       properties: {
+        csrfToken: { type: 'string' },
+        csrfHeaderName: { type: 'string' },
         uploadUrl: { type: 'string' },
         deleteUrl: { type: 'string' },
         uploadStatusText: { type: 'string' },
@@ -379,6 +389,8 @@ export class MultiFileUpload extends ConfigurableComponent {
  * Multi file upload config
  *
  * @typedef {object} MultiFileUploadConfig
+ * @property {string} [csrfToken] - CSRF token
+ * @property {string} [csrfHeaderName] - CSRF header name
  * @property {string} [uploadUrl] - File upload URL
  * @property {string} [deleteUrl] - File delete URL
  * @property {string} [uploadStatusText] - Upload status text

--- a/src/moj/components/multi-file-upload/multi-file-upload.spec.mjs
+++ b/src/moj/components/multi-file-upload/multi-file-upload.spec.mjs
@@ -340,9 +340,9 @@ describe('Multi-file upload', () => {
       await user.click(deleteButton)
 
       expect(deleteHook).toHaveBeenCalledTimes(1)
-      expect(server.requests[server.requests.length - 1].requestHeaders).not.toHaveProperty(
-        'X-CSRF-Token'
-      )
+      expect(
+        server.requests[server.requests.length - 1].requestHeaders
+      ).not.toHaveProperty('X-CSRF-Token')
     })
   })
 
@@ -367,9 +367,14 @@ describe('Multi-file upload', () => {
       ])
 
       const input = getByLabelText(component, 'Upload a file')
-      await user.upload(input, new File(['x'], 'test.txt', { type: 'text/plain' }))
+      await user.upload(
+        input,
+        new File(['x'], 'test.txt', { type: 'text/plain' })
+      )
 
-      expect(server.requests[0].requestHeaders['X-CSRF-Token']).toBe('test-token')
+      expect(server.requests[0].requestHeaders['X-CSRF-Token']).toBe(
+        'test-token'
+      )
     })
 
     test('sends CSRF header on delete', async () => {
@@ -385,9 +390,14 @@ describe('Multi-file upload', () => {
       ])
 
       const input = getByLabelText(component, 'Upload a file')
-      await user.upload(input, new File(['x'], 'test.txt', { type: 'text/plain' }))
+      await user.upload(
+        input,
+        new File(['x'], 'test.txt', { type: 'text/plain' })
+      )
 
-      const deleteButton = component.querySelector('.moj-multi-file-upload__delete')
+      const deleteButton = component.querySelector(
+        '.moj-multi-file-upload__delete'
+      )
       await user.click(deleteButton)
 
       const deleteRequest = server.requests[server.requests.length - 1]

--- a/src/moj/components/multi-file-upload/multi-file-upload.spec.mjs
+++ b/src/moj/components/multi-file-upload/multi-file-upload.spec.mjs
@@ -245,6 +245,24 @@ describe('Multi-file upload', () => {
 
       expect(errorHook).toHaveBeenCalledTimes(1)
     })
+
+    test('does not send CSRF header when csrfToken is not configured', async () => {
+      server.respondWith('POST', '/upload', [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(successResponse)
+      ])
+
+      const input = getByLabelText(component, 'Upload a file')
+      await user.upload(
+        input,
+        new File(['x'], 'test.txt', { type: 'text/plain' })
+      )
+
+      expect(server.requests[0].requestHeaders).not.toHaveProperty(
+        'X-CSRF-Token'
+      )
+    })
   })
 
   describe('File deletion', () => {
@@ -307,6 +325,73 @@ describe('Multi-file upload', () => {
         '.moj-multi-file__uploaded-files'
       )
       expect(feedbackContainer).toHaveClass('moj-hidden')
+    })
+
+    test('does not send CSRF header when csrfToken is not configured', async () => {
+      server.respondWith('POST', '/delete', [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ success: true })
+      ])
+
+      const deleteButton = component.querySelector(
+        '.moj-multi-file-upload__delete'
+      )
+      await user.click(deleteButton)
+
+      expect(deleteHook).toHaveBeenCalledTimes(1)
+      expect(server.requests[server.requests.length - 1].requestHeaders).not.toHaveProperty(
+        'X-CSRF-Token'
+      )
+    })
+  })
+
+  describe('CSRF header', () => {
+    beforeEach(() => {
+      document.body.innerHTML = ''
+      component = createComponent()
+
+      new MultiFileUpload(component, {
+        uploadUrl: '/upload',
+        deleteUrl: '/delete',
+        csrfToken: 'test-token',
+        hooks: { entryHook, exitHook, errorHook, deleteHook }
+      })
+    })
+
+    test('sends CSRF header on upload', async () => {
+      server.respondWith('POST', '/upload', [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(successResponse)
+      ])
+
+      const input = getByLabelText(component, 'Upload a file')
+      await user.upload(input, new File(['x'], 'test.txt', { type: 'text/plain' }))
+
+      expect(server.requests[0].requestHeaders['X-CSRF-Token']).toBe('test-token')
+    })
+
+    test('sends CSRF header on delete', async () => {
+      server.respondWith('POST', '/upload', [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(successResponse)
+      ])
+      server.respondWith('POST', '/delete', [
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ success: true })
+      ])
+
+      const input = getByLabelText(component, 'Upload a file')
+      await user.upload(input, new File(['x'], 'test.txt', { type: 'text/plain' }))
+
+      const deleteButton = component.querySelector('.moj-multi-file-upload__delete')
+      await user.click(deleteButton)
+
+      const deleteRequest = server.requests[server.requests.length - 1]
+      expect(deleteRequest.requestHeaders['X-CSRF-Token']).toBe('test-token')
     })
   })
 


### PR DESCRIPTION
### Description of the change
Add CSRF support to Multi-file Upload component.

#### What
Adds the ability to send CSRF tokens as a custom HTTP header on AJAX requests (upload and delete) made by the Multi-File upload component.

#### Why
The Multi-File upload component makes XHR POST requests for file uploads and deletions. Applications using CSRF protection (e.g. [Lusca](https://github.com/krakenjs/lusca)) need these requests to include a CSRF token, otherwise the server will reject them with a 403. There is currently no built-in way to attach a CSRF token to these requests other than via a query param (see
[issue](https://github.com/ministryofjustice/moj-frontend/issues/504)).

#### Design
Two new flat config properties were added to the MultiFileUploadConfig:
* csrfToken(string, default: undefined) - the CSRF token value
* csrfHeaderName(string, default 'X-CSRF-Token') - the http header name used to send the token

These were intentionally kept as flat, top-level config properties rather than a nested csrf object. This aligns with how govuk-frontend's ConfigurableComponent handles config merging - nested objects are shallow-replaced, not deep-merged. Flat properties avoid a bug where passing only { csrf: { token: '...'} } would wipeout the default headerName.

Being scalar string properties also means they work seamlessly with HTML data-* attributes:
``` html
<div data-module="moj-multi-file-upload"     data-csrf-token="abc123"     data-upload-url="/upload"     data-delete-url="/delete">
```

#### Backwards compatibility
This is a non-breaking change. The default csrfToken is undefined, so no CSRF header is sent unless explicitly configured.


### Alternative designs

Originally designed to use a nested structure, however this introduced a bug where if only csrfToken was provided, the headerName would be undefined due to shallow-replace.

### Possible drawbacks

The changes should be backwards compatible as described above. No drawback identified.

### Verification process

#### Unit testing
Added unit testing to the spec.mjs for the multi-file-upload component

#### Manual testing
Override the docs multi-file upload example script to include the csrfToken and csrfHeaderName.
Ran docs site locally, verify the network tab in the dev tools and drop/upload a document, this 404s as the url is invalid but the request header contains the csrf token.

Reverted changes to the script, add repeated the steps, the request header no longer contains the csrf token.

### Release notes

Multi file upload now supports sending a CSRF token as a request header on upload and delete requests, configurable via `csrfToken` and `csrfHeaderName` options.

Fixes: #504 
