### PR TITLE
docs: stop using saveUninitialized and resave (threat model FE15)

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -98,8 +98,8 @@ if (!(isDev || isTest)) {
 const sessionOptions = {
   secret: SESSION_SECRET,
   name: 'moj-frontend-session',
-  resave: true,
-  saveUninitialized: true,
+  resave: false,
+  saveUninitialized: false,
   cookie: {
     secure: !(isDev || isTest),
     maxAge: 24 * 60 * 60 * 1000,
@@ -118,8 +118,10 @@ app.use(session(sessionOptions))
 // Custom flash middleware -- from Ethan Brown's book, 'Web Development with Node & Express'
 app.use(function (req, res, next) {
   // if there's a flash message in the session request, make it available in the response, then delete it
-  res.locals.sessionFlash = req.session.sessionFlash
-  delete req.session.sessionFlash
+  if (req.session?.sessionFlash) {
+    res.locals.sessionFlash = req.session.sessionFlash
+    delete req.session.sessionFlash
+  }
   next()
 })
 

--- a/app/middleware/component-session.js
+++ b/app/middleware/component-session.js
@@ -10,7 +10,9 @@ const {
   ALLOWED_COMPONENT_IMAGE_MIME_TYPES,
   COMPONENT_FORM_PAGES: formPages,
   MESSAGES,
-  HTML_SANITIZATION_OPTIONS
+  HTML_SANITIZATION_OPTIONS,
+  ENV,
+  SESSION_SECRET
 } = require('../config')
 const ApplicationError = require('../helpers/application-error')
 const { getAnswersForSection } = require('../helpers/check-your-answers')
@@ -21,6 +23,109 @@ const { camelToKebab } = require('../helpers/text-helper')
 const { getHashedUrl } = require('../helpers/url-helper')
 const redis = require('../redis-client')
 const { getSchema } = require('../schema/schemas')
+
+const initialCsrfCookieName = 'moj-frontend-start-csrf'
+const initialCsrfMaxAge = 60 * 60 * 1000
+const initialCsrfCookieOptions = {
+  httpOnly: true,
+  secure: !['development', 'test'].includes(ENV),
+  sameSite: ['development', 'test'].includes(ENV) ? 'lax' : 'strict',
+  maxAge: initialCsrfMaxAge
+}
+
+const signInitialCsrfPayload = (payload) =>
+  crypto
+    .createHmac('sha256', SESSION_SECRET)
+    .update(payload)
+    .digest('base64url')
+
+const createInitialCsrfToken = () => {
+  const nonce = crypto.randomBytes(32).toString('base64url')
+  const expiresAt = Date.now() + initialCsrfMaxAge
+  const payload = `${nonce}.${expiresAt}`
+  const signature = signInitialCsrfPayload(payload)
+
+  return `${payload}.${signature}`
+}
+
+const parseCookies = (cookieHeader = '') => {
+  return cookieHeader.split(';').reduce((cookies, cookie) => {
+    const [name, ...valueParts] = cookie.trim().split('=')
+    if (name && valueParts.length > 0) {
+      try {
+        cookies[name] = decodeURIComponent(valueParts.join('='))
+      } catch {
+        cookies[name] = ''
+      }
+    }
+    return cookies
+  }, {})
+}
+
+const timingSafeEqual = (a, b) => {
+  const aBuffer = Buffer.from(a)
+  const bBuffer = Buffer.from(b)
+
+  return (
+    aBuffer.length === bBuffer.length &&
+    crypto.timingSafeEqual(aBuffer, bBuffer)
+  )
+}
+
+const isValidInitialCsrfToken = (token) => {
+  if (typeof token !== 'string') {
+    return false
+  }
+
+  const [nonce, expiresAt, signature] = token.split('.')
+  const expiresAtTime = Number(expiresAt)
+  if (
+    !nonce ||
+    !Number.isFinite(expiresAtTime) ||
+    !signature ||
+    expiresAtTime < Date.now()
+  ) {
+    return false
+  }
+
+  const expectedSignature = signInitialCsrfPayload(`${nonce}.${expiresAt}`)
+  return timingSafeEqual(signature, expectedSignature)
+}
+
+const getInitialCsrfCookieToken = (req) => {
+  const cookies = parseCookies(req?.headers?.cookie)
+  return cookies[initialCsrfCookieName]
+}
+
+const setInitialCsrfToken = (req, res, next) => {
+  const token = createInitialCsrfToken()
+  res.cookie(initialCsrfCookieName, token, initialCsrfCookieOptions)
+  req.initialCsrfToken = token
+  next()
+}
+
+const verifyInitialCsrfToken = (req, res, next) => {
+  const submittedToken = req?.body?._csrf
+  const cookieToken = getInitialCsrfCookieToken(req)
+
+  if (
+    !submittedToken ||
+    !cookieToken ||
+    !timingSafeEqual(submittedToken, cookieToken) ||
+    !isValidInitialCsrfToken(submittedToken)
+  ) {
+    const error = new Error('Invalid CSRF token')
+    error.status = 403
+    console.error(error.message)
+    return next(error)
+  }
+
+  res.clearCookie(initialCsrfCookieName, initialCsrfCookieOptions)
+  delete req.session.checkYourAnswers
+  req.session.started = true
+  req.session.csrfToken = crypto.randomBytes(32).toString('hex')
+  next()
+}
 
 /**
  * Extracts the template (view) to render from the request params
@@ -572,7 +677,7 @@ const validatePageParams = (req, res, next) => {
 }
 
 const setCsrfToken = (req, res, next) => {
-  if (req?.session) {
+  if (req?.session?.started || req?.session?.csrfToken) {
     if (!req?.session?.csrfToken) {
       req.session.csrfToken = crypto.randomBytes(32).toString('hex')
     }
@@ -603,6 +708,8 @@ module.exports = {
   checkEmailDomain,
   validatePageParams,
   setCsrfToken,
+  setInitialCsrfToken,
+  verifyInitialCsrfToken,
   xssComponentCode,
   setSuccessMessage,
   getPageData,

--- a/app/middleware/component-session.spec.js
+++ b/app/middleware/component-session.spec.js
@@ -32,6 +32,8 @@ const {
   checkEmailDomain,
   validatePageParams,
   setCsrfToken,
+  setInitialCsrfToken,
+  verifyInitialCsrfToken,
   xssComponentCode,
   setSuccessMessage,
   getPageData,
@@ -54,7 +56,8 @@ jest.mock('../config', () => {
   const original = jest.requireActual('../config')
   return {
     ...original,
-    MAX_ADD_ANOTHER: 3
+    MAX_ADD_ANOTHER: 3,
+    SESSION_SECRET: 'test-session-secret'
   }
 })
 jest.mock('../helpers/check-your-answers', () => ({
@@ -336,12 +339,26 @@ describe('validatePageParams', () => {
 })
 
 describe('setCsrfToken', () => {
-  const next = jest.fn()
-  test('it adds a token if one does not exist', () => {
+  let next
+
+  beforeEach(() => {
+    next = jest.fn()
+  })
+
+  test('it does not add a token before the journey has started', () => {
     const req = { session: {} }
     setCsrfToken(req, {}, next)
-    expect(req.session).toHaveProperty('csrfToken')
+    expect(req.session).not.toHaveProperty('csrfToken')
+    expect(next).toHaveBeenCalled()
   })
+
+  test('it adds a token if the journey has started and one does not exist', () => {
+    const req = { session: { started: true } }
+    setCsrfToken(req, {}, next)
+    expect(req.session).toHaveProperty('csrfToken')
+    expect(next).toHaveBeenCalled()
+  })
+
   test('if a token is already set it does not change', () => {
     const req = {
       session: {
@@ -351,6 +368,80 @@ describe('setCsrfToken', () => {
     setCsrfToken(req, {}, next)
     expect(req.session).toHaveProperty('csrfToken')
     expect(req.session.csrfToken).toBe('1234567890')
+  })
+})
+
+describe('initial CSRF token', () => {
+  let next, res
+  let originalConsoleError
+
+  beforeEach(() => {
+    next = jest.fn()
+    res = {
+      cookie: jest.fn(),
+      clearCookie: jest.fn()
+    }
+    originalConsoleError = console.error
+    console.error = jest.fn()
+  })
+
+  afterEach(() => {
+    console.error = originalConsoleError
+  })
+
+  test('sets a cookie-backed token without touching the session', () => {
+    const req = { session: {} }
+
+    setInitialCsrfToken(req, res, next)
+
+    expect(req.initialCsrfToken).toEqual(expect.any(String))
+    expect(req.session).toStrictEqual({})
+    expect(res.cookie).toHaveBeenCalledWith(
+      'moj-frontend-start-csrf',
+      req.initialCsrfToken,
+      expect.objectContaining({ httpOnly: true })
+    )
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  test('starts the session when the initial token is valid', () => {
+    const setupReq = { session: {} }
+    setInitialCsrfToken(setupReq, res, next)
+
+    next.mockClear()
+    const req = {
+      body: { _csrf: setupReq.initialCsrfToken },
+      headers: {
+        cookie: `moj-frontend-start-csrf=${setupReq.initialCsrfToken}`
+      },
+      session: { checkYourAnswers: true }
+    }
+
+    verifyInitialCsrfToken(req, res, next)
+
+    expect(req.session.started).toBe(true)
+    expect(req.session).toHaveProperty('csrfToken')
+    expect(res.clearCookie).toHaveBeenCalledWith(
+      'moj-frontend-start-csrf',
+      expect.objectContaining({ httpOnly: true })
+    )
+    expect(next).toHaveBeenCalledWith()
+  })
+
+  test('rejects requests without a matching cookie token', () => {
+    const req = {
+      body: { _csrf: 'token' },
+      headers: {},
+      session: {}
+    }
+
+    verifyInitialCsrfToken(req, res, next)
+
+    expect(next).toHaveBeenCalledWith(expect.any(Error))
+    const [error] = next.mock.calls[0]
+    expect(error.message).toBe('Invalid CSRF token')
+    expect(error.status).toBe(403)
+    expect(req.session).toStrictEqual({})
   })
 })
 

--- a/app/routes/add-component.js
+++ b/app/routes/add-component.js
@@ -38,6 +38,8 @@ const {
   checkEmailDomain,
   validatePageParams,
   setCsrfToken,
+  setInitialCsrfToken,
+  verifyInitialCsrfToken,
   setSuccessMessage,
   xssComponentCode
 } = require('../middleware/component-session')
@@ -89,7 +91,7 @@ router.all('{*splat}', setCsrfToken)
 
 // TODO:  Why is this a get * ? Can it not just be set in the get /checkYourAnswersPath route below?
 router.get('{*splat}', (req, res, next) => {
-  if (req?.session) {
+  if (req?.session?.started) {
     if (req?.url.endsWith(checkYourAnswersPath)) {
       // Indicate that we've been on the check your answers page
       req.session.checkYourAnswers = true
@@ -200,15 +202,17 @@ if (ENV === 'development') {
 }
 
 // Start
-router.get('/start', (req, res) => {
-  delete req.session.checkYourAnswers
-  req.session.started = true
+router.get('/start', setInitialCsrfToken, (req, res) => {
   res.render('start', {
     page: {
       title: 'Before you start'
     },
-    csrfToken: req?.session?.csrfToken
+    csrfToken: req.initialCsrfToken
   })
+})
+
+router.post('/start', verifyInitialCsrfToken, (req, res) => {
+  res.redirect(`${ADD_NEW_COMPONENT_ROUTE}/email`)
 })
 
 // Confirmation page
@@ -264,9 +268,7 @@ router.get('/email-invalid-token', (req, res) => {
   })
 })
 
-router.get('/email', (req, res) => {
-  req.session.started = true
-
+router.get('/email', sessionStarted, (req, res) => {
   if (req.query.reset === 'true') {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
     delete req.session['/email']
@@ -283,10 +285,6 @@ router.get('/email', (req, res) => {
 
 // For all following routed we must have a session in progress
 router.all('{*splat}', sessionStarted)
-
-router.post('/start', verifyCsrf, (req, res) => {
-  res.redirect(`${ADD_NEW_COMPONENT_ROUTE}/email`)
-})
 
 router.post(
   '/email',

--- a/app/tests/e2e/session.setup.js
+++ b/app/tests/e2e/session.setup.js
@@ -8,12 +8,10 @@ const sessionFile = path.join(
 )
 
 setup('session', async ({ page }) => {
-  // Perform authentication steps. Replace these actions with your own.
   await page.goto('start')
-
-  // Alternatively, you can wait until the page reaches a state where all cookies are set.
   await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible()
+  await page.getByRole('button', { name: 'Continue' }).click()
+  await expect(page).toHaveTitle(/Verify that you work for MOJ/)
   await page.waitForLoadState('networkidle')
-  // End of authentication steps.
   await page.context().storageState({ path: sessionFile })
 })


### PR DESCRIPTION
This pull request introduces a new, more secure CSRF protection mechanism for the initial step of the "add component" journey, along with related session management improvements and comprehensive tests. The main change is the addition of a cookie-based, HMAC-signed CSRF token for the `/start` route, ensuring that sessions are only started after a valid token is submitted. This improves the security posture of the application and ensures better separation between pre-session and in-session states.

**Security: Initial CSRF Protection**
* Adds a new mechanism for issuing and validating a secure, cookie-backed CSRF token specifically for the `/start` route, using HMAC signatures and timing-safe comparisons. This ensures the session is not started until a valid token is submitted. 

**Session Management Improvements**
* Changes session configuration to not resave or save uninitialized sessions, reducing unnecessary session creation and improving compliance with best practices. (`app/app.js`)
* Updates logic so that CSRF tokens are only set in the session after the journey has started, preventing premature token creation. 

**Testing Enhancements**
* Adds comprehensive tests for the new initial CSRF token logic, including cookie handling, session state changes, and error conditions.
* Updates E2E setup to click through the `/start` page using the new flow, ensuring the test session is correctly established.

A full runthrough of the submission process has been completed successfully on the preview site.

