### PR TITLE
ci: allow documentation site to be deployed manually

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -120,7 +120,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [result]
-    if: github.event_name == 'push'
+    if: ${{ (github.event_name == 'push') || (github.event_name == 'workflow_dispatch') }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
This PR simply adds the ability for the deployment step of the deploy action to run when triggered manually via workflow dispatch

