### PR TITLE
fix(search): ensure `input` options are passed through to the search input in the component

### DIFF
--- a/src/moj/components/search/fixtures.yaml
+++ b/src/moj/components/search/fixtures.yaml
@@ -156,7 +156,7 @@ examples:
         disabled: true
         spellcheck: false
         autocomplete: off
-        pattern: "[A-Za-z]+"
+        pattern: '[A-Za-z]+'
         inputmode: text
         describedBy: search-hint
       button:

--- a/src/moj/components/search/fixtures.yaml
+++ b/src/moj/components/search/fixtures.yaml
@@ -153,6 +153,12 @@ examples:
         id: search
         name: search
         classes: custom-input-class
+        disabled: true
+        spellcheck: false
+        autocomplete: off
+        pattern: "[A-Za-z]+"
+        inputmode: text
+        describedBy: search-hint
       button:
         text: Search
 

--- a/src/moj/components/search/search.nunjucks.spec.mjs
+++ b/src/moj/components/search/search.nunjucks.spec.mjs
@@ -374,6 +374,16 @@ describe('search', () => {
       const input = $component.querySelector('input[type="search"]')
       expect(input).toHaveClass('moj-search__input')
     })
+
+    test('passes input attributes through to the search input', () => {
+      const input = $component.querySelector('input[type="search"]')
+      expect(input).toBeDisabled()
+      expect(input).toHaveAttribute('spellcheck', 'false')
+      expect(input).toHaveAttribute('autocomplete', 'off')
+      expect(input).toHaveAttribute('pattern', '[A-Za-z]+')
+      expect(input).toHaveAttribute('inputmode', 'text')
+      expect(input).toHaveAttribute('aria-describedby', 'search-hint')
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/src/moj/components/search/template.njk
+++ b/src/moj/components/search/template.njk
@@ -81,8 +81,15 @@
       label: label,
       hint: hint,
       id: params.input.id,
+      value: params.input.value,
       name: params.input.name | default("search"),
       type: params.input.type | default("search"),
+      disabled: params.input.disabled,
+      spellcheck: params.input.spellcheck,
+      autocomplete: params.input.autocomplete,
+      pattern: params.input.pattern,
+      inputmode: params.input.inputmode,
+      describedBy: params.input.describedBy,
       inputWrapper: {
         classes: inputWrapperClassNames
       },


### PR DESCRIPTION
The component accepts an `input` param, which should accept most of the options allowed on a govuk text input component.  However not all of the options were correctly passed througuh and applied to the search input.  This PR make sure all the options that should be allowed are applied to the input in the component.  Most importantly this means it is now possible to preset the value of the search input.

Fixes #2590