### PR TITLE
chore: update semantic release config to support ! header to mark breaking changes

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,14 +5,38 @@
     { "name": "beta", "prerelease": true }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "headerPattern": "^(\\w*)(?:\\((.*)\\))?(!)?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+        },
+        "releaseRules": [
+          {
+            "breaking": "!",
+            "release": "major"
+          }
+        ]
+      }
+    ],
     [
       "@semantic-release/exec",
       {
         "verifyReleaseCmd": "npm version --no-git-tag-version --allow-same-version --workspace package ${nextRelease.version}"
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "headerPattern": "^(\\w*)(?:\\((.*)\\))?(!)?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "breaking", "subject"]
+        }
+      }
+    ],
     [
       "@semantic-release/changelog",
       {


### PR DESCRIPTION
This pull request updates the `.releaserc.json` configuration to extend the Angular preset to support using an `!` in the header of a commit to mark breaking releases.  This format is allowed in `conventional-commit`, but not enabled when using the `angular` presets.

This has caught us out before, where a commit has had an `!` but not a `BREAKING CHANGE` text in the body of the commit message, leading to an incorrect semantic-release version calculation.

This change means that **_either_** a `!` or `BREAKING CHANGE` will trigger a major release.
