### PR TITLE
Readme coding standards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,6 +208,8 @@ module.exports = {
         'no-undef': 'off',
         'no-unused-expressions': 'off',
         'no-useless-constructor': 'off',
+        '@typescript-eslint/no-extraneous-class': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
 
         // Ignore paths to example modules
         'import/no-absolute-path': 'off',

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -26,6 +26,7 @@ export default defineConfig({
   reporter: process.env.CI ? 'github' : [['list'], ['html', { open: 'never' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    headless: process.env.HEADLESS !== 'false',
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: `${process.env.APP_URL}/contribute/add-new-component/`,
     screenshot: 'only-on-failure',

--- a/readme/application-architecture.md
+++ b/readme/application-architecture.md
@@ -1,0 +1,171 @@
+# Application architecture
+
+MOJ Frontend is both a frontend component library and the application that
+documents and maintains that library. The source of truth is `src/`; the
+published package, distributable archive and documentation site are built from
+that source and from the files in `docs/`.
+
+## Repository structure
+
+- `src/`
+
+  Source files for the MOJ Frontend package.
+
+  - `moj/components/` contains component Sass, Nunjucks templates, fixtures and
+    component-specific JavaScript.
+  - `moj/all.scss` and `moj/all.mjs` are the aggregate package entry points.
+  - `moj/assets/` contains images and other package assets.
+  - `moj/core/`, `moj/settings/`, `moj/objects/`, `moj/helpers/` and
+    `moj/utilities/` contain shared styles and utilities.
+  - `moj/vendor/govuk-frontend/` contains the integration with GOV.UK
+    Frontend.
+
+- `package/` **contains auto-generated files**
+
+  The npm package output. Gulp copies package templates and assets from
+  `src/`, compiles each JavaScript and Sass module, and creates bundled and
+  minified entry points. Only package metadata and documentation intended for
+  npm consumption should be edited directly; rebuild the rest with
+  `npm run build:package`.
+
+- `dist/` **contains auto-generated files**
+
+  A standalone distribution of MOJ Frontend. It contains compiled,
+  versioned JavaScript and CSS, assets and `release.zip`, and is built with
+  `npm run build:dist`.
+
+- `docs/`
+
+  Source for the MOJ Pattern Library documentation site. Markdown files define pages, guidance and component documentation.
+
+  - `components/` contains guidance and examples on the design system components.
+  - `patterns/` contains guidance and examples on the design system patterns.
+  - `pages/` contains guidance and examples on the design system pages.
+  - `assets/` contains documentation-site images and other assets.
+  - `_data/` contains Eleventy global data files used to render the site.
+  - `_includes/` contains Eleventy layouts, partials and documentation macros.
+  - `stylesheets/` and `javascripts/` contain documentation-site assets.
+  - `11ty` contains the Eleventy configuration, filters and shortcodes used to
+    render the site.
+
+- `public/` **contains auto-generated files**
+
+  The built documentation site and its static assets. Eleventy renders
+  `docs/` here, while Gulp compiles and copies the stylesheets, JavaScript and
+  assets. Asset revisioning writes hashed filenames and a manifest during
+  `npm run build:docs`.
+
+- `app/`
+
+  An Express application used to collect new
+  component contributions. It configures Nunjucks, sessions, security
+  middleware, static files and the contribution routes.
+
+  - `app/views/` contains application pages and shared templates.
+  - `app/routes/add-component.js` implements the contribution journey.
+  - `app/schema/` defines Joi validation for form pages.
+  - `app/helpers/` contains navigation, session and form helpers.
+  - `app/middleware/` handles validation, file processing, documentation
+    generation, GitHub integration, email notifications and virus scanning.
+  - `app/tests/` contains end-to-end tests for the express application.
+
+- `gulp/`
+
+  Gulp tasks for building the npm package, standalone distribution and
+  documentation assets. Rollup bundles JavaScript, Sass/PostCSS compiles
+  stylesheets, and the tasks also copy assets and compress images.
+
+- `submissions/`
+
+  Component code examples produced by the contribution flow. A submission is
+  stored under a generated submission reference and is included in the pull
+  request created for the contributor.
+
+- `tests/`
+
+   End-to-end tests for the documentation site. Used to ensure that the
+   documentation site renders correctly and that the components behave as
+   expected.
+
+- `readme/`
+
+  Maintainer and contributor documentation, including coding standards and
+  this architecture overview.
+
+## Build and runtime relationships
+
+The main build flows are:
+
+```text
+src/ ──Gulp──> package/ ──> npm package
+  │
+  ├──Gulp──> dist/ ──> standalone release.zip
+  │
+  └──> docs/ + 11ty/ ──Eleventy/Gulp──> public/ ──> documentation site
+```
+
+The documentation site consumes the built MOJ package and GOV.UK Frontend
+assets. The Express app loads Nunjucks templates from `app/views`, `src/` and
+the GOV.UK Frontend distribution, and serves the generated `public/` files.
+During development, package and documentation watchers rebuild these inputs as
+they change.
+
+The principal commands are:
+
+- `npm run build:package` builds the npm package output.
+- `npm run build:dist` builds the standalone distribution.
+- `npm run build:docs` builds the documentation site.
+- `npm run build` builds the distribution and documentation site.
+- `npm run start` runs the package, documentation and application watchers.
+
+## Component architecture
+
+Components are implemented in `src/moj/components/<component>/`. A typical
+component has:
+
+- a Sass entry point;
+- `macro.njk`, which exposes the public Nunjucks macro;
+- `template.njk`, which renders the component;
+- `README.md` and, where applicable, `fixtures.yaml`;
+- JavaScript and unit/browser tests when it has interactive behaviour.
+
+New Sass components must be forwarded from
+[`src/moj/components/_all.scss`](../src/moj/components/_all.scss). Components
+with JavaScript behaviour must also be included in
+[`src/moj/all.mjs`](../src/moj/all.mjs) when they need package-wide
+initialisation. The build preserves individual modules and also creates
+bundles for consumers that need a single browser asset.
+
+## Contribution flow
+
+The contribution app exposes the add-component journey at
+`/contribute/add-new-component`. The journey is configuration-driven:
+`app/config.js` defines the pages and their conditional relationships, while
+the schemas validate each page. Session data is stored in Redis when
+configured; uploaded files are held in Redis and processed separately from
+the form values.
+
+On submission, the route:
+
+1. removes or masks personal data according to the contributor's choices;
+2. generates component Markdown and Eleventy data files;
+3. retrieves uploaded files and prepares component assets under
+   `docs/assets/images/`;
+4. writes supplied code examples under `submissions/<submission-reference>/`;
+5. pushes the generated files to GitHub, creates a pull request and review
+   issue, and sends notifications.
+
+## Testing and quality checks
+
+Tests are split by the surface they exercise:
+
+- `npm run test:components` runs component and package tests.
+- `npm run test:helpers` and `npm run test:middleware` run application unit
+  tests.
+- `npm run test:e2e` runs Playwright browser tests for the contribution flow.
+- `npm run test:scss` checks that the aggregate Sass compiles.
+- `npm run lint` runs TypeScript, JavaScript, Sass and formatting checks.
+
+Generated directories should be rebuilt rather than edited manually. When
+changing source files, run the smallest relevant build and test commands, then
+run `npm run lint` before submitting the change.

--- a/readme/browser-support.md
+++ b/readme/browser-support.md
@@ -1,0 +1,4 @@
+# Browser support
+
+MOJ Frontend follows the [browser support policy of GOV.UK
+Frontend](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/browser-support.md).

--- a/readme/coding-standards/component-options.md
+++ b/readme/coding-standards/component-options.md
@@ -1,0 +1,104 @@
+# Component configuration
+
+Configuration options allow developers to pass additional information into a component's JavaScript. This allows them to change how the component might work or appear without needing to create their own fork.
+
+Configuration options can be configured using Nunjucks, HTML or JavaScript, but only JavaScript will use the options.
+
+For more information, see the [GOV.UK guidance on building configurable components](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#building-configurable-components).
+
+## Preparing the component's JavaScript
+
+If a component class needs configuration, [extend the `ConfigurableComponent` class](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/) that GOV.UK Frontend provides. This class accepts configuration from the following sources:
+
+- [defaults defined as a `defaults` static property](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#setting-a-default-configuration-for-your-component) on the component’s class
+- [configuration passed as second argument](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#receiving-configuration-during-initialisation) to the component’s constructor or [`createAll`](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#using-createall-with-your-components)
+- [data attributes on the root element](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#receiving-configuration-from-data-attributes) of the component
+
+Configuration options from these sources are merged into a single configuration object by the `ConfigurableComponent` class. Note that:
+
+- configuration options passed to the constructor will override any defaults
+- data attribute values have highest precedence and will override any configuration set elsewhere
+
+Your component will then be able to:
+
+[access the merged configuration](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#accessing-the-component-s-configuration) using `this.config`
+use [the`Component` class](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#using-the-component-class) features
+
+## Adding a Nunjucks parameter
+
+Most, but not all, components support adding arbitrary attributes and values through the `attributes` parameter. This method is also more verbose compared to having a dedicated Nunjucks parameter to set data attributes on the root element. For example, this is how the Accordion does it for its `rememberExpanded` option:
+
+```nunjucks
+<div
+  class="govuk-accordion"
+  data-module="govuk-accordion"
+  {%- if params.rememberExpanded %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}>
+  ...
+</div>
+```
+
+The above code checks for the existence of the `rememberExpanded` parameter. If the parameter is present it adds the `data-remember-expanded` attribute. It then passes in the developer's defined value, running it through [Nunjucks' native `escape` filter](https://mozilla.github.io/nunjucks/templating.html#escape-aliased-as-e) to make sure that values can't break our HTML.
+
+With the previous code in the Accordion's template, this is how a page may set a specific value for the `rememberExpanded` option:
+
+```nunjucks
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+
+{{ govukAccordion({
+  id: "accordion",
+  rememberExpanded: false,
+  items: [...]
+}) }}
+```
+
+## Naming configuration options
+
+### In JavaScript
+
+Use camelCase to write the option in JavaScript.
+
+If the option is a boolean option that accepts `true` or `false` as values, favour affirmative language when naming the option. This avoids the use of double-negatives to enable something. For example, `rememberExpanded: true` is easier to understand than `forgetExpanded: false`.
+
+### In HTML
+
+`data-*` attributes in HTML should use the same name as JavaScript, converted into kebab-case. This is because the `dataset` property in JavaScript automatically converts between these two formats.
+
+> **Warning**: This automatic conversion does not happen for numbers, punctuation, or other non-Latin alphabet characters. For this reason, when you're naming configuration options, avoid using numbers or spell them out as words.
+
+In our example, `rememberExpanded` becomes `data-remember-expanded`.
+
+### In Nunjucks
+
+Unlike the `data-*` attribute in HTML, there is no intrinsic link between the Nunjucks parameter name and the names used elsewhere. The Nunjucks parameter can therefore be named differently, if convenient.
+
+A common case is specifying whether a parameter accepts HTML or only plain text. For example, if a configuration option's value is inserted into the page using `innerText`, you might want to name the Nunjucks parameter something like `sectionLabelText` to indicate that HTML will not be parsed if provided.
+
+There is more guidance on naming Nunjucks parameters in [the Nunjucks API documentation](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/nunjucks-api.md#naming-options).
+
+## Namespacing configuration options
+
+When passing configuration into your component's constructor, you can use nested objects to group options. For example, GOV.UK Frontend's translation strings are defined as an object named `i18n` (short for 'internationalisation'), as seen here with the Accordion:
+
+```mjs
+createAll(Accordion, {
+  i18n: {
+    hideAllSections: 'Hide all sections',
+    hideSection: 'Hide',
+    hideSectionAriaLabel: 'Hide this section',
+    showAllSections: 'Show all sections',
+    showSection: 'Show',
+    showSectionAriaLabel: 'Show this section'
+  },
+  rememberExpanded: true
+})
+```
+
+Data attributes only accept strings, but the GOV.UK [naming conventions for data attributes](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#receiving-configuration-from-data-attributes) allow you to set options in nested objects using a dot `.` separator for each level of nesting. For example `data-i18n.showSection="Show"` will set the same option as the following constructor argument:
+
+```json
+{
+  i18n: {
+    showSection: 'Show'
+  }
+}
+```

--- a/readme/coding-standards/components.md
+++ b/readme/coding-standards/components.md
@@ -1,0 +1,33 @@
+# Components
+
+You can find components in `src/moj/components`.
+
+## Name your components
+
+Generally, folder and file names should be singular, for example ‘accordion’, ‘backlink’, ‘button’. Only use plural names when the component is usually used in groups, for example ‘breadcrumbs’, ‘checkboxes’, ‘radios’.
+
+## Structure your component folder
+
+When creating your component, you should create the following files in the component’s folder:
+
+- `README.md` - Summary documentation with links to the installation instructions and component documentation on <https://design-system.service.gov.uk/>
+- `_[component-name].scss` - The main Sass entry point for the component. 
+- `fixtures.yaml` - Lists examples using all the component options. The examples are used to test component behaviour.
+- `macro.njk` - The main entry point for rendering the component. It provides a `moj[ComponentName](params)` macro, delegating render to the `template.njk` file
+- `template.njk` - The template used for rendering the component using any `params` provided to the macro
+- `[component-name].spec.js` - Tests to ensure the component renders as intended with its various options
+
+If your component uses JavaScript, you must also create the following files in the component’s folder:
+
+- `[component-name].mjs` - A JavaScript module with the implementation of any behaviour needed by the component. See the [JavaScript documentation]('./js.md#skeleton) for a skeleton and more details on that file's structure
+- `[component-name].js.spec.mjs` - Unit tests to verify any component-specific lower-level logic.
+- `[component-name].playwright.spec.js` - Functional tests to verify the behaviour of the whole component in a browser.
+- `[component-name].accessibility.playwright.spec.js` - Tests to verify the basic accessibility of the component in a browser. (Manual accessibility testing is still required to ensure the component meets all accessibility standards).
+
+## Building your components
+
+To help you build and initialise your own JavaScript components, GOV.UK Frontend provides some of its internal features for you to reuse. Follow our guidance on [building JavaScript components](https://frontend.design-system.service.gov.uk/building-your-own-javascript-components/#building-your-own-javascript-components) to use these features.
+
+Learn more about styling components in our [CSS style guide](./css.md). Our [JavaScript style guide](./js.md) has more information on coding components.
+
+If you need help building a component, [contact the MOJ Design System team](https://design-patterns.service.justice.gov.uk/help/) and we'll support you.

--- a/readme/coding-standards/css.md
+++ b/readme/coding-standards/css.md
@@ -1,0 +1,557 @@
+# CSS and Sass Style Guide
+
+## Sass modules
+
+MOJ Frontend supports `@use` to include Sass files.
+
+Our public API is prefixed with `moj-` to ensure consistent naming and avoid
+clashes with Sass elements in your application. You should `@use` moj-frontend
+modules without a namespace:
+
+Bad:
+
+```scss
+@use "foo";
+
+.bar {
+  color: foo.moj-function("baz")
+}
+```
+
+Good:
+
+```scss
+@use "foo" as *;
+
+.bar {
+  color:.moj-function("baz")
+}
+```
+
+## Class naming convention
+
+### `moj` namespacing
+
+All class names start with a `.moj-` namespace to reduce the likelihood of
+conflicting with existing classes in your application. It also helps to identify
+where the styling for a particular element is coming from.
+
+If you are building components for your own application or framework you should
+use a different prefix, for example `.app-` or the initials of your department.
+
+### Block Element Modifier (BEM)
+
+Like GOV.UK Frontend, MOJ Frontend uses the Block Element Modifier (BEM) methodology when naming
+CSS classes. This is designed to help developers understand how the different
+classes relate to each other.
+
+The naming convention follows this pattern:
+
+```scss
+.block {}
+.block__element {}
+.block--modifier {}
+
+.moj-card {}            // Block - the root of a component
+.moj-card__body {}      // Element - a part of the block
+.moj-card--active {}    // Modifier - a variant of the block
+```
+
+It uses double hyphens (`--`) and underscores (`__`) so that the block, element
+or modifiers themselves can be hyphen delimited without causing ambiguity.
+
+For example:
+
+```scss
+.moj-pagination {}
+.moj-pagination__link-title {}
+.moj-pagination__link-title--decorated {}
+```
+
+### Further reading:
+
+- [Get BEM](http://getbem.com/introduction/)
+- [BEM Resources](https://github.com/sturobson/BEM-resources)
+- [Harry Roberts - BEMIT: Taking the BEM Naming Convention a Step Further](https://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/)
+
+## Nesting
+
+Break elements and modifiers outside of blocks rather than nesting using a
+parent selector `&`.
+
+This makes the codebase easier to read, and makes it easier to search for a
+given class name. It also discourages excessive nesting.
+
+Bad:
+
+```scss
+.moj-alert {
+  // ...
+  &__title {
+    // ...
+  }
+}
+```
+
+Good:
+
+```scss
+.moj-alert {
+  // ...
+}
+
+.moj-alert__item {
+  // ...
+}
+```
+
+BEM stands for `Block__Element--Modifier`, not `Block__Element__Element--Modifier`.
+
+Avoid including multiple elements when naming classes.
+
+## Single Responsibility Principle
+
+Each class has a single purpose, so you can be sure when making a change to a
+class - it will only affect the element that class is applied to.
+
+Also when deprecating classes, all of the CSS for this class can be removed
+without affecting another component that had reused this css.
+
+**Why?**
+
+To ensure that styles can safely be added or removed without fear of breaking
+other components.
+
+## Component modifiers
+
+Keep all of the variants of a component in the same place.
+
+`.govuk-error-summary` modifies the `.govuk-list` component.
+
+Component modifiers use an extra class, scoped to the component:
+
+`.govuk-error-summary__list`
+
+This class is part of the component, rather than a parent of a component.
+
+**Why?**
+This makes it easier to keep track of different contexts.
+
+## Formatting and linting
+
+To ensure code quality and consistency in our Sass files we check that certain rules are followed. These rules are based on [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds/blob/main/scss.js), but we also add our own custom rules with a project [config file](/stylelint.config.js).
+
+For consistent formatting we run [Prettier](https://prettier.io).
+
+See [testing and linting](/docs/releasing/testing-and-linting.md) for more information.
+
+## Running the lint task
+
+You can run the linter with `npm run lint:scss`, or use linting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) and [other editors that support Stylelint](https://stylelint.io/user-guide/customize/#using-stylelint).
+
+To automatically fix Stylelint issues use the `npm run lint:scss:fix` command.
+
+## Running the formatting task
+
+You can run the formatter with `npm run lint:prettier`, or use formatting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [other editors that support Prettier](https://prettier.io/docs/en/editors.html)
+
+To automatically fix Prettier issues in all supported files, use the `npm run lint:prettier:fix` command.
+
+## Linting rules
+
+We use the following rules when linting files:
+
+### Use soft tabs (2 spaces)
+
+### Write each property on its own line
+
+Bad:
+
+```scss
+.selector {padding: 0; border: 0;}
+```
+
+Good:
+
+```scss
+.selector {
+  padding: 0;
+  border: 0;
+}
+```
+
+### Use variables for colours not HEX values in selectors rules, unless in variables.
+
+Bad:
+
+```scss
+.selector {
+  color: #005ea5;
+}
+```
+
+Good:
+
+```scss
+.selector {
+  color: $govuk-blue;
+}
+```
+
+### Colours defined as variables should be in lowercase and in full length
+
+Bad:
+
+```scss
+$white: #FFF;
+```
+
+Good:
+
+```scss
+$white: #ffffff;
+```
+
+### Avoid using ID selectors
+
+Bad:
+
+```scss
+#content {
+  // ...
+}
+```
+
+Good:
+
+```scss
+.moj-wrapper {
+  // ...
+}
+```
+
+### Separate rule, function, and mixin declarations with empty lines
+
+Bad:
+
+```scss
+p {
+  margin: 0;
+  em {
+    // ...
+  }
+}
+a {
+  // ...
+}
+```
+
+Good:
+
+```scss
+p {
+  margin: 0;
+
+  em {
+    // ...
+  }
+}
+
+a {
+  // ...
+}
+```
+
+### Use no more than 3 levels of nesting
+
+Bad:
+
+```scss
+.moj-breadcrumb {
+  // ...
+  &__item {
+    // ...
+  }
+}
+```
+
+Good:
+
+```scss
+.moj-breadcrumb {
+  // ...
+}
+
+.moj-breadcrumb__item {
+  // ...
+}
+```
+
+### Don't use extends, use mixins
+
+Bad:
+
+```scss
+@extend %contain-floats;
+```
+
+Good:
+
+```scss
+@include clearfix;
+```
+
+### Allow max 3-rule property shorthand if possible
+
+Bad:
+
+```scss
+margin: 1px 2px 3px 2px;
+```
+
+Good:
+
+```scss
+margin: 1px 2px 3px;
+```
+
+### Strings should always use double quotes
+
+Bad:
+
+```scss
+@use 'foo';
+
+.moj-font-family-gds-transport: 'GDS Transport', arial, sans-serif;
+
+.bar {
+  content: 'baz';
+}
+```
+
+Good:
+
+```scss
+@use "foo";
+
+.moj-font-family-gds-transport: "GDS Transport", arial, sans-serif;
+
+.bar {
+  content: "baz";
+}
+```
+
+### Files should always have a final newline
+
+### The basenames of `@use`ed SCSS partials should not begin with an underscore and should not include the filename extension
+
+Bad:
+
+```scss
+@use "_foo.scss";
+@use "_bar/foo.scss";
+```
+
+Good:
+
+```scss
+@use "foo";
+@use "bar/foo";
+```
+
+### Properties should be formatted with a single space separating the colon from the property's value
+
+Bad:
+
+```scss
+.foo {
+  content:"bar";
+}
+```
+
+Good:
+
+```scss
+.foo {
+  content: "bar";
+}
+```
+
+### `@if` statements should be written without surrounding brackets
+
+Bad:
+
+```scss
+@if ($foo == $bar) {
+  $baz: 1;
+}
+```
+
+Good:
+
+```scss
+@if $foo == $bar {
+  $baz: 1;
+}
+```
+
+### `@if` statements comparing against `null` values should use `not`
+
+Bad:
+
+```scss
+@if $foo == null {
+  $baz: 1;
+}
+```
+
+Good:
+
+```scss
+@if not $foo {
+  $baz: 1;
+}
+```
+
+### Operators should be formatted with a single space on both sides of an infix operator. These include `+, -, *, /, %, ==, !=, >, >=, <,` and `<=`
+
+Bad:
+
+```scss
+.selector-1 {
+  margin: 5px+15px;
+}
+
+$foo: 1;
+$bar: 3;
+
+.selector-2 {
+  margin: $foo+$bar+"px";
+}
+
+$foo: 1+1;
+$bar: 2-1;
+
+@if $foo==$bar {
+  $baz: 1;
+}
+
+@if $foo!=$bar {
+  $baz: 1;
+}
+```
+
+Good:
+
+```scss
+.selector-1 {
+  margin: 5px + 15px;
+}
+
+$foo: 1;
+$bar: 3;
+
+.selector-2 {
+  margin: $foo + $bar + "px";
+}
+
+$foo: 1 + 1;
+$bar: 2 - 1;
+
+@if $foo == $bar {
+  $baz: 1;
+}
+
+@if $foo != $bar {
+  $baz: 1;
+}
+```
+
+### Functions, mixins, variables, and placeholders should be declared with all lowercase letters and hyphens instead of underscores
+
+Bad:
+
+```scss
+@mixin FONT_STACK() {
+  font-family: .moj-font-stack;
+}
+```
+
+Good:
+
+```scss
+@mixin font-stack() {
+  font-family: .moj-font-stack;
+}
+```
+
+### Omit length units on zero values
+
+Bad:
+
+```scss
+.selector {
+  margin: 0px;
+}
+```
+
+Good:
+
+```scss
+.selector {
+  margin: 0;
+}
+```
+
+### Property values and variable declarations should always end with a semicolon
+
+Bad:
+
+```scss
+.selector {
+  margin: 0
+}
+
+$my-example-var: value
+```
+
+Good:
+
+```scss
+.selector {
+  margin: 0;
+}
+
+$my-example-var: value;
+```
+
+### Write leading or trailing zeroes for numeric values with a decimal point
+
+Bad:
+
+```scss
+.selector {
+  font-size: .50em;
+}
+```
+
+Good:
+
+```scss
+.selector {
+  font-size: 0.5em;
+}
+```
+
+### Remove trailing whitespace
+
+More write up on [supported rules](https://stylelint.io/user-guide/rules/list).
+
+## Comments
+
+For comments, you should normally use 2 slashes (`//`) at the start of the line.
+
+If you need to include the comment in the compiled CSS, use the multi-line ('loud') comment style, which starts with `/*` and ends at the next `*/`.
+
+Wrap comments at 80 characters wherever possible.
+

--- a/readme/coding-standards/js.md
+++ b/readme/coding-standards/js.md
@@ -1,0 +1,197 @@
+# JavaScript style guide
+
+## Files
+
+JavaScript files have the same name as the component's folder name. Test files have a `.spec` suffix placed before the file extension.
+
+```console
+component
+├── component.mjs
+└── component.spec.js
+```
+
+## Skeleton
+
+```mjs
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
+
+/**
+ * Component name
+ *
+ * @preserve
+ */
+export class Example extends GOVUKFrontendComponent {
+  /**
+   * @param {Element | null} $root - HTML element to use for component
+   */
+  constructor($root){
+    super($root)
+
+    // Code goes here
+    this.$root.addEventListener('click', () => {
+      // ...
+    })
+  }
+}
+```
+
+## Use data attributes to initialise component JavaScript
+
+Use `data-module` attributes in HTML to initialise a component in JavaScript. For example:
+
+```html
+data-module="moj-alert"
+```
+
+## Use classes to target DOM elements
+
+After you initialise a component, use `moj-js-*` classes to target DOM elements used specifically for js functionality. For example:
+
+```html
+class="moj-js-header-toggle"
+```
+
+## Comments
+
+Use `/** ... */` for multi-line comments. Include a description, and specify types and values for all parameters and return values.
+
+```mjs
+/**
+ * Get the first descendent (child) of an HTML element that matches a given tag name
+ *
+ * @param {Element} $element - HTML element
+ * @param {string} tagName - Tag name (for example 'div')
+ * @returns {Element} Ancestor element
+ */
+function exampleHelper($element, tagName) {
+  // Code goes here
+  return $element.querySelector(tagName)
+}
+```
+
+Use `//` for single-line comments. Place single-line comments on a new line above the subject of the comment.
+
+Use `// FIXME:` to annotate problems.
+
+Use `// TODO:` to annotate solutions to problems.
+
+## Classes and methods
+
+Use the class design pattern to structure your code.
+
+Create a class and define the methods you need.
+
+```mjs
+class Example {
+  // Code goes here
+}
+```
+
+Add methods to the class.
+
+```mjs
+// Good
+class Example {
+  doSomething() {
+    // Code goes here
+  }
+}
+
+// Bad
+Example.prototype = {
+  doSomething: function () {
+    // Code goes here
+  }
+}
+```
+
+When initialising a class, use the `new` keyword.
+
+```mjs
+// Bad
+const myExample1 = Example()
+
+// Good
+const myExample2 = new Example()
+```
+
+## Modules
+
+Use ECMAScript (ES) modules (`import`/`export`) over CommonJS and other formats. You can always transpile to your preferred module system.
+
+```mjs
+import { closestAttributeValue } from '../common/index.mjs'
+
+// Code goes here
+export function exampleHelper1() {}
+export function exampleHelper2() {}
+```
+
+You must specify the file extension when using the import keyword.
+
+Avoid using namespace imports (`import * as namespace`) in code bundled for CommonJS and other formats as this can prevent "tree shaking" optimisations.
+
+Prefer named exports over default exports to avoid compatibility issues with transpiler "synthetic default" as discussed in: https://github.com/alphagov/govuk-frontend/issues/2829
+
+## Throwing errors
+
+### Error types
+
+First, check if one of the [native errors provides](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) the right semantic for the error you're looking to throw, if so, use this class.
+
+If none of the native errors have the right semantics, create a new class for this error. This class should:
+
+- have a name ending in `Error` to match the native conventions
+- extend `GOVUKFrontendError`, so users can separate our custom errors from native ones using `instanceof`
+- have a `name` property set to its class name, as extending classes doesn't set this automatically and grabbing the constructor's name risks being affected by mangling during minification
+
+```js
+class CustomError extends GOVUKFrontendError {
+  name = 'CustomError'
+}
+```
+
+### Error message
+
+Keep the message to the point, but provide the users the information they need to identify the cause of the error.
+
+If the message is the same whatever the situation, you may use the constructor of our custom error to centralise that message, rather than passing it each time an error is thrown.
+
+```js
+class SupportError extends GOVUKFrontendError {
+  name = 'SupportError'
+
+  constructor () {
+    super('GOV.UK Frontend is not supported in this browser')
+  }
+}
+```
+
+## Polyfilling
+
+If you need polyfills for features that are not yet included in this project, please see the following guide on [how to add polyfills](../polyfilling.md).
+
+## Formatting and linting
+
+GOV.UK Frontend uses [ESLint](https://eslint.org) with [JavaScript Standard Style](https://standardjs.com), an opinionated JavaScript style guide. All JavaScript files follow its conventions, and it runs on GitHub Actions to ensure that new pull requests are in line with them.
+
+For consistent formatting we run [Prettier](https://prettier.io).
+
+The standard docs have a [complete list of rules and some reasoning behind them](https://standardjs.com/rules.html).
+
+Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#linting).
+
+See also [testing and linting](/docs/releasing/testing-and-linting.md).
+
+## Running the lint task
+
+You can run the linter with `npm run lint:js`, or use linting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [other editors that support ESLint](https://eslint.org/docs/latest/use/integrations#editors).
+
+To automatically fix ESLint issues, run the `npm run lint:js:fix` command.
+
+## Running the formatting task
+
+You can run the formatter with `npm run lint:prettier`, or use formatting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [other editors that support Prettier](https://prettier.io/docs/en/editors.html)
+
+To automatically fix Prettier issues in all supported files, run the `npm run lint:prettier:fix` command
+

--- a/readme/coding-standards/js.md
+++ b/readme/coding-standards/js.md
@@ -167,10 +167,6 @@ class SupportError extends GOVUKFrontendError {
 }
 ```
 
-## Polyfilling
-
-If you need polyfills for features that are not yet included in this project, please see the following guide on [how to add polyfills](../polyfilling.md).
-
 ## Formatting and linting
 
 GOV.UK Frontend uses [ESLint](https://eslint.org) with [JavaScript Standard Style](https://standardjs.com), an opinionated JavaScript style guide. All JavaScript files follow its conventions, and it runs on GitHub Actions to ensure that new pull requests are in line with them.
@@ -181,7 +177,7 @@ The standard docs have a [complete list of rules and some reasoning behind them]
 
 Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/js.html#linting).
 
-See also [testing and linting](/docs/releasing/testing-and-linting.md).
+See also [testing and linting](/readme/testing-and-linting.md).
 
 ## Running the lint task
 

--- a/readme/coding-standards/nunjucks-api.md
+++ b/readme/coding-standards/nunjucks-api.md
@@ -1,0 +1,103 @@
+# Component API definition and use
+
+We have chosen as Nunjucks as the templating language for MOJ Frontend components. We expose those templates as reusable chunks of code: macros. Developers import macros into their application, call them as per documentation and provide data to its options.
+
+To provide a level of consistency for developers we have standardised option names, their expected input, use and placement. There are exceptions, and if so they are documented accordingly.
+
+## Specifying content
+
+When providing _content_ to a macro, say for a label or a button, we accept two options:
+
+- `text` accepts a plain string and is the default way of passing content
+- `html` accepts html markup. In the template we will not escape html so it will be rendered. In a scenario where both text and html are set, html option will take precedence over text.
+
+Example:
+
+```njk
+{{ mojAlert({ text: "Alert text" }) }}
+```
+
+```njk
+{{ mojAlert({ html: "Alert <span class='bold'>text</span>" }) }}
+```
+
+Example of implementing logic in a component template:
+
+```njk
+{{ params.html | safe if params.html else params.text }}
+```
+
+Example shows that if `html` and `text` options are present, then `html` takes precedence over `text` and we are not escaping it.
+
+## Naming options
+
+We should use **camelCase** for naming options.
+
+If a component depends on another component, we group the options for the dependent component inside an object, where the name of the object is the name of the component using **camelCase** convention. In case of ambiguity we prefix the component name.
+
+Example of a component depending on two other components
+
+```njk
+{{ mojDatepicker({
+  label: {
+    text: "Label text"
+  },
+  errorMessage: {
+    text: "Error message"
+  }
+}) }}
+```
+
+## Mimic HTML attribute names
+
+When there is a need to specify html attributes, such as _checked, disabled, id, name_, etc, and they map directly, we use the same option name. We use boolean value to check and render the attribute.
+
+Example:
+
+```njk
+{{ govukButton({ disabled: true }) }}
+```
+
+```njk
+{{ govukCheckbox({ checked: true }) }}
+```
+
+## Defining additional HTML attributes
+
+When there is a need to add additional attributes to the component, we accept an **_"attributes"_** object with key : value pairs for each attribute.
+
+You cannot use this to set attributes that are already defined, such as class – use the classes option instead.
+
+Example:
+
+```njk
+{{ govukButton({
+  attributes: {
+    "data-target": "contact-by-text",
+    "aria-labelledby": "error-summary-heading-example-1",
+    "tabindex": "-1"
+  }
+}) }}
+```
+
+## Specifying multiple items
+
+When a component accepts a _single array of items_ for an output, such as checkboxes or radios, we accept an **_"items"_** array of objects. Table component is an exception is it can contain multiple array for rows, head, footer where there is need to for more specific names.
+
+Example:
+
+```njk
+{{ govukCheckbox({
+   items: [
+   {
+      value: "checkbox value",
+      text: "Checkbox text"
+    },
+    {
+      value: "checkbox value 2",
+      text: "Checkbox text 2"
+    }
+  ]
+}) }}
+```
+

--- a/readme/deployment.md
+++ b/readme/deployment.md
@@ -1,0 +1,27 @@
+# Deploying the Design System website
+
+The design system website uses a continuous integration and deployment (CI/CD)
+pipeline to automatically build and deploy the website whenever changes are made
+to the codebase. The deployment process is managed using GitHub Actions, which
+runs a series of jobs to build the site and deploy it to the hosting
+environment.
+
+## Deploying a preview of your changes
+
+To deploy a preview of your changes, create a pull request (PR) in the GitHub
+repository. Add the `preview: request` label to the PR. This will trigger the
+CI/CD pipeline to build the site and deploy a preview version of the website.
+The preview will be available at a unique URL, which will be posted in the PR
+comments. 
+
+Any further pushes to the PR will automatically trigger a rebuild and redeploy
+of the preview site. You can view the preview site to verify that your changes
+look and function as expected before merging the PR.
+
+## Deploying to production
+
+Once your changes have been reviewed and approved, and all the GitHub automated
+checks have passed, you can merge the PR into the `main` branch. This will
+trigger the CI/CD pipeline to build the site and automatically deploy it to the production
+environment. The changes will be live on the design system website within a few
+minutes.

--- a/readme/github-actions.md
+++ b/readme/github-actions.md
@@ -1,0 +1,191 @@
+# How to write GitHub Actions
+
+## Install the VS Code extension
+
+If you're using Visual Studio Code, install the GitHub Actions workflow extension: https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions
+
+## Set inputs as environment variables
+
+Set inputs as environment variables for the workflow rather than using inline expressions (`${{ }}`).
+
+Set the [`env` at the top level](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#env)
+of the workflow or [per step](https://docs.github.com/en/actions/reference/security/secure-use#use-an-intermediate-environment-variable).
+
+Bad:
+
+```yaml
+- name: Check PR title
+  run: |
+    if [[ "${{ github.event.pull_request.title }}" =~ ^octocat ]]; then
+      echo "PR title starts with 'octocat'"
+      exit 0
+    else
+      echo "PR title did not start with 'octocat'"
+      exit 1
+    fi
+```
+
+Good :
+
+```yaml
+- name: Check PR title
+  env:
+    TITLE: ${{ github.event.pull_request.title }}
+  run: |
+    if [[ "$TITLE" =~ ^octocat ]]; then
+      echo "PR title starts with 'octocat'"
+      exit 0
+    else
+      echo "PR title did not start with 'octocat'"
+      exit 1
+    fi
+```
+
+## Use quotes to protect variables
+
+When using variables, use double quotes to prevent the variables from breaking scripts when spaces or other characters are used.
+
+Bad:
+
+```shell
+RELEASE_TITLE="Release v6.2.0"
+git commit -m $RELEASE_TITLE
+# Results in the command breaking since there is a space in the RELEASE_TITLE variable
+```
+
+Good:
+
+```shell
+RELEASE_TITLE="Release v6.2.0"
+git commit -m "$RELEASE_TITLE"
+```
+
+## Move complicated logic outside of the workflow
+
+Try to run any complicated logic in scripts outside the GitHub workflow, as this allows us to test them using our regular test suite.
+
+Bad:
+
+```yaml
+- name: Generate release notes
+  uses: actions/github-script@v9.0.0
+  with:
+    script: |
+      function generateReleaseNotes (version) {
+        // ... lots of logic here
+      }
+
+      generateReleaseNotes(process.env.PACKAGE_VERSION)
+```
+
+Good:
+
+```yaml
+- name: Generate release notes
+  uses: actions/github-script@v9.0.0
+  with:
+    script: |
+      const { generateReleaseNotes } = await import('${{ github.workspace }}/shared/github-scripts/changelog-release-helper.mjs')
+
+      generateReleaseNotes(process.env.PACKAGE_VERSION)
+```
+
+## Using environments
+
+Avoid skipping steps with destructive commands and instead output them to the logs using `echo`.
+
+Bad:
+
+```yaml
+- name: Create GitHub release
+  if: inputs.environment == 'production'
+  run: |
+    if gh release view "$GH_TAG" > /dev/null 2>&1; then
+      echo "::error::Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+      exit 1
+    fi
+
+    gh release create
+```
+
+Good:
+
+```yaml
+- name: Create GitHub release
+  env:
+    IS_PRODUCTION: inputs.environment == 'production'
+  run: |
+    if gh release view "$GH_TAG" > /dev/null 2>&1; then
+      echo "::error::Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+      exit 1
+    fi
+
+    create_github_release() {
+      gh release create
+    }
+
+    if $IS_PRODUCTION; then
+      create_github_release
+    else
+      declare -f create_github_release
+    fi
+```
+
+Good:
+
+Note that if the step is a one line command, it's okay to use `if:`.
+
+```yaml
+- name: Publish to npm
+  if: inputs.environment == 'production'
+  run: npm publish
+```
+
+## Surface important information into the Github Job Summary
+
+When there is important information to review, output it to the top level summary.
+
+### Single line output
+
+```shell
+echo '# Built package output' >> $GITHUB_STEP_SUMMARY
+```
+
+### Multiline output
+
+````shell
+{
+  echo '# Built package output'
+  echo '```dist'
+  tree dist
+  echo '```'
+} >> $GITHUB_STEP_SUMMARY
+````
+
+### Set errors as annotations
+
+Set errors [using ::error::](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message), which outputs to the top level summary
+
+Bad:
+
+```shell
+  echo "Error: Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+  exit 1
+```
+
+Good:
+
+```shell
+  echo "::error::Release $GH_TAG already exists. Please delete the release and tag via the GitHub UI and re-run this workflow"
+  exit 1
+```
+
+## Clearing corrupt caches
+
+Sometimes you may run into issues where parts of GitHub Actions workflows are cached in a corrupted state.
+
+If a new pull request triggers a GitHub Actions workflow that does not have a cache reference, the workflow will check if a cache with the same key exists on the `main` branch.
+
+This means you must remove the cache on `main` as well, if needed.
+
+You can delete the cache from https://github.com/alphagov/govuk-frontend/actions/caches or using the GitHub CLI (`gh cache delete --all`).

--- a/readme/publishing.md
+++ b/readme/publishing.md
@@ -1,0 +1,52 @@
+# Publishing
+
+To publish a new version of the moj-frontend package, you need to create a pull
+request (PR) with the changes you want to release. The PR title should follow
+the angular commit message guidelines, as described in the
+[Versioning](versioning.md) section.
+
+Once the PR has been approved and merged, the CI/CD pipeline will automatically
+build and publish any changes to the design system website.
+
+A new version of the moj-frontend package must be published manually to npm.
+This is done using a GitHub Action.
+
+## Do a dry run
+
+Before publishing a new version of the package, **you must do a dry run** to check
+what the next version will be. This is done using the "Publish package" workflow
+in dry run mode.
+
+1. Open the [**Actions** tab](https://github.com/ministryofjustice/moj-frontend/actions) on the `ministryofjustice/moj-frontend` repo.
+
+2. Select the ["Publish package" workflow](https://github.com/ministryofjustice/moj-frontend/actions/workflows/publish-package.yml) and run the workflow:
+   1. Set the **Use workflow from** select field to `main`.
+   2. Set the **Publish mode** to `dryrun`.
+   3. Select **Run workflow**.
+
+3. Inspect the running workflow - within the build job there will be a step
+   called "Get next version" which will output the results of semantic-release's
+   versioning analysis. This will show you what the next version of the package
+   will be, based on the commit messages in the PR. Check that this is the
+   version you expect to be published.
+
+4. If the next version is not what you expect, you will need to amend the PR
+   commit messages to ensure that they follow the angular commit message
+   guidelines. You can then re-run the dry run workflow to check that the next
+   version is now correct.
+
+## Publish the package
+
+1. Open the [**Actions** tab](https://github.com/ministryofjustice/moj-frontend/actions) on the `ministryofjustice/moj-frontend` repo.
+
+2. Select the ["Publish package" workflow](https://github.com/ministryofjustice/moj-frontend/actions/workflows/publish-package.yml) and run the workflow:
+   1. Set the **Use workflow from** select field to `main`.
+   2. Set the **Publish mode** to `publish`.
+   3. Select **Run workflow**.
+
+3. When the workflow has completed, check the [npm package
+   page](https://www.npmjs.com/package/@ministryofjustice/moj-frontend) to
+   confirm that the new version has been published. Also check the [GitHub
+   releases page](https://://github.com/ministryofjustice/moj-frontend/releases)
+   to confirm that a new release has been created with the correct version
+   number and edit the release note.

--- a/readme/running-locally.md
+++ b/readme/running-locally.md
@@ -1,0 +1,57 @@
+# Running locally
+
+You'll need [Git](https://help.github.com/articles/set-up-git/) and [Node.js](https://nodejs.org/en/) installed to get this project running.
+
+Note: You will need the Node.js version specified in the [.nvmrc](/../../.nvmrc) file.
+This should reflect the most current [active LTS (Long-term support)](https://github.com/nodejs/Release#release-schedule).
+
+## 1. Fork repository (optional)
+
+If you're an external contributor make sure to [fork this project first](https://help.github.com/articles/fork-a-repo/)
+
+## 2. Clone repository
+
+```shell
+git clone git@github.com:ministryofjustice/moj-frontend.git # or clone your own fork
+
+cd moj-frontend
+```
+
+## 3. Using nvm (optional)
+
+If you work across multiple Node.js projects there's a good chance they require different Node.js and npm versions.
+
+To enable this we use [nvm (Node Version Manager)](https://github.com/creationix/nvm) to switch between versions easily.
+
+1. [install nvm](https://github.com/creationix/nvm#installation)
+2. Run `nvm install` in the project directory (this will use [.nvmrc](/../../.nvmrc))
+
+## 4. Install npm dependencies
+
+We use [npm](https://docs.npmjs.com/getting-started/what-is-npm) to manage the dependencies in development.
+
+```shell
+npm install
+npm run setup
+```
+
+## 5. Build the project
+
+Before you can run the local server for the first time, you need to build the project.
+
+```shell
+npm run build:package
+npm run build:docs
+```
+
+## 6. Start a local server
+
+This will build sources, serve pages and watch for changes.
+
+```shell
+npm run start
+```
+
+The local server will be available at
+[http://localhost:3001](http://localhost:3001).
+

--- a/readme/tasks.md
+++ b/readme/tasks.md
@@ -1,0 +1,228 @@
+# npm and Gulp tasks
+
+This document describes the npm scripts and Gulp tasks used to build the MOJ
+Frontend package, standalone distribution and documentation site, and to run
+the Express contribution app.
+
+Commands should be run from the repository root. Install dependencies first
+with `npm run setup`.
+
+## npm script aliases
+
+npm scripts are defined in [`package.json`](../package.json). npm lifecycle
+scripts run automatically before or after scripts with the corresponding
+name.
+
+### Setup and development
+
+**`npm run setup`** will:
+
+- install the exact dependency versions from `package-lock.json` with
+  `npm ci`;
+- use the HMPPS npm script allowlist to only run whitelisted postinstall scripts.
+
+**`npm start`** runs the `prestart` lifecycle script, then starts the
+development watchers:
+
+- `prestart` builds the npm package and performs the initial Gulp
+  documentation-asset build;
+- `watch:11ty` watches `docs/` and rebuilds `public/` with Eleventy;
+- `watch:package` runs the Gulp package and documentation-asset watchers;
+- `watch:app` starts the Express app with Nodemon and restarts it when
+  application files change.
+
+**`npm run start:e2e`** starts the Express app with `ENV=test` and Nodemon.
+This is used by Playwright to run tests against the application.
+
+### Builds
+
+**`npm run build`** runs `prebuild`, then builds the standalone distribution
+and documentation site concurrently. `prebuild` runs
+`npm run build:package` first because both the distribution and documentation
+builds consume package output.
+
+**`npm run build:package`** runs the `build:package` Gulp task. Its
+`postbuild:package` lifecycle script then validates the generated package with
+`govuk-prototype-kit validate-plugin package`.
+
+**`npm run build:dist`** runs the `build:dist` Gulp task to create the
+standalone distribution in `dist/`.
+
+**`npm run build:docs`** runs the `build:docs` Gulp task and then runs Eleventy
+to render `docs/` into `public/`.
+
+### Tests
+
+**`npm test`** runs the test scripts matching `npm:test:*` concurrently:
+
+- `test:components` runs Jest tests under `src/`;
+- `test:helpers` runs Jest tests under `helpers/`;
+- `test:middleware` runs Jest tests under `middleware/`;
+- `test:scss` compiles the aggregate `src/moj/all.scss` stylesheet;
+- `test:e2e` runs the Playwright test suite.
+
+Individual test groups can be run directly. For example:
+
+```sh
+npm run test:components
+npm run test:e2e -- app/tests/e2e/02.component-details.spec.js
+```
+
+### Linting and type checking
+
+**`npm run lint`** runs all checks:
+
+- `lint:types` runs the TypeScript project build;
+- `lint:js` runs ESLint against JavaScript, Markdown and related source files;
+- `lint:scss` runs Stylelint against Sass files;
+- `lint:prettier` checks supported source formats with Prettier.
+
+The individual checks can be run separately:
+
+```sh
+npm run lint:types
+npm run lint:js
+npm run lint:scss
+npm run lint:prettier
+```
+
+**`npm run lint:fix`** runs the type check and applies automatic fixes for
+JavaScript, Sass and Prettier checks. The lower-level `lint:js:fix`,
+`lint:scss:fix` and `lint:prettier:fix` scripts can be run independently.
+
+The `*:cli` scripts expose the underlying tool command and are useful when
+passing a narrower file or directory selection, for example:
+
+```sh
+npm run lint:js:cli -- readme/tasks.md
+```
+
+### Release and container tasks
+
+**`npm run ci:release`** runs semantic-release in CI mode.
+
+**`npm run ci:dryrun`** runs semantic-release in CI dry-run mode without
+publishing a release.
+
+## Gulp tasks
+
+Gulp tasks are registered by [`gulpfile.js`](../gulpfile.js), which loads task
+definitions from [`gulp/`](../gulp). List the available tasks with:
+
+```sh
+npx gulp --tasks
+```
+
+The task names below can be run directly with `npx gulp <task>`.
+
+### Package tasks
+
+**`build:package`** rebuilds the npm package in this order:
+
+1. `build:clean`
+2. `build:copy`
+3. `build:javascripts`
+4. `build:javascripts-minified`
+5. `build:stylesheets`
+6. `build:stylesheets-minified`
+7. `build:compress-images`
+
+**`build:clean`** removes generated files from `package/`, preserving
+`package.json`, `govuk-prototype-kit.config.json` and `README.md`.
+
+**`build:copy`** runs these tasks in parallel:
+
+- `build:copy-assets` copies `src/moj/assets/`;
+- `build:copy-templates` copies Nunjucks and Markdown files from `src/moj/`;
+- `build:copy-others` copies filters, vendor files, initialisation files and
+  the package README.
+
+**`build:javascripts`** finds component JavaScript modules and builds each
+  module with Rollup into:
+
+- preserved ECMAScript modules;
+- bundled ECMAScript modules;
+- Universal Module Definition bundles for browser script usage.
+
+It also builds the `moj/helpers.mjs` and `moj/all.mjs` entry points. GOV.UK
+Frontend modules remain external where appropriate.
+
+**`build:javascripts-minified`** creates the minified ES module bundle
+`package/moj/moj-frontend.min.js`.
+
+**`build:stylesheets`** compiles every Sass module under `src/moj/` to the
+matching location under `package/`, applying the configured PostCSS
+transforms.
+
+**`build:stylesheets-minified`** compiles the aggregate
+`src/moj/all.scss` entry point to `package/moj/moj-frontend.min.css`.
+
+**`build:compress-images`** optimises PNG, JPEG and SVG images in
+`package/moj/assets/images/`.
+
+### Standalone distribution tasks
+
+**`build:dist`** rebuilds the standalone distribution in this order:
+
+1. `dist:clean`
+2. `dist:javascripts`
+3. `dist:stylesheets`
+4. `dist:assets`
+5. `dist:zip`
+
+**`dist:clean`** removes generated files from `dist/`.
+
+**`dist:javascripts`** creates the versioned, minified ES module bundle
+`dist/moj-frontend-<version>.min.js`.
+
+**`dist:stylesheets`** creates the versioned, minified stylesheet
+`dist/moj-frontend-<version>.min.css`.
+
+**`dist:assets`** copies package assets into `dist/assets/`.
+
+**`dist:zip`** packages the contents of `dist/` into `dist/release.zip`.
+
+### Documentation tasks
+
+**`build:docs`** rebuilds the initial documentation assets in this order:
+
+1. `docs:clean`
+2. `docs:copy`
+3. `docs:stylesheets` and `docs:javascripts` in parallel
+4. `docs:revision`
+
+Eleventy is run separately by `npm run build:docs` to render the documentation
+pages.
+
+**`docs:clean`** removes generated files from `public/`.
+
+**`docs:copy`** runs these tasks in parallel:
+
+- `docs:copy-assets` copies documentation, MOJ Frontend and GOV.UK Frontend
+  assets into `public/assets/`;
+- `docs:copy-stylesheets` copies the minified MOJ Frontend stylesheet into
+  `public/stylesheets/`;
+- `docs:copy-javascripts` copies the minified MOJ Frontend and GOV.UK Frontend
+  JavaScript into `public/javascripts/`.
+
+**`docs:stylesheets`** compiles the documentation stylesheets
+`application.scss`, `example.scss` and `govuk-frontend.scss` into minified
+files under `public/stylesheets/`.
+
+**`docs:javascripts`** bundles `docs/javascripts/application.mjs` as
+`public/javascripts/application.min.js`.
+
+**`docs:revision`** applies content hashes to cacheable CSS, JavaScript and
+asset files, writes source maps for CSS and JavaScript, and creates the
+revision manifest in `public/`.
+
+### Watch tasks
+
+**`watch`** runs all package and documentation watchers in parallel:
+
+The Eleventy and Express watchers used by `npm start` are npm scripts rather
+than Gulp tasks:
+
+- `watch:11ty` watches and renders the documentation pages;
+- `watch:app` runs the Express application with Nodemon;
+- `watch:package` runs the Gulp `watch` task.

--- a/readme/testing-and-linting.md
+++ b/readme/testing-and-linting.md
@@ -1,0 +1,107 @@
+# Testing and linting
+
+GitHub Actions lints Sass and JavaScript, runs unit and functional tests with Node.js.
+
+
+## Testing terminology
+
+We use different types of tests to check different areas of our code are working as expected.
+
+Unit tests are small, modular tests that verify a "unit" of code. We write unit tests to check our JavaScript logic, particularly 'background logic' that does not heavily rely on [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction) interaction (where functional tests may be better suited).
+
+Functional tests verify the output of an action and do not check the intermediate states of the system when performing that action. We write functional tests to check component interactions have the expected results, so we also refer to these as component tests. We also write functional tests to check that our Nunjucks code outputs expected HTML, and we refer to these as our Nunjucks tests.
+
+## Running linting and tests
+
+### Running all tests locally
+
+To test the whole codebase, run:
+
+```shell
+npm test
+```
+
+This will compile JavaScript and Sass, including documentation, then trigger [Jest](https://github.com/facebook/jest) and [Playwright](https://playwright.dev/) for our testing.
+
+See [Tasks](../tasks.md) for details of what `npm test` does.
+
+### Running individual tests
+
+You can run a subset of the test suite that only tests specific components by running:
+
+```shell
+npx jest src/moj/components/alert
+```
+
+Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
+
+```shell
+npx jest --watch src/moj/components/alert
+```
+
+### Running all linting checks locally
+
+To lint the whole codebase, run:
+
+```shell
+npm run lint
+```
+
+This will run the following checks:
+
+2. [Prettier](https://prettier.io)
+3. [ESLint](https://eslint.org) (using [JavaScript Standard Style](https://standardjs.com))
+4. [Stylelint](https://stylelint.io) (using [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds))
+
+### Running only Prettier linting
+
+```shell
+npm run lint:prettier
+```
+
+See [.prettierrc.js](/.prettierrc.js) for details.
+
+### Running only Sass linting
+
+```shell
+npm run lint:scss
+```
+
+See [CSS Coding Standards](/docs/contributing/coding-standards/css.md#linting) for details.
+
+### Running only JavaScript linting
+
+```shell
+npm run lint:js
+```
+
+See [JavaScript Coding Standards](/docs/contributing/coding-standards/js.md#formatting-and-linting) for details.
+
+## Unit and functional tests with Node.js
+
+We use [Jest](https://jestjs.io/), an automated testing platform with an assertion library, and [Playwright](https://playwright.dev/) that is used to control [headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome).
+
+Tests should be written using ES modules (`*.mjs`) by default, but use CommonJS modules (`*.js`) for tests using browser [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) in Playwright. 
+
+### Component tests
+
+We write functional tests for every component to check the output of our Nunjucks code. These are found in `[component-name].nunjucks.spec.js` files in each component directory. These Nunjucks tests render the component examples defined in the component yaml files, and assert that the HTML tags, attributes and classes are as expected. For example: checking that when you pass in an `id` to the component using the Nunjucks macro, it outputs the component with an `id` attribute equal to that value.
+
+If a component uses JavaScript, we also write functional tests in a `[component name].playwright.spec.js` file, for example [add-another.playwright.spec.js](/src/moj/components/add-another/add-another.js.spec.js). These component tests check that interactions, such as a mouse click, have the expected result.
+
+If you want to inspect a test that's running in the browser, configure Playwright in non-headless mode with the environment variable `HEADLESS=false`.
+
+```shell
+HEADLESS=false npx playwright test --headed src/moj/components/add-another/add-another.playwright.spec.js
+```
+
+You should also test component Javascript logic with unit tests, in a `[component name].js.test.mjs` file. These tests are better suited for testing behind-the-scenes logic, or in cases where the final output of some logic is not a change to the component markup.
+
+### Conventions
+
+We aim to write the test descriptions in everyday language. For example, "back-link component fails to render if the required fields are not included".
+
+Keep all tests separate from each other. It should not matter the order or amount of tests you run from a test suite.
+
+Try and keep assertions small, so each test only checks for one thing. This makes tests more readable and makes it easier to see what's happening if a test is failing.
+

--- a/readme/versioning.md
+++ b/readme/versioning.md
@@ -1,0 +1,45 @@
+# Versioning
+
+The project uses semantic-release to automate changelog generation, release notes, deployment and publishing based on the content of commit messages.
+
+Commit messages and PR titles must follow the angular commit message guidelines:
+```
+<type>(<scope>): <subject>
+
+<BLANK LINE>
+
+<body>
+
+<BLANK LINE>
+
+<footer>
+```
+
+The `<type>` and `<subject>` are mandatory and the `<scope>` is optional.
+
+Type must be one of the following:
+
+  - **feat:** A new feature
+  - **fix:** A bug fix
+  - **docs:** Documentation only changes
+  - **style:** Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+  - **refactor:** A code change that neither fixes a bug nor adds a feature
+  - **perf:** A code change that improves performance
+  - **test:** Adding missing or correcting existing tests
+  - **chore:** Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+Based on the content of the commit message, different actions will be performed see: default release rules
+
+  - **fix:** will bump the patch version
+  - **feat:** will bump the minor version
+  - **perf:** will bump the patch version
+
+> [!IMPORTANT]
+> **fix:**, **feat:** and **perf:** should ONLY be used for changes within the `src/` directory.
+
+To ensure this formatting, the repo is configured with a github action that will
+validate that the PR title follows the angular commit message guidelines. If it
+does not, the PR will be blocked from merging. This is because we use a squash
+and merge strategy, so the PR title will be used as the commit message for the
+merge commit.
+


### PR DESCRIPTION
This pull request adds documentation to the repository, clarifying the application's architecture, coding standards, and component development practices. It introduces detailed guides for maintainers and contributors, and makes a minor configuration change to Playwright test settings for improved CI flexibility.  These docs are _strongly_ based on similar docs in gov.uk frontend, but with changes made for MOJ.


